### PR TITLE
Add OpenRouter.ai support and enhance LLM documentation

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -105,6 +105,7 @@ cp persona-template/en.md ME.md
 | Google Gemini | `gemini` | `gemini-2.5-flash` | [aistudio.google.com](https://aistudio.google.com) |
 | OpenAI | `openai` | `gpt-4o-mini` | [platform.openai.com](https://platform.openai.com) |
 | OpenAI-kompatibel (Ollama, vllm…) | `openai` + `BASE_URL=` | — | — |
+| OpenRouter.ai (Mehrfachanbieter) | `openai` + `BASE_URL=https://openrouter.ai/api/v1` | — | [openrouter.ai](https://openrouter.ai) |
 
 **Kimi K2.5 `.env` Beispiel:**
 ```env
@@ -112,6 +113,25 @@ PLATFORM=kimi
 API_KEY=sk-...   # von platform.moonshot.ai
 AGENT_NAME=Yukine
 ```
+
+**Google Gemini `.env` Beispiel:**
+```env
+PLATFORM=gemini
+API_KEY=AIza...   # von aistudio.google.com
+MODEL=gemini-2.5-flash  # oder gemini-2.5-pro
+AGENT_NAME=Yukine
+```
+
+**OpenRouter.ai `.env` Beispiel:**
+```env
+PLATFORM=openai
+BASE_URL=https://openrouter.ai/api/v1
+API_KEY=sk-or-...   # von openrouter.ai
+MODEL=mistralai/mistral-7b-instruct  # optional
+AGENT_NAME=Yukine
+```
+
+> **Hinweis:** Um lokale/NVIDIA-Modelle zu deaktivieren, setzen Sie `BASE_URL` nicht auf einen lokalen Endpunkt wie `http://localhost:11434/v1`. Verwenden Sie stattdessen Cloud-Anbieter.
 
 ---
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -105,6 +105,7 @@ cp persona-template/en.md ME.md
 | Google Gemini | `gemini` | `gemini-2.5-flash` | [aistudio.google.com](https://aistudio.google.com) |
 | OpenAI | `openai` | `gpt-4o-mini` | [platform.openai.com](https://platform.openai.com) |
 | Compatible OpenAI (Ollama, vllm…) | `openai` + `BASE_URL=` | — | — |
+| OpenRouter.ai (multi-fournisseurs) | `openai` + `BASE_URL=https://openrouter.ai/api/v1` | — | [openrouter.ai](https://openrouter.ai) |
 
 **Exemple `.env` pour Kimi K2.5 :**
 ```env
@@ -112,6 +113,25 @@ PLATFORM=kimi
 API_KEY=sk-...   # from platform.moonshot.ai
 AGENT_NAME=Yukine
 ```
+
+**Exemple `.env` pour Google Gemini :**
+```env
+PLATFORM=gemini
+API_KEY=AIza...   # from aistudio.google.com
+MODEL=gemini-2.5-flash  # or gemini-2.5-pro
+AGENT_NAME=Yukine
+```
+
+**Exemple `.env` pour OpenRouter.ai :**
+```env
+PLATFORM=openai
+BASE_URL=https://openrouter.ai/api/v1
+API_KEY=sk-or-...   # from openrouter.ai
+MODEL=mistralai/mistral-7b-instruct  # optional
+AGENT_NAME=Yukine
+```
+
+> **Note :** Pour désactiver les modèles locaux/NVIDIA, ne définissez pas `BASE_URL` sur un endpoint local comme `http://localhost:11434/v1`. Utilisez plutôt des fournisseurs cloud.
 
 ---
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -108,6 +108,7 @@ cp persona-template/en.md ME.md
 | Google Gemini | `gemini` | `gemini-2.5-flash` | [aistudio.google.com](https://aistudio.google.com) |
 | OpenAI | `openai` | `gpt-4o-mini` | [platform.openai.com](https://platform.openai.com) |
 | OpenAI互換（Ollama、vllmなど） | `openai` + `BASE_URL=` | — | — |
+| OpenRouter.ai（マルチプロバイダー） | `openai` + `BASE_URL=https://openrouter.ai/api/v1` | — | [openrouter.ai](https://openrouter.ai) |
 
 **Kimi K2.5 `.env` の例：**
 ```env
@@ -115,6 +116,25 @@ PLATFORM=kimi
 API_KEY=sk-...   # platform.moonshot.ai から取得
 AGENT_NAME=ユキネ
 ```
+
+**Google Gemini `.env` の例：**
+```env
+PLATFORM=gemini
+API_KEY=AIza...   # aistudio.google.com から取得
+MODEL=gemini-2.5-flash  # または gemini-2.5-pro
+AGENT_NAME=ユキネ
+```
+
+**OpenRouter.ai `.env` の例：**
+```env
+PLATFORM=openai
+BASE_URL=https://openrouter.ai/api/v1
+API_KEY=sk-or-...   # openrouter.ai から取得
+MODEL=mistralai/mistral-7b-instruct  # オプション
+AGENT_NAME=ユキネ
+```
+
+> **注意：** ローカル/NVIDIAモデルを無効化するには、`BASE_URL` を `http://localhost:11434/v1` のようなローカルエンドポイントに設定しないでください。クラウドプロバイダーを使用してください。
 
 ---
 

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -105,6 +105,7 @@ cp persona-template/en.md ME.md
 | Google Gemini | `gemini` | `gemini-2.5-flash` | [aistudio.google.com](https://aistudio.google.com) |
 | OpenAI | `openai` | `gpt-4o-mini` | [platform.openai.com](https://platform.openai.com) |
 | OpenAI 相容（Ollama、vllm 等） | `openai` + `BASE_URL=` | — | — |
+| OpenRouter.ai（多供應商） | `openai` + `BASE_URL=https://openrouter.ai/api/v1` | — | [openrouter.ai](https://openrouter.ai) |
 
 **Kimi K2.5 `.env` 範例：**
 ```env
@@ -112,6 +113,25 @@ PLATFORM=kimi
 API_KEY=sk-...   # 來自 platform.moonshot.ai
 AGENT_NAME=Yukine
 ```
+
+**Google Gemini `.env` 範例：**
+```env
+PLATFORM=gemini
+API_KEY=AIza...   # 來自 aistudio.google.com
+MODEL=gemini-2.5-flash  # 或 gemini-2.5-pro
+AGENT_NAME=Yukine
+```
+
+**OpenRouter.ai `.env` 範例：**
+```env
+PLATFORM=openai
+BASE_URL=https://openrouter.ai/api/v1
+API_KEY=sk-or-...   # 來自 openrouter.ai
+MODEL=mistralai/mistral-7b-instruct  # 可選
+AGENT_NAME=Yukine
+```
+
+> **注意：** 要停用本地/NVIDIA 模型，請勿將 `BASE_URL` 設定為本地端點如 `http://localhost:11434/v1`。請使用雲端服務提供商。
 
 ---
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -105,6 +105,7 @@ cp persona-template/en.md ME.md
 | Google Gemini | `gemini` | `gemini-2.5-flash` | [aistudio.google.com](https://aistudio.google.com) |
 | OpenAI | `openai` | `gpt-4o-mini` | [platform.openai.com](https://platform.openai.com) |
 | OpenAI 兼容（Ollama、vllm 等） | `openai` + `BASE_URL=` | — | — |
+| OpenRouter.ai（多供应商） | `openai` + `BASE_URL=https://openrouter.ai/api/v1` | — | [openrouter.ai](https://openrouter.ai) |
 
 **Kimi K2.5 `.env` 示例：**
 ```env
@@ -112,6 +113,25 @@ PLATFORM=kimi
 API_KEY=sk-...   # 来自 platform.moonshot.ai
 AGENT_NAME=Yukine
 ```
+
+**Google Gemini `.env` 示例：**
+```env
+PLATFORM=gemini
+API_KEY=AIza...   # 来自 aistudio.google.com
+MODEL=gemini-2.5-flash  # 或 gemini-2.5-pro
+AGENT_NAME=Yukine
+```
+
+**OpenRouter.ai `.env` 示例：**
+```env
+PLATFORM=openai
+BASE_URL=https://openrouter.ai/api/v1
+API_KEY=sk-or-...   # 来自 openrouter.ai
+MODEL=mistralai/mistral-7b-instruct  # 可选
+AGENT_NAME=Yukine
+```
+
+> **注意：** 要禁用本地/NVIDIA 模型，请勿将 `BASE_URL` 设置为本地端点如 `http://localhost:11434/v1`。请使用云服务提供商。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ cp persona-template/en.md ME.md
 | Google Gemini | `gemini` | `gemini-2.5-flash` | [aistudio.google.com](https://aistudio.google.com) |
 | OpenAI | `openai` | `gpt-4o-mini` | [platform.openai.com](https://platform.openai.com) |
 | OpenAI-compatible (Ollama, vllm…) | `openai` + `BASE_URL=` | — | — |
+| OpenRouter.ai (multi-provider) | `openai` + `BASE_URL=https://openrouter.ai/api/v1` | — | [openrouter.ai](https://openrouter.ai) |
 
 **Kimi K2.5 `.env` example:**
 ```env
@@ -117,6 +118,25 @@ PLATFORM=kimi
 API_KEY=sk-...   # from platform.moonshot.ai
 AGENT_NAME=Yukine
 ```
+
+**Google Gemini `.env` example:**
+```env
+PLATFORM=gemini
+API_KEY=AIza...   # from aistudio.google.com
+MODEL=gemini-2.5-flash  # or gemini-2.5-pro for higher capability
+AGENT_NAME=Yukine
+```
+
+**OpenRouter.ai `.env` example:**
+```env
+PLATFORM=openai
+BASE_URL=https://openrouter.ai/api/v1
+API_KEY=sk-or-...   # from openrouter.ai
+MODEL=mistralai/mistral-7b-instruct  # optional: specify model
+AGENT_NAME=Yukine
+```
+
+> **Note:** To disable local/NVIDIA models, simply don't set `BASE_URL` to a local endpoint like `http://localhost:11434/v1`. Use cloud providers instead.
 
 ---
 


### PR DESCRIPTION
## Changes
- Added OpenRouter.ai support to all README files
- Enhanced Gemini configuration examples
- Added note about disabling local/NVIDIA models

## Files Changed
- README.md (English)
- README-ja.md (Japanese)
- README-zh.md (Simplified Chinese)
- README-zh-TW.md (Traditional Chinese)
- README-fr.md (French)
- README-de.md (German)

(ja)
変更内容
 1. OpenRouter.aiサポートの追加
• すべてのREADMEファイルにOpenRouter.aiをサポートプラットフォームとして追加
• 設定例を追加：PLATFORM=openai + BASE_URL=https://openrouter.ai/api/v1の使用方法
• モデル指定例を追加：MODEL=mistralai/mistral-7b-instruct
 2. Geminiドキュメントの強化
• Google Geminiの詳細な.env設定例を追加
• モデルオプションを明記（gemini-2.5-flash vs gemini-2.5-pro）
• APIキーの取得元を明確化
 3. ローカル/NVIDIAモデル無効化の注釈追加
• ローカルモデルを避ける方法を明記（http://localhost:11434/v1を使用しない）
• クラウドプロバイダーの利用を推奨

技術的な注記
• OpenRouter.aiは既存のOpenAI互換バックエンドを通じて動作
• コード変更は不要 - ドキュメントの強化のみ
• すべての言語版で一貫した更新を実施
• 既存のフォーマットとスタイルを維持
このPRの利点
 1. OpenRouter.aiのマルチプロバイダーマーケットプレイスが容易に利用可能に
 2. Geminiの適切なモデル選択が明確に
 3. ローカル/NVIDIAモデルを避けたいユーザーに明確なガイダンスを提供
