### PR TITLE
fix(tts): use go2rtc.exe on Windows; document go2rtc setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,24 @@ TUYA_DEVICE_ID=your-device-id
 # ──────────────────────────────────────────
 ELEVENLABS_API_KEY=your-elevenlabs-key
 ELEVENLABS_VOICE_ID=cgSgspJ2msm6clMCkdW9
+
+# ──────────────────────────────────────────
+# go2rtc — camera speaker playback (optional)
+# Required to play TTS audio through the camera's built-in speaker.
+# Without this, TTS falls back to the local PC speaker (mpv/ffplay).
+#
+# Setup:
+#   1. Download go2rtc from https://github.com/AlexxIT/go2rtc/releases
+#        Linux/macOS : go2rtc_linux_amd64 / go2rtc_darwin_amd64
+#        Windows     : go2rtc_win64.exe
+#   2. Rename and place at:
+#        Linux/macOS : ~/.cache/embodied-claude/go2rtc/go2rtc   (chmod +x)
+#        Windows     : %USERPROFILE%\.cache\embodied-claude\go2rtc\go2rtc.exe
+#   3. Create ~/.cache/embodied-claude/go2rtc/go2rtc.yaml:
+#        streams:
+#          tapo_cam:
+#            - rtsp://YOUR_CAM_USER:YOUR_CAM_PASS@YOUR_CAM_IP/stream1
+#   4. These env vars are optional if you use the defaults below.
+# ──────────────────────────────────────────
+# GO2RTC_URL=http://localhost:1984     # default
+# GO2RTC_STREAM=tapo_cam              # must match the key in go2rtc.yaml

--- a/README-de.md
+++ b/README-de.md
@@ -178,17 +178,45 @@ Starte `./run.sh` und fang an zu chatten. Füge Hardware später hinzu.
    ELEVENLABS_API_KEY=sk_...
    ELEVENLABS_VOICE_ID=...   # optional, verwendet Standardstimme wenn weggelassen
    ```
-3. Die Stimme wird über den integrierten Kameralautsprecher via go2rtc abgespielt (beim ersten Start automatisch heruntergeladen)
+Es gibt zwei Wiedergabeziele:
 
-**Lokale Audiowiedergabe** (Fallback oder ohne Kameralautsprecher) erfordert **mpv** oder **ffplay**. mpv wird empfohlen:
+#### A) Kameralautsprecher (via go2rtc)
+
+Um Audio über den integrierten Kameralautsprecher abzuspielen, muss [go2rtc](https://github.com/AlexxIT/go2rtc/releases) manuell eingerichtet werden:
+
+1. Lade das Binary von der [Releases-Seite](https://github.com/AlexxIT/go2rtc/releases) herunter:
+   - Linux/macOS: `go2rtc_linux_amd64` / `go2rtc_darwin_amd64`
+   - **Windows: `go2rtc_win64.exe`**
+
+2. Ablegen und umbenennen:
+   ```
+   # Linux / macOS
+   ~/.cache/embodied-claude/go2rtc/go2rtc          # chmod +x erforderlich
+
+   # Windows
+   %USERPROFILE%\.cache\embodied-claude\go2rtc\go2rtc.exe
+   ```
+
+3. `go2rtc.yaml` im selben Verzeichnis erstellen:
+   ```yaml
+   streams:
+     tapo_cam:
+       - rtsp://YOUR_CAM_USER:YOUR_CAM_PASS@YOUR_CAM_IP/stream1
+   ```
+
+4. familiar-ai startet go2rtc automatisch beim Start. Wenn die Kamera bidirektionales Audio (Backchannel) unterstützt, kommt die Stimme aus dem Kameralautsprecher.
+
+#### B) Lokaler PC-Lautsprecher (Fallback)
+
+Ohne go2rtc oder wenn die Kamera kein Backchannel-Audio unterstützt, wird auf **mpv** oder **ffplay** zurückgefallen:
 
 | OS | Installation |
 |----|-------------|
 | macOS | `brew install mpv` |
 | Ubuntu / Debian | `sudo apt install mpv` |
-| Windows | [mpv.io/installation](https://mpv.io/installation/) — herunterladen und zu PATH hinzufügen, **oder** ffmpeg installieren: `winget install ffmpeg` |
+| Windows | [mpv.io/installation](https://mpv.io/installation/) — herunterladen und zu PATH hinzufügen, **oder** `winget install ffmpeg` |
 
-> Ohne mpv oder ffplay kann familiar-ai Sprache generieren, aber nicht lokal abspielen. Kameralautsprecher (go2rtc) ist davon nicht betroffen.
+> Ohne go2rtc und lokalen Player funktioniert die Sprachgenerierung (ElevenLabs API) weiterhin — die Wiedergabe wird lediglich übersprungen.
 
 ---
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -178,17 +178,45 @@ Lancez `./run.sh` et commencez à discuter. Ajoutez du matériel au fur et à me
    ELEVENLABS_API_KEY=sk_...
    ELEVENLABS_VOICE_ID=...   # optionnel, utilise la voix par défaut si omis
    ```
-3. La voix joue via le haut-parleur intégré de la caméra via go2rtc (téléchargé automatiquement au premier lancement)
+Il y a deux destinations de lecture :
 
-**La lecture audio locale** (utilisée en repli ou sans haut-parleur caméra) nécessite **mpv** ou **ffplay**. mpv est recommandé :
+#### A) Haut-parleur de la caméra (via go2rtc)
+
+Pour diffuser l'audio via le haut-parleur intégré de la caméra, installez [go2rtc](https://github.com/AlexxIT/go2rtc/releases) manuellement :
+
+1. Téléchargez le binaire depuis la [page des releases](https://github.com/AlexxIT/go2rtc/releases) :
+   - Linux/macOS : `go2rtc_linux_amd64` / `go2rtc_darwin_amd64`
+   - **Windows : `go2rtc_win64.exe`**
+
+2. Placez et renommez-le :
+   ```
+   # Linux / macOS
+   ~/.cache/embodied-claude/go2rtc/go2rtc          # chmod +x requis
+
+   # Windows
+   %USERPROFILE%\.cache\embodied-claude\go2rtc\go2rtc.exe
+   ```
+
+3. Créez `go2rtc.yaml` dans le même répertoire :
+   ```yaml
+   streams:
+     tapo_cam:
+       - rtsp://YOUR_CAM_USER:YOUR_CAM_PASS@YOUR_CAM_IP/stream1
+   ```
+
+4. familiar-ai démarre go2rtc automatiquement. Si la caméra supporte l'audio bidirectionnel, la voix sort du haut-parleur de la caméra.
+
+#### B) Haut-parleur PC local (repli)
+
+Sans go2rtc ou si la caméra ne supporte pas le backchannel audio, familiar-ai utilise **mpv** ou **ffplay** :
 
 | OS | Installation |
 |----|-------------|
 | macOS | `brew install mpv` |
 | Ubuntu / Debian | `sudo apt install mpv` |
-| Windows | [mpv.io/installation](https://mpv.io/installation/) — télécharger et ajouter au PATH, **ou** installer ffmpeg : `winget install ffmpeg` |
+| Windows | [mpv.io/installation](https://mpv.io/installation/) — télécharger et ajouter au PATH, **ou** `winget install ffmpeg` |
 
-> Sans mpv ni ffplay, familiar-ai peut générer la parole mais ne peut pas la lire localement. La lecture via le haut-parleur de la caméra (go2rtc) n'est pas affectée.
+> Sans go2rtc ni lecteur local, la génération vocale (appel API ElevenLabs) fonctionne toujours — la lecture est simplement ignorée.
 
 ---
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -181,17 +181,47 @@ API_KEY=sk-...
    ELEVENLABS_API_KEY=sk_...
    ELEVENLABS_VOICE_ID=...   # オプション、省略時はデフォルト音声を使用
    ```
-3. 音声はgo2rtc経由でカメラのスピーカーから再生されます（初回実行時に自動ダウンロード）
 
-**ローカル音声再生**（カメラスピーカー未設定時のフォールバック）には **mpv** または **ffplay** が必要です。mpv推奨：
+音声の再生先は2通りあります：
+
+#### A) カメラのスピーカーから再生（go2rtc 経由）
+
+カメラ内蔵スピーカーから声を出したい場合は [go2rtc](https://github.com/AlexxIT/go2rtc/releases) のセットアップが必要です。
+
+1. [リリースページ](https://github.com/AlexxIT/go2rtc/releases) からバイナリをダウンロード：
+   - Linux/macOS: `go2rtc_linux_amd64` / `go2rtc_darwin_amd64`
+   - **Windows: `go2rtc_win64.exe`**
+
+2. 以下の場所に配置・リネーム：
+   ```
+   # Linux / macOS
+   ~/.cache/embodied-claude/go2rtc/go2rtc       # chmod +x が必要
+
+   # Windows
+   %USERPROFILE%\.cache\embodied-claude\go2rtc\go2rtc.exe
+   ```
+
+3. 同じディレクトリに `go2rtc.yaml` を作成：
+   ```yaml
+   streams:
+     tapo_cam:
+       - rtsp://YOUR_CAM_USER:YOUR_CAM_PASS@YOUR_CAM_IP/stream1
+   ```
+   ※ `YOUR_CAM_USER` / `YOUR_CAM_PASS` は Tapoアプリで作成したローカルアカウント。`YOUR_CAM_IP` はカメラのIPアドレス。
+
+4. familiar-ai 起動時に go2rtc が自動起動します。カメラが双方向音声（バックチャンネル）に対応していれば、カメラのスピーカーから声が出ます。
+
+#### B) PCのスピーカーから再生（フォールバック）
+
+go2rtc が未設定、またはカメラがバックチャンネル非対応の場合、**mpv** または **ffplay** でPCから再生します。
 
 | OS | インストール方法 |
 |----|----------------|
 | macOS | `brew install mpv` |
 | Ubuntu / Debian | `sudo apt install mpv` |
-| Windows | [mpv.io/installation](https://mpv.io/installation/) からダウンロードしてPATHに追加、**または** ffmpegをインストール：`winget install ffmpeg` |
+| Windows | [mpv.io/installation](https://mpv.io/installation/) からダウンロードしてPATHに追加、**または** `winget install ffmpeg` |
 
-> mpv・ffplayがない場合でも音声生成自体は動作します。カメラスピーカー経由（go2rtc）の再生には影響しません。
+> go2rtc・mpv・ffplay がいずれも未設定でも、音声生成自体（ElevenLabs API呼び出し）は動作します。再生がスキップされるだけです。
 
 ---
 

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -178,17 +178,45 @@ API_KEY=sk-...
    ELEVENLABS_API_KEY=sk_...
    ELEVENLABS_VOICE_ID=...   # 可選，省略則使用預設聲音
    ```
-3. 語音透過 go2rtc（首次執行時自動下載）透過攝影機內建喇叭播放
+音訊有兩種播放方式：
 
-**本機音訊播放**（無攝影機喇叭時的備用方案）需要安裝 **mpv** 或 **ffplay**，建議使用 mpv：
+#### A) 攝影機喇叭（透過 go2rtc）
+
+若要透過攝影機內建喇叭播放，需手動安裝 [go2rtc](https://github.com/AlexxIT/go2rtc/releases)：
+
+1. 從[發布頁面](https://github.com/AlexxIT/go2rtc/releases)下載二進位檔：
+   - Linux/macOS：`go2rtc_linux_amd64` / `go2rtc_darwin_amd64`
+   - **Windows：`go2rtc_win64.exe`**
+
+2. 放置並重新命名到以下路徑：
+   ```
+   # Linux / macOS
+   ~/.cache/embodied-claude/go2rtc/go2rtc          # 需要 chmod +x
+
+   # Windows
+   %USERPROFILE%\.cache\embodied-claude\go2rtc\go2rtc.exe
+   ```
+
+3. 在同一目錄下建立 `go2rtc.yaml`：
+   ```yaml
+   streams:
+     tapo_cam:
+       - rtsp://YOUR_CAM_USER:YOUR_CAM_PASS@YOUR_CAM_IP/stream1
+   ```
+
+4. familiar-ai 啟動時會自動啟動 go2rtc。若攝影機支援雙向音訊，聲音將從攝影機喇叭輸出。
+
+#### B) 本機 PC 喇叭（備用方案）
+
+未設定 go2rtc 或攝影機不支援雙向音訊時，回退至 **mpv** 或 **ffplay**：
 
 | 作業系統 | 安裝方式 |
 |---------|---------|
 | macOS | `brew install mpv` |
 | Ubuntu / Debian | `sudo apt install mpv` |
-| Windows | 從 [mpv.io/installation](https://mpv.io/installation/) 下載並加入 PATH，**或**安裝 ffmpeg：`winget install ffmpeg` |
+| Windows | 從 [mpv.io/installation](https://mpv.io/installation/) 下載並加入 PATH，**或** `winget install ffmpeg` |
 
-> 未安裝 mpv 或 ffplay 時，familiar-ai 仍可生成語音，但無法在本機播放。透過攝影機喇叭（go2rtc）播放不受影響。
+> 即使沒有 go2rtc 或本機播放器，語音生成本身（ElevenLabs API 呼叫）仍可正常運作，只是不會播放。
 
 ---
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -178,17 +178,45 @@ API_KEY=sk-...
    ELEVENLABS_API_KEY=sk_...
    ELEVENLABS_VOICE_ID=...   # 可选，省略则使用默认声音
    ```
-3. 语音通过 go2rtc（首次运行时自动下载）通过摄像头内置扬声器播放
+音频有两种播放方式：
 
-**本地音频播放**（无摄像头扬声器时的回退方案）需要安装 **mpv** 或 **ffplay**，推荐使用 mpv：
+#### A) 摄像头扬声器（通过 go2rtc）
+
+若要通过摄像头内置扬声器播放，需手动安装 [go2rtc](https://github.com/AlexxIT/go2rtc/releases)：
+
+1. 从[发布页面](https://github.com/AlexxIT/go2rtc/releases)下载二进制文件：
+   - Linux/macOS：`go2rtc_linux_amd64` / `go2rtc_darwin_amd64`
+   - **Windows：`go2rtc_win64.exe`**
+
+2. 放置并重命名到以下路径：
+   ```
+   # Linux / macOS
+   ~/.cache/embodied-claude/go2rtc/go2rtc          # 需要 chmod +x
+
+   # Windows
+   %USERPROFILE%\.cache\embodied-claude\go2rtc\go2rtc.exe
+   ```
+
+3. 在同一目录下创建 `go2rtc.yaml`：
+   ```yaml
+   streams:
+     tapo_cam:
+       - rtsp://YOUR_CAM_USER:YOUR_CAM_PASS@YOUR_CAM_IP/stream1
+   ```
+
+4. familiar-ai 启动时会自动启动 go2rtc。如果摄像头支持双向音频，声音将从摄像头扬声器输出。
+
+#### B) 本地 PC 扬声器（回退方案）
+
+未配置 go2rtc 或摄像头不支持双向音频时，回退到 **mpv** 或 **ffplay**：
 
 | 操作系统 | 安装方式 |
 |---------|---------|
 | macOS | `brew install mpv` |
 | Ubuntu / Debian | `sudo apt install mpv` |
-| Windows | 从 [mpv.io/installation](https://mpv.io/installation/) 下载并添加到 PATH，**或**安装 ffmpeg：`winget install ffmpeg` |
+| Windows | 从 [mpv.io/installation](https://mpv.io/installation/) 下载并添加到 PATH，**或** `winget install ffmpeg` |
 
-> 未安装 mpv 或 ffplay 时，familiar-ai 仍可生成语音，但无法在本地播放。通过摄像头扬声器（go2rtc）播放不受影响。
+> 即使没有 go2rtc 或本地播放器，语音生成本身（ElevenLabs API 调用）仍可正常工作，只是不会播放。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -183,17 +183,47 @@ Run `./run.sh` and start chatting. Add hardware as you go.
    ELEVENLABS_API_KEY=sk_...
    ELEVENLABS_VOICE_ID=...   # optional, uses default voice if omitted
    ```
-3. Voice plays through the camera's built-in speaker via go2rtc (auto-downloaded on first run)
 
-**Local audio playback** (used as fallback, or when no camera speaker is configured) requires **mpv** or **ffplay**. mpv is recommended:
+There are two playback destinations:
+
+#### A) Camera speaker (via go2rtc)
+
+To play audio through the camera's built-in speaker, set up [go2rtc](https://github.com/AlexxIT/go2rtc/releases) manually:
+
+1. Download the binary from the [releases page](https://github.com/AlexxIT/go2rtc/releases):
+   - Linux/macOS: `go2rtc_linux_amd64` / `go2rtc_darwin_amd64`
+   - **Windows: `go2rtc_win64.exe`**
+
+2. Place and rename it:
+   ```
+   # Linux / macOS
+   ~/.cache/embodied-claude/go2rtc/go2rtc          # chmod +x required
+
+   # Windows
+   %USERPROFILE%\.cache\embodied-claude\go2rtc\go2rtc.exe
+   ```
+
+3. Create `go2rtc.yaml` in the same directory:
+   ```yaml
+   streams:
+     tapo_cam:
+       - rtsp://YOUR_CAM_USER:YOUR_CAM_PASS@YOUR_CAM_IP/stream1
+   ```
+   Use the local camera account credentials (not your TP-Link cloud account).
+
+4. familiar-ai starts go2rtc automatically at launch. If your camera supports two-way audio (backchannel), voice plays from the camera speaker.
+
+#### B) Local PC speaker (fallback)
+
+If go2rtc is not set up, or the camera does not support backchannel audio, familiar-ai falls back to **mpv** or **ffplay**:
 
 | OS | Install |
 |----|---------|
 | macOS | `brew install mpv` |
 | Ubuntu / Debian | `sudo apt install mpv` |
-| Windows | [mpv.io/installation](https://mpv.io/installation/) — download and add to PATH, **or** install ffmpeg: `winget install ffmpeg` |
+| Windows | [mpv.io/installation](https://mpv.io/installation/) — download and add to PATH, **or** `winget install ffmpeg` |
 
-> Without mpv or ffplay, familiar-ai can still generate speech — it just won't play it locally. Voice via camera speaker (go2rtc) is unaffected.
+> If neither go2rtc nor a local player is available, speech is still generated — it just won't play.
 
 ---
 

--- a/src/familiar_agent/tools/tts.py
+++ b/src/familiar_agent/tools/tts.py
@@ -8,6 +8,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import urllib.request
 from pathlib import Path
@@ -16,7 +17,8 @@ from urllib.parse import quote
 logger = logging.getLogger(__name__)
 
 _GO2RTC_CACHE = Path.home() / ".cache" / "embodied-claude" / "go2rtc"
-_GO2RTC_BIN = _GO2RTC_CACHE / "go2rtc"
+# On Windows the binary is go2rtc.exe; on other platforms there is no extension.
+_GO2RTC_BIN = _GO2RTC_CACHE / ("go2rtc.exe" if sys.platform == "win32" else "go2rtc")
 _GO2RTC_CONFIG = _GO2RTC_CACHE / "go2rtc.yaml"
 
 


### PR DESCRIPTION
## Problem

Windows users (e.g. Tapo C220 + familiar-ai) reported that TTS audio plays from the PC speaker instead of the camera speaker.

Root cause: the go2rtc binary path was hardcoded without a `.exe` extension:

```python
# Before (broken on Windows)
_GO2RTC_BIN = _GO2RTC_CACHE / "go2rtc"
```

On Windows, `go2rtc.exe` exists but `go2rtc` does not → `_GO2RTC_BIN.exists()` returns `False` → go2rtc is never started → TTS falls back to the local PC speaker silently.

Additionally, the README incorrectly stated go2rtc was "auto-downloaded on first run" (no such code exists), and `.env.example` had no mention of `GO2RTC_URL` / `GO2RTC_STREAM`.

## Changes

### Code fix (`tts.py`)
- Append `.exe` suffix on `sys.platform == "win32"`

### Documentation (all READMEs: en/ja/zh/zh-TW/fr/de)
- Replace the one-liner "auto-downloaded" claim with accurate step-by-step go2rtc setup instructions
- Separate camera speaker (go2rtc) vs local PC speaker (mpv/ffplay) into two clear sections
- Explicit Windows binary path (`go2rtc_win64.exe` → `%USERPROFILE%\.cache\embodied-claude\go2rtc\go2rtc.exe`)
- Sample `go2rtc.yaml` for Tapo cameras

### `.env.example`
- Add `GO2RTC_URL` and `GO2RTC_STREAM` with full setup instructions as comments

## Test plan

- [x] Windows: place `go2rtc_win64.exe` at the documented path → go2rtc starts automatically
- [x] Linux/macOS: existing path `go2rtc` (no extension) still works
- [x] Camera speaker plays TTS when go2rtc + camera backchannel is configured
- [x] Falls back to mpv/ffplay when go2rtc is absent