### PR TITLE
fix(backend): default TOOLS_MODE to prompt for local/compatible endpoints

### DIFF
--- a/src/familiar_agent/backend.py
+++ b/src/familiar_agent/backend.py
@@ -803,7 +803,15 @@ def create_backend(
         base_url = config.base_url
         if not os.environ.get("BASE_URL"):
             base_url = "https://api.openai.com/v1"
-        tools_mode = config.tools_mode if os.environ.get("TOOLS_MODE") else "native"
+        # Default to "prompt" for local/compatible endpoints; "native" only for real OpenAI.
+        # Local model servers (LM Studio, Ollama, vllm, etc.) often hang or timeout when
+        # they receive the `tools` parameter without proper support — causing Request timed out.
+        is_real_openai = "api.openai.com" in base_url
+        tools_mode = (
+            config.tools_mode
+            if os.environ.get("TOOLS_MODE")
+            else ("native" if is_real_openai else "prompt")
+        )
         logger.info(
             "Using OpenAI backend: %s @ %s (tools=%s)",
             model,


### PR DESCRIPTION
## Problem

When using `PLATFORM=openai` with a local model server (LM Studio, Ollama, vllm, etc.), `TOOLS_MODE` was defaulting to `"native"`, which sends the `tools` parameter in every request.

Many local model servers hang or return **Request timed out** when they receive `tools` without proper native function-calling support. This was reported by users trying LM Studio:

```
# .env
PLATFORM=openai
BASE_URL=http://192.168.10.6:1234/v1
API_KEY=lmstudio
MODEL=qwen/qwen3-vl-8b
# TOOLS_MODE not set → was "native" → Request timed out
```

Ollama worked because it tends to ignore unknown parameters and respond normally, whereas LM Studio hangs.

## Fix

Default `TOOLS_MODE` to `"prompt"` for any endpoint that is not `api.openai.com`. Only the real OpenAI API defaults to `"native"`.

`TOOLS_MODE` env var still overrides the default in all cases.

## Workaround (before this fix)

Add `TOOLS_MODE=prompt` to your `.env`.

## Test plan

- [x] `PLATFORM=openai` + `BASE_URL` pointing to LM Studio → `tools_mode` should be `"prompt"`
- [x] `PLATFORM=openai` + no `BASE_URL` set → uses `api.openai.com`, `tools_mode` should be `"native"`
- [x] `TOOLS_MODE=native` explicitly set → overrides to `"native"` regardless of endpoint
- [x] `TOOLS_MODE=prompt` explicitly set → overrides to `"prompt"` regardless of endpoint