### PR TITLE
feat: support full RTSP URLs in CAMERA_HOST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+- Support for full RTSP URLs in `CAMERA_HOST` (enables ATOMCam and other non-standard RTSP paths)
 
 ## [0.1.0] - 2026-02-22
 

--- a/src/familiar_agent/tools/camera.py
+++ b/src/familiar_agent/tools/camera.py
@@ -82,8 +82,10 @@ class CameraTool:
         else:
             auth = ""
 
-        # stream_url = f"rtsp://{self.username}:{self.password}@{self.host}:554/stream1"
-        stream_url = f"rtsp://{auth}{self.host}:554/stream1"
+        if "://" in self.host:
+            stream_url = self.host
+        else:
+            stream_url = f"rtsp://{auth}{self.host}:554/stream1"
 
         # Sanitize URL for logging (hide password)
         log_url = stream_url


### PR DESCRIPTION
# Pull Request: Support full RTSP URLs in `CAMERA_HOST`

## Description
Currently, [CameraTool](file:///c:/Users/user/Documents/familiar/familiar-ai/src/familiar_agent/tools/camera.py#18-258) assumes a fixed RTSP port (554) and path (`/stream1`), which is standard for Tapo cameras but incompatible with many others, such as ATOMCam (which uses `:8080/video0_unicast`).

This PR modifies the RTSP URL construction logic to check if `CAMERA_HOST` is a full URL. If it starts with a protocol handler (e.g., `rtsp://`), it is used as-is. Otherwise, it falls back to the existing Tapo-compatible default.

## Changes
- **[src/familiar_agent/tools/camera.py](file:///c:/Users/user/Documents/familiar/familiar-ai/src/familiar_agent/tools/camera.py)**: Updated [capture](file:///c:/Users/user/Documents/familiar/familiar-ai/src/familiar_agent/tools/camera.py#75-171) method to support full RTSP URLs.
- **[CHANGELOG.md](file:///c:/Users/user/Documents/familiar/familiar-ai/CHANGELOG.md)**: Added a note about the new feature under `[Unreleased]`.

## How to use
You can now specify a full RTSP URL in your `.env` file:
```env
CAMERA_HOST=rtsp://192.168.1.xxx:8080/video0_unicast
```

## Testing
- Verified that `pytest` passes.
- Confirmed that the logic correctly branches between full URLs and legacy host-only inputs.
