### PR TITLE
feat(dev): add developer Claude Code skills

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,27 @@
+# dev/ — Developer Skills for familiar-ai
+
+Claude Code skills for contributors and power users of familiar-ai.
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| [`familiar-add-tool`](./familiar-add-tool/SKILL.md) | Scaffold a new sensor/actuator tool and register it in all required places |
+| [`familiar-check-env`](./familiar-check-env/SKILL.md) | Validate `.env` configuration and surface common misconfigurations |
+| [`familiar-debug-loop`](./familiar-debug-loop/SKILL.md) | Diagnose a stuck or misbehaving ReAct agent loop |
+
+## Installation
+
+Copy or symlink the skills into your Claude Code skills directory:
+
+```bash
+# Copy all familiar-ai dev skills
+cp -r dev/familiar-* ~/.claude/skills/
+
+# Or symlink (changes to the repo are reflected immediately)
+for d in dev/familiar-*/; do
+  ln -sf "$(pwd)/$d" ~/.claude/skills/
+done
+```
+
+Then invoke from Claude Code with e.g. `/familiar-add-tool`.

--- a/dev/familiar-add-tool/SKILL.md
+++ b/dev/familiar-add-tool/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: familiar-add-tool
+description: Scaffold a new sensor/actuator tool for familiar-ai. Generates the tool file and registers it in all required places in agent.py.
+---
+
+# familiar-add-tool
+
+Scaffold a new tool (sensor, actuator, or service) for the familiar-ai agent.
+
+## When to Use
+
+- Adding a new physical sensor (microphone, temperature, GPS, …)
+- Adding a new actuator (arm, LED, speaker, …)
+- Wrapping a new external service (weather API, home automation, …)
+
+## What This Skill Does
+
+1. Creates `src/familiar_agent/tools/<name>.py` from the standard template
+2. Registers the tool in `agent.py` in **all three required places**
+3. Adds any new env vars to `config.py` and `.env.example`
+4. Adds the tool's body description to the system prompt in `agent.py`
+
+---
+
+## Step 1: Gather Requirements
+
+Ask the user (or infer from context):
+
+- **Tool name** (snake_case, e.g. `microphone`)
+- **Tool verbs** — the callable actions the agent can take (e.g. `listen`, `record`)
+- **Config vars** — env vars needed (e.g. `MIC_DEVICE_INDEX`)
+- **System prompt description** — how should the agent understand this body part?
+- **Optional flag** — is the tool optional (guarded by config) or always available?
+
+---
+
+## Step 2: Create the Tool File
+
+Create `src/familiar_agent/tools/<name>.py`:
+
+```python
+"""<Name> tool — <one-line description>."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class <Name>Tool:
+    """<Description>."""
+
+    def __init__(self, <config_params>) -> None:
+        self.<param> = <param>
+        # TODO: initialize hardware/client
+
+    async def <verb>(self, <args>) -> tuple[str, str | None]:
+        """<What this action does>. Returns (text_result, image_b64_or_None)."""
+        # TODO: implement
+        return "Not implemented yet.", None
+
+    def get_tool_definitions(self) -> list[dict]:
+        return [
+            {
+                "name": "<verb>",
+                "description": "<What the agent does when calling this tool>.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        # "<param>": {"type": "string", "description": "..."},
+                    },
+                    "required": [],
+                },
+            },
+        ]
+
+    async def call(self, tool_name: str, tool_input: dict) -> tuple[str, str | None]:
+        if tool_name == "<verb>":
+            return await self.<verb>(**tool_input)
+        return f"Unknown tool: {tool_name}", None
+```
+
+**Key rules for tool files:**
+- `call()` always returns `tuple[str, str | None]` — text result + optional JPEG base64
+- `get_tool_definitions()` uses Anthropic input_schema format
+- Keep each tool in its own file, one class per file
+
+---
+
+## Step 3: Register in `agent.py`
+
+Touch **three** places:
+
+### 3a. Import (top of file)
+```python
+from .tools.<name> import <Name>Tool
+```
+
+### 3b. `_init_tools()` — instantiate if config is available
+```python
+# In Agent._init_tools():
+<name>_cfg = self.config.<name>          # or read directly from config
+if <name>_cfg.<required_field>:
+    self._<name> = <Name>Tool(<name>_cfg.<field>, ...)
+```
+
+### 3c. `_all_tool_defs` property — expose definitions
+```python
+# In Agent._all_tool_defs:
+if self._<name>:
+    defs.extend(self._<name>.get_tool_definitions())
+```
+
+### 3d. `_execute_tool()` — route calls
+```python
+# In Agent._execute_tool():
+<name>_tools = {"<verb1>", "<verb2>"}
+
+if name in <name>_tools and self._<name>:
+    return await self._<name>.call(name, tool_input)
+```
+
+Also add `self._<name>: <Name>Tool | None = None` to `__init__`.
+
+---
+
+## Step 4: Update `config.py`
+
+If new env vars are needed, add a config dataclass:
+
+```python
+@dataclass
+class <Name>Config:
+    <field>: str = field(default_factory=lambda: os.environ.get("<ENV_VAR>", ""))
+```
+
+And add it to `AgentConfig`:
+```python
+<name>: <Name>Config = field(default_factory=<Name>Config)
+```
+
+---
+
+## Step 5: Update System Prompt in `agent.py`
+
+Add the tool to the body parts description in `SYSTEM_PROMPT`:
+
+```
+- <Body part name> (<verb>): <How the agent should think about and use this>.
+```
+
+Keep it grounded and concrete — e.g. "Ears (listen): Your hearing. Calling listen() records audio from the microphone and transcribes it."
+
+---
+
+## Step 6: Update `.env.example`
+
+```bash
+# <Name> tool
+<ENV_VAR>=
+```
+
+---
+
+## Checklist Before Finishing
+
+- [ ] `tools/<name>.py` created with `get_tool_definitions()` and `call()`
+- [ ] Import added to `agent.py`
+- [ ] `_init_tools()` instantiates the tool (with optional guard)
+- [ ] `_all_tool_defs` includes it
+- [ ] `_execute_tool()` routes to it
+- [ ] `config.py` has new config class (if needed)
+- [ ] `AgentConfig` references the new config (if needed)
+- [ ] `SYSTEM_PROMPT` describes the new body part
+- [ ] `.env.example` documents new env vars
+- [ ] Run `uv run ruff check . && uv run ruff format .` before committing

--- a/dev/familiar-check-env/SKILL.md
+++ b/dev/familiar-check-env/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: familiar-check-env
+description: Validate the .env configuration for familiar-ai. Detects common misconfigurations like wrong ports, missing MODEL, or TOOLS_MODE issues that cause silent failures or timeouts.
+---
+
+# familiar-check-env
+
+Validate the `.env` (or environment) for familiar-ai and surface likely misconfigurations before they cause cryptic errors.
+
+## When to Use
+
+- "It's not responding" / "Request timed out" with a local LLM
+- Setting up familiar-ai for the first time
+- Switching between platforms (Anthropic → LM Studio → Ollama, etc.)
+- After upgrading familiar-ai when new env vars were added
+
+---
+
+## What to Check
+
+Read the current `.env` (or `os.environ`) and validate each section:
+
+---
+
+### Section 1: Core LLM
+
+| Var | Expected | Common Mistake |
+|-----|----------|----------------|
+| `PLATFORM` | `anthropic` / `openai` / `gemini` / `kimi` | Typo, or not set (defaults to `anthropic`) |
+| `API_KEY` | Non-empty | Forgotten, wrong key for the platform |
+| `MODEL` | Platform-appropriate model ID | Not set → defaults to `claude-haiku-4-5-20251001` or `gpt-4o-mini`, which LM Studio won't serve |
+| `BASE_URL` | Valid URL | Wrong port (LM Studio=1234, Ollama=11434), HTTP vs HTTPS |
+| `TOOLS_MODE` | `prompt` for local models, `native` for real OpenAI | Missing → now defaults to `prompt` for non-OpenAI (was `native` before v0.x) |
+
+**Platform-specific checks:**
+
+- `PLATFORM=anthropic` → `API_KEY` should start with `sk-ant-`; `BASE_URL` and `TOOLS_MODE` are ignored
+- `PLATFORM=openai` + `BASE_URL` not set → falls back to `https://api.openai.com/v1` (real OpenAI)
+- `PLATFORM=openai` + `BASE_URL` set to local → warn if `TOOLS_MODE=native` (may cause timeout on models that don't support function calling)
+- `PLATFORM=gemini` → `API_KEY` should be a Google AI Studio key; `BASE_URL` is ignored
+- `PLATFORM=kimi` → `API_KEY` is a Moonshot AI key
+
+**LM Studio specific:**
+- Default port is **1234**, not 11434
+- LM Studio only binds to `localhost` by default; cross-machine access requires enabling "Allow connections from network" in LM Studio settings
+- `MODEL` must exactly match the identifier shown in LM Studio's loaded model list
+
+**Ollama specific:**
+- Default port is **11434**
+- Ollama binds to `0.0.0.0` by default, so cross-machine access usually works without extra config
+
+---
+
+### Section 2: Camera (optional)
+
+| Var | Notes |
+|-----|-------|
+| `CAMERA_HOST` | IP of the camera on the local network |
+| `CAMERA_USERNAME` | Usually `admin` |
+| `CAMERA_PASSWORD` | Required if `CAMERA_HOST` is set |
+| `CAMERA_ONVIF_PORT` | Default `2020` for Tapo; check your camera's spec |
+
+Warn if `CAMERA_HOST` is set but `CAMERA_PASSWORD` is empty — camera tool will silently skip init.
+
+---
+
+### Section 3: TTS / Voice (optional)
+
+| Var | Notes |
+|-----|-------|
+| `ELEVENLABS_API_KEY` | Required for TTS |
+| `ELEVENLABS_VOICE_ID` | Defaults to a built-in voice; override for custom voices |
+| `GO2RTC_URL` | Default `http://localhost:1984`; only needed for camera speaker |
+| `GO2RTC_STREAM` | Default `tapo_cam` |
+
+Check that `mpv` or `ffplay` is available in PATH for local speaker playback:
+```bash
+which mpv || which ffplay
+```
+
+---
+
+### Section 4: Mobility / Robot Vacuum (optional)
+
+| Var | Notes |
+|-----|-------|
+| `TUYA_API_KEY` | From Tuya IoT Platform |
+| `TUYA_API_SECRET` | From Tuya IoT Platform |
+| `TUYA_DEVICE_ID` | The vacuum's device ID in Tuya |
+| `TUYA_REGION` | `us` / `eu` / `cn` / `in` |
+
+Mobility tool silently skips init if any of these are missing.
+
+---
+
+## Output Format
+
+Report findings grouped by severity:
+
+```
+[PLATFORM: openai]
+  ✅ API_KEY is set
+  ✅ BASE_URL = http://192.168.10.6:1234/v1  (LM Studio)
+  ⚠️  TOOLS_MODE not set → defaulting to "prompt" (correct for local models)
+  ❌ MODEL not set → will request "gpt-4o-mini" which LM Studio may not serve
+     Fix: set MODEL=<your-loaded-model-identifier>
+
+[CAMERA]
+  ✅ CAMERA_HOST = 192.168.10.5
+  ❌ CAMERA_PASSWORD is empty → camera tool will not initialize
+
+[TTS]
+  ⚠️  ELEVENLABS_API_KEY not set → TTS disabled
+  ⚠️  mpv not found in PATH, ffplay not found → no local audio playback
+
+[MOBILITY]
+  ℹ️  TUYA_* not set → mobility disabled (OK if no robot vacuum)
+```
+
+Always end with a summary:
+```
+Summary: 1 error, 2 warnings. Fix errors before starting the agent.
+```

--- a/dev/familiar-debug-loop/SKILL.md
+++ b/dev/familiar-debug-loop/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: familiar-debug-loop
+description: Debug a stuck or misbehaving familiar-ai ReAct loop. Diagnoses tool-call failures, model output issues, prompt-mode parsing errors, and silent tool skips.
+---
+
+# familiar-debug-loop
+
+Diagnose why the familiar-ai agent loop is stuck, looping, or behaving unexpectedly.
+
+## When to Use
+
+- Agent responds but never calls any tools
+- Agent keeps calling the same tool in a loop
+- "Tool not available" errors despite the tool being configured
+- TTS / camera / mobility silently does nothing
+- Agent finishes immediately without doing anything useful
+- Weird JSON parse errors in prompt-mode tool calling
+
+---
+
+## Diagnostic Flow
+
+Work through these checks in order. Stop at the first confirmed cause.
+
+---
+
+### Check 1: Tool Availability
+
+The agent skips tool init silently if env vars are missing. Verify each tool actually initialized:
+
+```python
+# In a Python REPL or quick script:
+from familiar_agent.config import AgentConfig
+from familiar_agent.agent import FamiliarAgent
+
+cfg = AgentConfig()
+agent = FamiliarAgent(cfg)
+
+print("Camera:", agent._camera)     # None = not initialized
+print("Mobility:", agent._mobility) # None = not initialized
+print("TTS:", agent._tts)           # None = not initialized
+print("Tools:", [t["name"] for t in agent._all_tool_defs])
+```
+
+If a tool is `None`, run **familiar-check-env** to find the missing config.
+
+---
+
+### Check 2: Model is Generating Tool Calls
+
+In `TOOLS_MODE=prompt`, the model must output `<tool_call>{...}</tool_call>` blocks.
+In `TOOLS_MODE=native`, the model must return `finish_reason="tool_calls"`.
+
+**Enable debug logging** to see raw model output:
+
+```bash
+# .env
+LOG_LEVEL=DEBUG
+```
+
+Or in Python:
+```python
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+Look for lines like:
+```
+DEBUG familiar_agent.backend - ...
+```
+
+**Prompt-mode symptoms:**
+- Model outputs `<tool_call>` but nothing happens → check `_TOOL_CALL_RE` regex parse
+- Model outputs plain text instead of `<tool_call>` → model isn't following the tools prompt; try a different/larger model
+- Model outputs `<tool_call>` then keeps talking → model ignored the "STOP after tool_call" instruction; try `TOOLS_MODE=prompt` with a stronger system prompt hint
+
+**Native-mode symptoms:**
+- `finish_reason` is `"stop"` instead of `"tool_calls"` → model doesn't support native function calling; switch to `TOOLS_MODE=prompt`
+- Request timeout → model hangs on `tools` parameter; switch to `TOOLS_MODE=prompt`
+
+---
+
+### Check 3: Tool Call Routing
+
+In `agent.py → _execute_tool()`, tool calls are routed by name string matching.
+
+If you added a new tool but it's returning `"Tool 'xyz' not available"`:
+
+1. Check the tool name in `get_tool_definitions()` matches exactly the string being routed in `_execute_tool()`
+2. Check the tool's set is included in `_execute_tool()`:
+   ```python
+   <name>_tools = {"<verb1>", "<verb2>"}
+   if name in <name>_tools and self._<name>:
+       return await self._<name>.call(name, tool_input)
+   ```
+3. Check `self._<name>` is not `None` (see Check 1)
+
+---
+
+### Check 4: Camera Issues
+
+**"see() returns no image"**
+- RTSP stream URL is wrong → check `CAMERA_HOST`, `CAMERA_ONVIF_PORT`
+- Camera is offline → try pinging `CAMERA_HOST`
+- ffmpeg not in PATH → `which ffmpeg`
+
+**"look() does nothing"**
+- ONVIF PTZ not supported by camera model → check camera spec
+- Wrong ONVIF port → default for Tapo is `2020`, other brands vary
+
+**"Connection refused"**
+- ONVIF port not open → check firewall, camera settings
+
+---
+
+### Check 5: TTS Issues
+
+**"say() returns success but no sound"**
+- go2rtc not running → check `~/.cache/embodied-claude/go2rtc/go2rtc` exists and is executable
+- Camera doesn't support backchannel audio → go2rtc fallback should kick in and play locally
+- `mpv` / `ffplay` not in PATH → no local playback fallback; install one
+
+**"TTS API failed (401)"**
+- `ELEVENLABS_API_KEY` is wrong or expired
+
+**"TTS API failed (422)"**
+- Text too long → truncated at 200 chars automatically; if still failing, check for special characters
+
+---
+
+### Check 6: Agent Loop Logic
+
+**Agent loops on the same action:**
+- Check `MAX_ITERATIONS` (default 50) in `agent.py`
+- Likely the model isn't getting a useful result back from the tool and keeps retrying
+- Look at what the tool is returning — is it a meaningful observation or an error message?
+
+**Agent ends turn immediately after one action:**
+- System prompt says "speak after every see()" — if `say()` is the last required step, the loop ends naturally
+- Check if `stop_reason == "end_turn"` is coming too early — model may be concluding the task prematurely
+
+**Agent never enters tool-calling mode (just talks):**
+- `_all_tool_defs` returns empty list → all tools are `None`; run Check 1
+- Model ignoring tools prompt → try a VLM with stronger instruction following (qwen3-vl, llava-next, etc.)
+
+---
+
+### Check 7: Memory Issues
+
+**"recall() returns nothing"**
+- DB file not created yet → first run
+- Embedding model not downloaded → check `~/.cache/huggingface/`
+- DB path wrong → check `MEMORY_DB_PATH` or default `~/.familiar_ai/observations.db`
+
+**"remember() hangs"**
+- Embedding model loading for the first time (downloads ~117MB) → wait
+- Torch not installed → `uv add torch --extra-index-url https://download.pytorch.org/whl/cpu`
+
+---
+
+## Quick Reference: Log Levels
+
+```bash
+LOG_LEVEL=DEBUG    # Full backend request/response, tool routing
+LOG_LEVEL=INFO     # Tool init, backend selection, key events (default)
+LOG_LEVEL=WARNING  # Only problems
+```
+
+Log file location: `~/.cache/familiar-ai/familiar-ai.log`
+
+---
+
+## Useful One-Liners
+
+```bash
+# Check what tools are available given current .env
+uv run python -c "
+from familiar_agent.config import AgentConfig
+from familiar_agent.agent import FamiliarAgent
+a = FamiliarAgent(AgentConfig())
+print([t['name'] for t in a._all_tool_defs])
+"
+
+# Tail the log
+tail -f ~/.cache/familiar-ai/familiar-ai.log
+
+# Check DB exists and has records
+sqlite3 ~/.familiar_ai/observations.db "SELECT count(*) FROM observations;"
+```


### PR DESCRIPTION
## Summary

Adds a `dev/` directory with three Claude Code skills for familiar-ai contributors and power users:

- **`familiar-add-tool`** — Step-by-step scaffold for adding a new sensor/actuator tool, covering all three registration points in `agent.py` plus `config.py` and the system prompt
- **`familiar-check-env`** — Validates `.env` configuration across all platforms (Anthropic, LM Studio, Ollama, Gemini, Kimi) and surfaces common issues like wrong ports, missing MODEL, and TOOLS_MODE mismatches
- **`familiar-debug-loop`** — Diagnostic flow for stuck/looping/silent agent behavior, covering tool availability, model output, tool routing, camera, TTS, memory, and logging

## Install

```bash
cp -r dev/familiar-* ~/.claude/skills/
# then: /familiar-add-tool, /familiar-check-env, /familiar-debug-loop
```

## Test plan

- [x] `/familiar-add-tool` guides through creating a new tool with no steps missed
- [x] `/familiar-check-env` catches LM Studio port mismatch and missing MODEL
- [x] `/familiar-debug-loop` surfaces the right diagnosis for a tool-not-initialized scenario