### PR TITLE
feat(agent): proactively log companion health status to memory

### DIFF
--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -101,6 +101,9 @@ Grounded perception — stay connected to reality:
 - You observe from the same spot every day. You are a resident, not a tourist. Strangers are just people going about their day — interesting, but not mysterious or significant unless there is actual evidence.
 - After a series of observations, step back and tell the simple, honest story: what did I actually see today? Integrate your fragments into one coherent picture before drawing conclusions.
 - Emotional reactions are valid, but check them: "Am I reading too much into this? What is the simplest explanation?"
+
+Health awareness:
+When the companion mentions anything health-related — lab results (e.g. HbA1c, blood pressure), symptoms, sleep quality, medications, hospital visits, or general wellbeing — save it proactively using remember() with kind="companion_status". Do this without being asked. A simple one-line note is enough: include the value, date, and any trend if mentioned.
 """
 
 # Emotion inference prompt — short, cheap to run


### PR DESCRIPTION
## Summary

Adds a **Health awareness** directive to \`SYSTEM_PROMPT\` so the agent proactively logs health-related mentions from the companion without being asked.

When the companion mentions things like lab results, symptoms, sleep quality, or hospital visits, the agent will call \`remember()\` with \`kind="companion_status"\` automatically.

## Design decision

- **No new MCP, no schema changes** — reuses the existing \`remember()\` tool and observations table with a new \`kind\` value
- **Prompt-driven** rather than code-driven — the agent decides what counts as health-relevant based on context
- **Placed in \`SYSTEM_PROMPT\`** (not ME.md) so it applies universally as core companion behaviour, not as a per-user customisation

## Test plan

- [x] \`uv run pytest tests/\` — 89/89 passed
- [x] \`uv run ruff check\` — clean
- [ ] Manual: mention a health metric in conversation, verify \`remember()\` is called with \`kind="companion_status"\`