### PR TITLE
docs: document ffmpeg as required dependency (all languages)

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -46,7 +46,22 @@ Im Leerlauf handelt es nach seinen eigenen Wünschen: Neugier, den Wunsch nach d
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-### 2. Klone und installiere
+### 2. Installiere ffmpeg
+
+ffmpeg ist **erforderlich** für die Kamerabilderfassung und Audiowiedergabe.
+
+| OS | Befehl |
+|----|--------|
+| macOS | `brew install ffmpeg` |
+| Ubuntu / Debian | `sudo apt install ffmpeg` |
+| Fedora / RHEL | `sudo dnf install ffmpeg` |
+| Arch Linux | `sudo pacman -S ffmpeg` |
+| Windows | `winget install ffmpeg` — oder von [ffmpeg.org](https://ffmpeg.org/download.html) herunterladen und zu PATH hinzufügen |
+| Raspberry Pi | `sudo apt install ffmpeg` |
+
+Überprüfen: `ffmpeg -version`
+
+### 3. Klone und installiere
 
 ```bash
 git clone https://github.com/lifemate-ai/familiar-ai
@@ -54,7 +69,7 @@ cd familiar-ai
 uv sync
 ```
 
-### 3. Konfiguriere
+### 4. Konfiguriere
 
 ```bash
 cp .env.example .env
@@ -78,14 +93,14 @@ cp .env.example .env
 | `CAMERA_USER` / `CAMERA_PASS` | Anmeldedaten der Kamera |
 | `ELEVENLABS_API_KEY` | Für Sprachausgabe — [elevenlabs.io](https://elevenlabs.io/) |
 
-### 4. Erstelle deinen Familiar
+### 5. Erstelle deinen Familiar
 
 ```bash
 cp persona-template/en.md ME.md
 # Bearbeite ME.md — gib ihm einen Namen und eine Persönlichkeit
 ```
 
-### 5. Starten
+### 6. Starten
 
 ```bash
 ./run.sh             # Textuelle TUI (empfohlen)

--- a/README-fr.md
+++ b/README-fr.md
@@ -46,7 +46,22 @@ Quand elle est inactive, elle agit selon ses propres désirs : la curiosité, l'
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-### 2. Cloner et installer
+### 2. Installer ffmpeg
+
+ffmpeg est **requis** pour la capture d'images de la caméra et la lecture audio.
+
+| OS | Commande |
+|----|---------|
+| macOS | `brew install ffmpeg` |
+| Ubuntu / Debian | `sudo apt install ffmpeg` |
+| Fedora / RHEL | `sudo dnf install ffmpeg` |
+| Arch Linux | `sudo pacman -S ffmpeg` |
+| Windows | `winget install ffmpeg` — ou télécharger depuis [ffmpeg.org](https://ffmpeg.org/download.html) et ajouter au PATH |
+| Raspberry Pi | `sudo apt install ffmpeg` |
+
+Vérifier : `ffmpeg -version`
+
+### 3. Cloner et installer
 
 ```bash
 git clone https://github.com/lifemate-ai/familiar-ai
@@ -54,7 +69,7 @@ cd familiar-ai
 uv sync
 ```
 
-### 3. Configurer
+### 4. Configurer
 
 ```bash
 cp .env.example .env
@@ -78,14 +93,14 @@ cp .env.example .env
 | `CAMERA_USER` / `CAMERA_PASS` | Identifiants de la caméra |
 | `ELEVENLABS_API_KEY` | Pour la sortie vocale — [elevenlabs.io](https://elevenlabs.io/) |
 
-### 4. Créer votre compagne
+### 5. Créer votre compagne
 
 ```bash
 cp persona-template/en.md ME.md
 # Modifiez ME.md — donnez-lui un nom et une personnalité
 ```
 
-### 5. Lancer
+### 6. Lancer
 
 ```bash
 ./run.sh             # Interface textuelle (recommandé)

--- a/README-ja.md
+++ b/README-ja.md
@@ -49,7 +49,22 @@ user input
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-### 2. クローンしてインストール
+### 2. ffmpeg をインストール
+
+ffmpegは**必須**です。カメラ画像のキャプチャと音声再生に使用します。
+
+| OS | コマンド |
+|----|---------|
+| macOS | `brew install ffmpeg` |
+| Ubuntu / Debian | `sudo apt install ffmpeg` |
+| Fedora / RHEL | `sudo dnf install ffmpeg` |
+| Arch Linux | `sudo pacman -S ffmpeg` |
+| Windows | `winget install ffmpeg` — または [ffmpeg.org](https://ffmpeg.org/download.html) からダウンロードしてPATHに追加 |
+| Raspberry Pi | `sudo apt install ffmpeg` |
+
+確認: `ffmpeg -version`
+
+### 3. クローンしてインストール
 
 ```bash
 git clone https://github.com/lifemate-ai/familiar-ai
@@ -57,12 +72,13 @@ cd familiar-ai
 uv sync
 ```
 
-### 3. 設定
+### 4. 設定
 
 ```bash
 cp .env.example .env
 # .env を編集して設定を入力
 ```
+
 
 **必須項目：**
 
@@ -81,14 +97,14 @@ cp .env.example .env
 | `CAMERA_USER` / `CAMERA_PASS` | カメラの認証情報 |
 | `ELEVENLABS_API_KEY` | 音声出力用 — [elevenlabs.io](https://elevenlabs.io/) |
 
-### 4. familiarを作る
+### 5. familiarを作る
 
 ```bash
 cp persona-template/en.md ME.md
 # ME.md を編集して、名前と性格を設定
 ```
 
-### 5. 実行
+### 6. 実行
 
 ```bash
 ./run.sh             # Textual TUI（推奨）

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -46,7 +46,22 @@ Familiar AI 執行一個由你選擇的大型語言模型驅動的 [ReAct](https
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-### 2. 複製並安裝
+### 2. 安裝 ffmpeg
+
+ffmpeg是**必要**的，用於相機圖像擷取和音訊播放。
+
+| OS | 指令 |
+|----|------|
+| macOS | `brew install ffmpeg` |
+| Ubuntu / Debian | `sudo apt install ffmpeg` |
+| Fedora / RHEL | `sudo dnf install ffmpeg` |
+| Arch Linux | `sudo pacman -S ffmpeg` |
+| Windows | `winget install ffmpeg` — 或從 [ffmpeg.org](https://ffmpeg.org/download.html) 下載並加入 PATH |
+| Raspberry Pi | `sudo apt install ffmpeg` |
+
+驗證：`ffmpeg -version`
+
+### 3. 複製並安裝
 
 ```bash
 git clone https://github.com/lifemate-ai/familiar-ai
@@ -54,7 +69,7 @@ cd familiar-ai
 uv sync
 ```
 
-### 3. 設定
+### 4. 設定
 
 ```bash
 cp .env.example .env
@@ -78,14 +93,14 @@ cp .env.example .env
 | `CAMERA_USER` / `CAMERA_PASS` | 攝影機憑證 |
 | `ELEVENLABS_API_KEY` | 用於語音輸出 — [elevenlabs.io](https://elevenlabs.io/) |
 
-### 4. 建立你的夥伴
+### 5. 建立你的夥伴
 
 ```bash
 cp persona-template/en.md ME.md
 # 編輯 ME.md — 給它取名字，定義個性
 ```
 
-### 5. 執行
+### 6. 執行
 
 ```bash
 ./run.sh             # 文字 UI（推薦）

--- a/README-zh.md
+++ b/README-zh.md
@@ -46,7 +46,22 @@ Familiar AI 运行一个由你选择的大语言模型驱动的 [ReAct](https://
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-### 2. 克隆并安装
+### 2. 安装 ffmpeg
+
+ffmpeg是**必须**的，用于摄像头图像捕获和音频播放。
+
+| OS | 命令 |
+|----|------|
+| macOS | `brew install ffmpeg` |
+| Ubuntu / Debian | `sudo apt install ffmpeg` |
+| Fedora / RHEL | `sudo dnf install ffmpeg` |
+| Arch Linux | `sudo pacman -S ffmpeg` |
+| Windows | `winget install ffmpeg` — 或从 [ffmpeg.org](https://ffmpeg.org/download.html) 下载并添加到 PATH |
+| Raspberry Pi | `sudo apt install ffmpeg` |
+
+验证：`ffmpeg -version`
+
+### 3. 克隆并安装
 
 ```bash
 git clone https://github.com/lifemate-ai/familiar-ai
@@ -54,7 +69,7 @@ cd familiar-ai
 uv sync
 ```
 
-### 3. 配置
+### 4. 配置
 
 ```bash
 cp .env.example .env
@@ -78,14 +93,14 @@ cp .env.example .env
 | `CAMERA_USER` / `CAMERA_PASS` | 摄像头凭证 |
 | `ELEVENLABS_API_KEY` | 用于语音输出 — [elevenlabs.io](https://elevenlabs.io/) |
 
-### 4. 创建你的伙伴
+### 5. 创建你的伙伴
 
 ```bash
 cp persona-template/en.md ME.md
 # 编辑 ME.md — 给它起名字，定义性格
 ```
 
-### 5. 运行
+### 6. 运行
 
 ```bash
 ./run.sh             # 文本 UI（推荐）

--- a/README.md
+++ b/README.md
@@ -51,7 +51,22 @@ When idle, it acts on its own desires: curiosity, wanting to look outside, missi
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-### 2. Clone and install
+### 2. Install ffmpeg
+
+ffmpeg is **required** for camera image capture and audio playback.
+
+| OS | Command |
+|----|---------|
+| macOS | `brew install ffmpeg` |
+| Ubuntu / Debian | `sudo apt install ffmpeg` |
+| Fedora / RHEL | `sudo dnf install ffmpeg` |
+| Arch Linux | `sudo pacman -S ffmpeg` |
+| Windows | `winget install ffmpeg` — or download from [ffmpeg.org](https://ffmpeg.org/download.html) and add to PATH |
+| Raspberry Pi | `sudo apt install ffmpeg` |
+
+Verify: `ffmpeg -version`
+
+### 3. Clone and install
 
 ```bash
 git clone https://github.com/lifemate-ai/familiar-ai
@@ -59,7 +74,7 @@ cd familiar-ai
 uv sync
 ```
 
-### 3. Configure
+### 4. Configure
 
 ```bash
 cp .env.example .env
@@ -83,14 +98,14 @@ cp .env.example .env
 | `CAMERA_USER` / `CAMERA_PASS` | Camera credentials |
 | `ELEVENLABS_API_KEY` | For voice output — [elevenlabs.io](https://elevenlabs.io/) |
 
-### 4. Create your familiar
+### 5. Create your familiar
 
 ```bash
 cp persona-template/en.md ME.md
 # Edit ME.md — give it a name and personality
 ```
 
-### 5. Run
+### 6. Run
 
 ```bash
 ./run.sh             # Textual TUI (recommended)


### PR DESCRIPTION
Closes #19

## Summary

Added a new **step 2 "Install ffmpeg"** to the Getting Started section in all README files, with OS-specific installation commands.

ffmpeg is used in two places:
- `tools/camera.py` — RTSP frame capture (required for any camera)
- `tools/tts.py` — local audio playback fallback (`ffplay`) and camera speaker via go2rtc

Previously this was only mentioned in the TTS/audio section, making it easy to miss. Now it's front-and-center in setup.

## Languages updated

- `README.md` (English) — base
- `README-ja.md` (日本語)
- `README-zh.md` (简体中文)
- `README-zh-TW.md` (繁體中文)
- `README-fr.md` (Français)
- `README-de.md` (Deutsch)

## Test plan

- [x] All 6 READMEs show step 2 as "Install ffmpeg" with OS table
- [x] Steps renumbered correctly (1→2→3→4→5→6)
- [ ] `ffmpeg -version` verify command present in each language