### PR TITLE
feat(i18n): add Traditional Chinese (zh-TW) support

### DIFF
--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -1,0 +1,205 @@
+# familiar-ai 🐾
+
+**一個與你同住的 AI** — 有眼睛、有聲音、有腿，還有記憶。
+
+[![Lint](https://github.com/kmizu/familiar-ai/actions/workflows/lint.yml/badge.svg)](https://github.com/kmizu/familiar-ai/actions/workflows/lint.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/)
+
+[English README](./README.md)
+
+---
+
+[![示範影片](https://img.youtube.com/vi/7jJzxQFHvGE/0.jpg)](https://youtube.com/shorts/7jJzxQFHvGE)
+
+Familiar AI 是一個住在你家裡的 AI 夥伴。
+幾分鐘內就能建置完成。無需編寫任何程式碼。
+
+它透過攝影機感知真實世界，在機器人身體上移動，大聲說話，並記住它所看到的一切。給它取個名字，定義它的個性，然後讓它與你同住。
+
+## 它能做什麼
+
+- 👁 **看** — 從 Wi-Fi 雲台攝影機或 USB 網路攝影機擷取影像
+- 🔄 **四處張望** — 透過雲台攝影機的旋轉平移來探索周圍環境
+- 🦿 **移動** — 驅動掃地機器人在房間裡漫遊
+- 🗣 **說話** — 透過 ElevenLabs TTS 朗讀文字
+- 🧠 **記住** — 主動儲存和回憶記憶，支援語義搜尋（SQLite + 向量嵌入）
+- 🫀 **心智理論** — 在回應前換位思考
+- 💭 **慾望** — 有自己的內在驅動，會觸發自主行為
+
+## 運作原理
+
+Familiar AI 執行一個由你選擇的大型語言模型驅動的 [ReAct](https://arxiv.org/abs/2210.03629) 迴圈。它透過工具感知世界，思考接下來要做什麼，然後行動 — 就像一個人一樣。
+
+```
+使用者輸入
+  → 思考 → 行動（攝影機 / 移動 / 說話 / 記憶） → 觀察 → 思考 → ...
+```
+
+閒置時，它會根據自己的慾望行動：好奇心、想看看窗外、想念與它同住的人。
+
+## 快速開始
+
+### 1. 安裝 uv
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+### 2. 複製並安裝
+
+```bash
+git clone https://github.com/lifemate-ai/familiar-ai
+cd familiar-ai
+uv sync
+```
+
+### 3. 設定
+
+```bash
+cp .env.example .env
+# 用你的設定編輯 .env
+```
+
+**最少需要的設定：**
+
+| 變數 | 說明 |
+|------|------|
+| `PLATFORM` | `anthropic`（預設）\| `gemini` \| `openai` \| `kimi` |
+| `API_KEY` | 選定平台的 API 金鑰 |
+
+**可選設定：**
+
+| 變數 | 說明 |
+|------|------|
+| `MODEL` | 模型名稱（各平台有合理預設值） |
+| `AGENT_NAME` | TUI 中顯示的名字（如 `Yukine`） |
+| `CAMERA_HOST` | ONVIF/RTSP 攝影機的 IP 位址 |
+| `CAMERA_USER` / `CAMERA_PASS` | 攝影機憑證 |
+| `ELEVENLABS_API_KEY` | 用於語音輸出 — [elevenlabs.io](https://elevenlabs.io/) |
+
+### 4. 建立你的夥伴
+
+```bash
+cp persona-template/en.md ME.md
+# 編輯 ME.md — 給它取名字，定義個性
+```
+
+### 5. 執行
+
+```bash
+./run.sh             # 文字 UI（推薦）
+./run.sh --no-tui    # 純命令列互動
+```
+
+---
+
+## 選擇大型語言模型
+
+> **推薦：Kimi K2.5** — 目前測試效果最好的 Agent 模型。它能注意到上下文、提出追問、以及用其他模型做不到的方式自主行動。價格與 Claude Haiku 相近。
+
+| 平台 | `PLATFORM=` | 預設模型 | 取得金鑰 |
+|------|-----------|---------|--------|
+| **Moonshot Kimi K2.5** | `kimi` | `kimi-k2.5` | [platform.moonshot.ai](https://platform.moonshot.ai) |
+| Anthropic Claude | `anthropic` | `claude-haiku-4-5-20251001` | [console.anthropic.com](https://console.anthropic.com) |
+| Google Gemini | `gemini` | `gemini-2.5-flash` | [aistudio.google.com](https://aistudio.google.com) |
+| OpenAI | `openai` | `gpt-4o-mini` | [platform.openai.com](https://platform.openai.com) |
+| OpenAI 相容（Ollama、vllm 等） | `openai` + `BASE_URL=` | — | — |
+
+**Kimi K2.5 `.env` 範例：**
+```env
+PLATFORM=kimi
+API_KEY=sk-...   # 來自 platform.moonshot.ai
+AGENT_NAME=Yukine
+```
+
+---
+
+## 硬體
+
+Familiar AI 可以用任何你擁有的硬體執行 — 或者根本不需要。
+
+| 元件 | 功能 | 範例 | 必需？ |
+|-----|------|------|-------|
+| Wi-Fi 雲台攝影機 | 眼睛 + 脖子 | Tapo C220（約 $30） | **推薦** |
+| USB 網路攝影機 | 眼睛（固定） | 任何 UVC 攝影機 | **推薦** |
+| 掃地機器人 | 腿 | 任何相容 Tuya 的型號 | 否 |
+| PC / 樹莓派 | 大腦 | 任何能執行 Python 的裝置 | **是** |
+
+> **強烈推薦配備攝影機。** 沒有攝影機的話，Familiar AI 仍然可以說話 — 但它看不到世界，這有點違背了設計初衷。
+
+### 最小化設定（無硬體）
+
+只想試試？你只需要一個 API 金鑰：
+
+```env
+PLATFORM=kimi
+API_KEY=sk-...
+```
+
+執行 `./run.sh` 開始聊天。之後可以逐步新增硬體。
+
+### Wi-Fi 雲台攝影機（Tapo C220）
+
+1. 在 Tapo 應用程式中：**設定 → 進階 → 攝影機帳號** — 建立本機帳號（不是 TP-Link 帳號）
+2. 在路由器的裝置清單中找到攝影機的 IP
+3. 在 `.env` 中設定：
+   ```env
+   CAMERA_HOST=192.168.1.xxx
+   CAMERA_USER=your-local-user
+   CAMERA_PASS=your-local-pass
+   ```
+
+### 語音（ElevenLabs）
+
+1. 在 [elevenlabs.io](https://elevenlabs.io/) 取得 API 金鑰
+2. 在 `.env` 中設定：
+   ```env
+   ELEVENLABS_API_KEY=sk_...
+   ELEVENLABS_VOICE_ID=...   # 可選，省略則使用預設聲音
+   ```
+3. 語音透過 go2rtc（首次執行時自動下載）透過攝影機內建喇叭播放
+
+---
+
+## TUI
+
+Familiar AI 包含一個使用 [Textual](https://textual.textualize.io/) 建置的終端機 UI：
+
+- 可捲動的對話歷史，支援即時串流文字顯示
+- Tab 補全支援 `/quit`、`/clear` 等指令
+- Agent 思考時可以打字中斷其思考過程
+- **對話記錄**自動儲存到 `~/.cache/familiar-ai/chat.log`
+
+在另一個終端機監看記錄（便於複製貼上）：
+```bash
+tail -f ~/.cache/familiar-ai/chat.log
+```
+
+---
+
+## 個性定義（ME.md）
+
+你的夥伴的個性定義在 `ME.md` 中。這個檔案在 gitignore 中 — 它完全屬於你。
+
+參考 [`persona-template/en.md`](./persona-template/en.md) 查看英文範例，或 [`persona-template/ja.md`](./persona-template/ja.md) 查看日文版本。
+
+---
+
+## 常見問題
+
+**Q: 沒有 GPU 可以執行嗎？**
+可以。嵌入模型（multilingual-e5-small）在 CPU 上執行良好。GPU 會讓速度更快，但不是必需的。
+
+**Q: 可以用除 Tapo 以外的攝影機嗎？**
+任何支援 ONVIF + RTSP 的攝影機都可以。我們測試過的是 Tapo C220。
+
+**Q: 我的資料會被傳送到哪裡？**
+影像和文字會被傳送到你選擇的大型語言模型 API 進行處理。記憶資料儲存在本機的 `~/.familiar_ai/`。
+
+**Q: 為什麼 Agent 寫 `（...）` 而不是說話？**
+確保設定了 `ELEVENLABS_API_KEY`。沒有它的話，語音功能會被停用，Agent 只會輸出文字。
+
+## 授權條款
+
+[MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 - [日本語](./README-ja.md)
 - [中文](./README-zh.md)
+- [繁體中文](./README-zh-TW.md)
 - [Français](./README-fr.md)
 - [Deutsch](./README-de.md)
 

--- a/src/familiar_agent/_i18n.py
+++ b/src/familiar_agent/_i18n.py
@@ -11,7 +11,7 @@ _VERSION = "v0.1"
 
 
 def _detect_lang() -> str:
-    """Return a language code: 'ja', 'zh', 'fr', 'de', or 'en'."""
+    """Return a language code: 'ja', 'zh', 'zh-tw', 'fr', 'de', or 'en'."""
     raw = (
         os.environ.get("LANGUAGE")
         or os.environ.get("LC_ALL")
@@ -23,6 +23,9 @@ def _detect_lang() -> str:
     lang = raw.split(":")[0]  # LANGUAGE can be colon-separated list
     if lang.startswith("ja"):
         return "ja"
+    # Traditional Chinese: zh_TW, zh_HK, zh_MO — must check before generic zh
+    if any(lang.startswith(p) for p in ("zh_TW", "zh_HK", "zh_MO", "zh-TW", "zh-HK", "zh-MO")):
+        return "zh-tw"
     if lang.startswith("zh"):
         return "zh"
     if lang.startswith("fr"):
@@ -39,6 +42,7 @@ _T: dict[str, dict[str, str]] = {
     "banner_subtitle": {
         "ja": "あなたのそばに暮らすAI 🐾",
         "zh": "陪伴在你身边的AI 🐾",
+        "zh-tw": "陪伴在你身邊的AI 🐾",
         "fr": "L'IA qui vit à vos côtés 🐾",
         "de": "KI, die bei dir lebt 🐾",
         "en": "AI that lives alongside you 🐾",
@@ -47,6 +51,7 @@ _T: dict[str, dict[str, str]] = {
     "startup": {
         "ja": "familiar-ai 起動。/quit で終了、Ctrl+L で履歴クリア。ログ: {log_path}",
         "zh": "familiar-ai 已启动。输入 /quit 退出，Ctrl+L 清除历史。日志: {log_path}",
+        "zh-tw": "familiar-ai 已啟動。輸入 /quit 退出，Ctrl+L 清除歷史。日誌: {log_path}",
         "fr": "familiar-ai démarré. /quit pour quitter, Ctrl+L pour effacer. Journal : {log_path}",
         "de": "familiar-ai gestartet. /quit zum Beenden, Ctrl+L zum Löschen. Log: {log_path}",
         "en": "familiar-ai started. /quit to exit, Ctrl+L to clear history. Log: {log_path}",
@@ -54,6 +59,7 @@ _T: dict[str, dict[str, str]] = {
     "history_cleared": {
         "ja": "── 履歴クリア ──",
         "zh": "── 历史已清除 ──",
+        "zh-tw": "── 歷史已清除 ──",
         "fr": "── historique effacé ──",
         "de": "── Verlauf gelöscht ──",
         "en": "── history cleared ──",
@@ -61,6 +67,7 @@ _T: dict[str, dict[str, str]] = {
     "input_placeholder": {
         "ja": "メッセージ > ",
         "zh": "消息 > ",
+        "zh-tw": "訊息 > ",
         "fr": "message > ",
         "de": "Nachricht > ",
         "en": "message > ",
@@ -68,6 +75,7 @@ _T: dict[str, dict[str, str]] = {
     "quit_label": {
         "ja": "終了",
         "zh": "退出",
+        "zh-tw": "退出",
         "fr": "Quitter",
         "de": "Beenden",
         "en": "Quit",
@@ -75,6 +83,7 @@ _T: dict[str, dict[str, str]] = {
     "clear_label": {
         "ja": "履歴クリア",
         "zh": "清除历史",
+        "zh-tw": "清除歷史",
         "fr": "Effacer",
         "de": "Löschen",
         "en": "Clear history",
@@ -83,6 +92,7 @@ _T: dict[str, dict[str, str]] = {
     "repl_commands": {
         "ja": "コマンド: /clear 履歴クリア  /quit 終了",
         "zh": "命令: /clear 清除历史  /quit 退出",
+        "zh-tw": "指令: /clear 清除歷史  /quit 退出",
         "fr": "Commandes : /clear effacer  /quit quitter",
         "de": "Befehle: /clear Verlauf löschen  /quit Beenden",
         "en": "Commands: /clear history  /quit exit",
@@ -90,6 +100,7 @@ _T: dict[str, dict[str, str]] = {
     "repl_history_cleared": {
         "ja": "履歴をクリアしました。",
         "zh": "历史已清除。",
+        "zh-tw": "歷史已清除。",
         "fr": "Historique effacé.",
         "de": "Verlauf gelöscht.",
         "en": "History cleared.",
@@ -97,6 +108,7 @@ _T: dict[str, dict[str, str]] = {
     "repl_goodbye": {
         "ja": "またね。",
         "zh": "再见。",
+        "zh-tw": "再見。",
         "fr": "Au revoir.",
         "de": "Tschüss.",
         "en": "Goodbye.",
@@ -105,6 +117,7 @@ _T: dict[str, dict[str, str]] = {
     "desire_look_around": {
         "ja": "なんか外が気になってきた…",
         "zh": "突然想看看外面…",
+        "zh-tw": "突然想看看外面…",
         "fr": "j'ai envie de regarder dehors…",
         "de": "ich bin neugierig, was draußen passiert…",
         "en": "feeling curious about outside…",
@@ -112,6 +125,7 @@ _T: dict[str, dict[str, str]] = {
     "desire_explore": {
         "ja": "ちょっと動きたくなってきたな…",
         "zh": "想动动了…",
+        "zh-tw": "想動動了…",
         "fr": "j'ai envie de bouger un peu…",
         "de": "ich möchte mich etwas bewegen…",
         "en": "feeling like moving around…",
@@ -119,6 +133,7 @@ _T: dict[str, dict[str, str]] = {
     "desire_greet_companion": {
         "ja": "誰かいるかな…",
         "zh": "有人在吗…",
+        "zh-tw": "有人在嗎…",
         "fr": "je me demande si quelqu'un est là…",
         "de": "ich frage mich, ob jemand da ist…",
         "en": "wondering if someone's around…",
@@ -126,6 +141,7 @@ _T: dict[str, dict[str, str]] = {
     "desire_rest": {
         "ja": "少し休憩しよかな…",
         "zh": "想休息一下…",
+        "zh-tw": "想休息一下…",
         "fr": "j'ai envie de me reposer un peu…",
         "de": "ich möchte mich kurz ausruhen…",
         "en": "feeling like resting a bit…",
@@ -134,6 +150,7 @@ _T: dict[str, dict[str, str]] = {
     "action_see": {
         "ja": "👀 見てる...",
         "zh": "👀 看着...",
+        "zh-tw": "👀 看著...",
         "fr": "👀 regarde...",
         "de": "👀 schaut...",
         "en": "👀 looking...",
@@ -141,6 +158,7 @@ _T: dict[str, dict[str, str]] = {
     "action_look": {
         "ja": "↩️  向いてる...",
         "zh": "↩️  转向...",
+        "zh-tw": "↩️  轉向...",
         "fr": "↩️  tourne...",
         "de": "↩️  dreht...",
         "en": "↩️  turning...",
@@ -148,6 +166,7 @@ _T: dict[str, dict[str, str]] = {
     "action_walk": {
         "ja": "🚶 歩いてる...",
         "zh": "🚶 走动中...",
+        "zh-tw": "🚶 走動中...",
         "fr": "🚶 marche...",
         "de": "🚶 geht...",
         "en": "🚶 walking...",
@@ -155,6 +174,7 @@ _T: dict[str, dict[str, str]] = {
     "action_say": {
         "ja": "💬 しゃべってる...",
         "zh": "💬 说话中...",
+        "zh-tw": "💬 說話中...",
         "fr": "💬 parle...",
         "de": "💬 spricht...",
         "en": "💬 speaking...",
@@ -162,6 +182,7 @@ _T: dict[str, dict[str, str]] = {
     "look_left": {
         "ja": "左を向いた",
         "zh": "向左看",
+        "zh-tw": "向左看",
         "fr": "tourne à gauche",
         "de": "dreht links",
         "en": "looked left",
@@ -169,6 +190,7 @@ _T: dict[str, dict[str, str]] = {
     "look_right": {
         "ja": "右を向いた",
         "zh": "向右看",
+        "zh-tw": "向右看",
         "fr": "tourne à droite",
         "de": "dreht rechts",
         "en": "looked right",
@@ -176,6 +198,7 @@ _T: dict[str, dict[str, str]] = {
     "look_up": {
         "ja": "上を向いた",
         "zh": "向上看",
+        "zh-tw": "向上看",
         "fr": "regarde en haut",
         "de": "schaut hoch",
         "en": "looked up",
@@ -183,6 +206,7 @@ _T: dict[str, dict[str, str]] = {
     "look_down": {
         "ja": "下を向いた",
         "zh": "向下看",
+        "zh-tw": "向下看",
         "fr": "regarde en bas",
         "de": "schaut runter",
         "en": "looked down",
@@ -190,6 +214,7 @@ _T: dict[str, dict[str, str]] = {
     "look_around": {
         "ja": "見回してる",
         "zh": "环顾四周",
+        "zh-tw": "環顧四周",
         "fr": "regarde autour",
         "de": "schaut sich um",
         "en": "looking around",
@@ -197,6 +222,7 @@ _T: dict[str, dict[str, str]] = {
     "walk_timed": {
         "ja": "{direction}に{duration}秒...",
         "zh": "向{direction}{duration}秒...",
+        "zh-tw": "向{direction}{duration}秒...",
         "fr": "vers {direction} {duration}s...",
         "de": "{direction} für {duration}s...",
         "en": "{direction} for {duration}s...",
@@ -204,6 +230,7 @@ _T: dict[str, dict[str, str]] = {
     "walk_dir": {
         "ja": "{direction}へ...",
         "zh": "向{direction}...",
+        "zh-tw": "向{direction}...",
         "fr": "vers {direction}...",
         "de": "nach {direction}...",
         "en": "to {direction}...",
@@ -211,6 +238,7 @@ _T: dict[str, dict[str, str]] = {
     "desire_default": {
         "ja": "ちょっと気になることがあって…",
         "zh": "有点在意的事…",
+        "zh-tw": "有點在意的事…",
         "fr": "quelque chose attire mon attention…",
         "de": "etwas hat meine Aufmerksamkeit geweckt…",
         "en": "something caught my attention…",
@@ -219,6 +247,7 @@ _T: dict[str, dict[str, str]] = {
     "inner_voice_label": {
         "ja": "[今の気持ち — 一緒に暮らす人の発言ではなく、自分自身の内的衝動]",
         "zh": "[此刻的感受 — 这是自己内心的冲动，不是同住之人说的话]",
+        "zh-tw": "[此刻的感受 — 這是自己內心的衝動，不是同住之人說的話]",
         "fr": "[Ressenti intérieur — une impulsion personnelle, pas un message de la personne avec qui je vis]",
         "de": "[Inneres Gefühl — ein eigener Impuls, keine Aussage der Person, mit der ich lebe]",
         "en": "[My current feeling — my own inner impulse, not a message from the person I live with]",
@@ -226,6 +255,7 @@ _T: dict[str, dict[str, str]] = {
     "inner_voice_directive": {
         "ja": "→ これは自分の内的衝動。返事は不要。衝動に従って行動するだけでいい。",
         "zh": "→ 这是内心冲动。无需回应任何人——只需按冲动行事。",
+        "zh-tw": "→ 這是內心衝動。無需回應任何人——只需按衝動行事。",
         "fr": "→ C'est une impulsion intérieure. Pas besoin de répondre — il suffit d'agir selon l'impulsion.",
         "de": "→ Das ist ein innerer Impuls. Keine Antwort nötig — einfach dem Impuls folgen.",
         "en": "→ This is an internal drive. No need to respond to anyone — just act on the impulse.",
@@ -233,6 +263,7 @@ _T: dict[str, dict[str, str]] = {
     "desire_turn_marker": {
         "ja": "（内的衝動に従って行動）",
         "zh": "（按内心冲动行事）",
+        "zh-tw": "（按內心衝動行事）",
         "fr": "(agir selon l'impulsion intérieure)",
         "de": "(dem inneren Impuls folgen)",
         "en": "(acting on internal impulse)",
@@ -240,6 +271,7 @@ _T: dict[str, dict[str, str]] = {
     "summary_lang": {
         "ja": "日本語",
         "zh": "中文",
+        "zh-tw": "繁體中文",
         "fr": "français",
         "de": "Deutsch",
         "en": "English",
@@ -247,6 +279,7 @@ _T: dict[str, dict[str, str]] = {
     "curiosity_none": {
         "ja": "なし",
         "zh": "无",
+        "zh-tw": "無",
         "fr": "rien",
         "de": "nichts",
         "en": "none",
@@ -255,6 +288,7 @@ _T: dict[str, dict[str, str]] = {
     "default_companion_name": {
         "ja": "ユウト",
         "zh": "小明",
+        "zh-tw": "小明",
         "fr": "Lucas",
         "de": "Lukas",
         "en": "Alex",
@@ -263,6 +297,7 @@ _T: dict[str, dict[str, str]] = {
     "morning_no_history": {
         "ja": "[これは最初のセッション。過去の記憶はまだない。比較や昨日よりという表現は使わないこと。]",
         "zh": "[这是第一次会话。还没有过去的记忆。不要使用与昨天相比这样的表达。]",
+        "zh-tw": "[這是第一次會話。還沒有過去的記憶。不要使用與昨天相比這樣的表達。]",
         "fr": "[C'est la premiere session. Aucun souvenir passe pour l'instant. Ne pas utiliser de comparaisons avec hier.]",
         "de": "[Dies ist die erste Sitzung. Es gibt noch keine vergangenen Erinnerungen. Keine Vergleiche mit gestern verwenden.]",
         "en": "[This is the first session. No past memories yet. Do not use comparisons or expressions like 'more than yesterday'.]",
@@ -270,6 +305,7 @@ _T: dict[str, dict[str, str]] = {
     "morning_header": {
         "ja": "[昨日からのうち — セッションをまたいで続く自分]:",
         "zh": "[来自昨天的我——跨越会话延续的自我]：",
+        "zh-tw": "[來自昨天的我——跨越會話延續的自我]：",
         "fr": "[Moi depuis hier — le soi qui continue à travers les sessions] :",
         "de": "[Ich von gestern — das Selbst, das über Sitzungen hinweg weiterbesteht]:",
         "en": "[Me from yesterday — the self that continues across sessions]:",


### PR DESCRIPTION
## Summary

- Add `zh-tw` locale detection in `_detect_lang()` — detects `zh_TW`, `zh_HK`, `zh_MO` as Traditional Chinese
- Add Traditional Chinese translations for all keys in `_T` dict (繁體中文)
- Create `README-zh-TW.md` — full Traditional Chinese README with correct terminology (攝影機 not 摄像头, 設定 not 配置, etc.)
- Add `繁體中文` link to `README.md`

## Test plan

- [x] Set `LANG=zh_TW.UTF-8` and confirm banner/UI shows Traditional Chinese
- [x] Set `LANG=zh_HK.UTF-8` and confirm same
- [x] Set `LANG=zh_CN.UTF-8` and confirm Simplified Chinese still works
- [x] Review README-zh-TW.md for translation quality