### PR TITLE
feat(tts): add TTS_OUTPUT routing — local / remote / both

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,12 @@ ELEVENLABS_VOICE_ID=cgSgspJ2msm6clMCkdW9
 # GO2RTC_URL=http://localhost:1984     # default
 # GO2RTC_STREAM=tapo_cam              # must match the key in go2rtc.yaml
 
+# TTS audio output destination (optional, default: local)
+#   local  = PC speaker (mpv / ffplay)
+#   remote = camera speaker via go2rtc (requires go2rtc setup above)
+#   both   = camera speaker + PC speaker simultaneously
+# TTS_OUTPUT=local
+
 # ── MCP (Model Context Protocol) ──────────────────────────────────────────────
 # Optional: Connect external MCP servers to extend the agent's tools.
 # Body tools (camera, TTS, mobility) stay built-in. Use MCP for everything else.

--- a/README-de.md
+++ b/README-de.md
@@ -92,6 +92,7 @@ cp .env.example .env
 | `CAMERA_HOST` | IP-Adresse deiner ONVIF/RTSP-Kamera |
 | `CAMERA_USER` / `CAMERA_PASS` | Anmeldedaten der Kamera |
 | `ELEVENLABS_API_KEY` | Für Sprachausgabe — [elevenlabs.io](https://elevenlabs.io/) |
+| `TTS_OUTPUT` | Audioziel: `local` (PC-Lautsprecher, Standard) \| `remote` (Kameralautsprecher) \| `both` (beides gleichzeitig) |
 
 ### 5. Erstelle deinen Familiar
 
@@ -231,11 +232,17 @@ Starte `./run.sh` und fang an zu chatten. Füge Hardware später hinzu.
    ELEVENLABS_API_KEY=sk_...
    ELEVENLABS_VOICE_ID=...   # optional, verwendet Standardstimme wenn weggelassen
    ```
-Es gibt zwei Wiedergabeziele:
+Das Audioziel wird mit `TTS_OUTPUT` gesteuert:
+
+```env
+TTS_OUTPUT=local    # PC-Lautsprecher (Standard)
+TTS_OUTPUT=remote   # Nur Kameralautsprecher
+TTS_OUTPUT=both     # Kameralautsprecher + PC-Lautsprecher gleichzeitig
+```
 
 #### A) Kameralautsprecher (via go2rtc)
 
-Um Audio über den integrierten Kameralautsprecher abzuspielen, muss [go2rtc](https://github.com/AlexxIT/go2rtc/releases) manuell eingerichtet werden:
+Setze `TTS_OUTPUT=remote` (oder `both`). [go2rtc](https://github.com/AlexxIT/go2rtc/releases) muss manuell eingerichtet werden:
 
 1. Lade das Binary von der [Releases-Seite](https://github.com/AlexxIT/go2rtc/releases) herunter:
    - Linux/macOS: `go2rtc_linux_amd64` / `go2rtc_darwin_amd64`
@@ -259,9 +266,9 @@ Um Audio über den integrierten Kameralautsprecher abzuspielen, muss [go2rtc](ht
 
 4. familiar-ai startet go2rtc automatisch beim Start. Wenn die Kamera bidirektionales Audio (Backchannel) unterstützt, kommt die Stimme aus dem Kameralautsprecher.
 
-#### B) Lokaler PC-Lautsprecher (Fallback)
+#### B) Lokaler PC-Lautsprecher
 
-Ohne go2rtc oder wenn die Kamera kein Backchannel-Audio unterstützt, wird auf **mpv** oder **ffplay** zurückgefallen:
+Standard (`TTS_OUTPUT=local`). Verwendet **mpv** oder **ffplay**. Wird auch als Fallback genutzt, wenn `TTS_OUTPUT=remote` und go2rtc nicht verfügbar ist.
 
 | OS | Installation |
 |----|-------------|

--- a/README-fr.md
+++ b/README-fr.md
@@ -92,6 +92,7 @@ cp .env.example .env
 | `CAMERA_HOST` | Adresse IP de votre caméra ONVIF/RTSP |
 | `CAMERA_USER` / `CAMERA_PASS` | Identifiants de la caméra |
 | `ELEVENLABS_API_KEY` | Pour la sortie vocale — [elevenlabs.io](https://elevenlabs.io/) |
+| `TTS_OUTPUT` | Destination audio : `local` (haut-parleur PC, défaut) \| `remote` (haut-parleur caméra) \| `both` (les deux simultanément) |
 
 ### 5. Créer votre compagne
 
@@ -231,11 +232,17 @@ Lancez `./run.sh` et commencez à discuter. Ajoutez du matériel au fur et à me
    ELEVENLABS_API_KEY=sk_...
    ELEVENLABS_VOICE_ID=...   # optionnel, utilise la voix par défaut si omis
    ```
-Il y a deux destinations de lecture :
+La destination audio est contrôlée par `TTS_OUTPUT` :
+
+```env
+TTS_OUTPUT=local    # Haut-parleur PC (défaut)
+TTS_OUTPUT=remote   # Haut-parleur caméra uniquement
+TTS_OUTPUT=both     # Haut-parleur caméra + haut-parleur PC simultanément
+```
 
 #### A) Haut-parleur de la caméra (via go2rtc)
 
-Pour diffuser l'audio via le haut-parleur intégré de la caméra, installez [go2rtc](https://github.com/AlexxIT/go2rtc/releases) manuellement :
+Utilisez `TTS_OUTPUT=remote` (ou `both`). Installez [go2rtc](https://github.com/AlexxIT/go2rtc/releases) manuellement :
 
 1. Téléchargez le binaire depuis la [page des releases](https://github.com/AlexxIT/go2rtc/releases) :
    - Linux/macOS : `go2rtc_linux_amd64` / `go2rtc_darwin_amd64`
@@ -259,9 +266,9 @@ Pour diffuser l'audio via le haut-parleur intégré de la caméra, installez [go
 
 4. familiar-ai démarre go2rtc automatiquement. Si la caméra supporte l'audio bidirectionnel, la voix sort du haut-parleur de la caméra.
 
-#### B) Haut-parleur PC local (repli)
+#### B) Haut-parleur PC local
 
-Sans go2rtc ou si la caméra ne supporte pas le backchannel audio, familiar-ai utilise **mpv** ou **ffplay** :
+Mode par défaut (`TTS_OUTPUT=local`). Utilise **mpv** ou **ffplay**. Également utilisé en repli quand `TTS_OUTPUT=remote` et que go2rtc est indisponible.
 
 | OS | Installation |
 |----|-------------|

--- a/README-ja.md
+++ b/README-ja.md
@@ -96,6 +96,7 @@ cp .env.example .env
 | `CAMERA_HOST` | ONVIF/RTSPカメラのIPアドレス |
 | `CAMERA_USER` / `CAMERA_PASS` | カメラの認証情報 |
 | `ELEVENLABS_API_KEY` | 音声出力用 — [elevenlabs.io](https://elevenlabs.io/) |
+| `TTS_OUTPUT` | 音声出力先：`local`（PCスピーカー、デフォルト）\| `remote`（カメラスピーカー）\| `both`（両方同時） |
 
 ### 5. familiarを作る
 
@@ -236,11 +237,17 @@ API_KEY=sk-...
    ELEVENLABS_VOICE_ID=...   # オプション、省略時はデフォルト音声を使用
    ```
 
-音声の再生先は2通りあります：
+音声の再生先は `TTS_OUTPUT` で切り替えられます：
+
+```env
+TTS_OUTPUT=local    # PCスピーカー（デフォルト）
+TTS_OUTPUT=remote   # カメラスピーカーのみ
+TTS_OUTPUT=both     # カメラスピーカー + PCスピーカー同時再生
+```
 
 #### A) カメラのスピーカーから再生（go2rtc 経由）
 
-カメラ内蔵スピーカーから声を出したい場合は [go2rtc](https://github.com/AlexxIT/go2rtc/releases) のセットアップが必要です。
+`TTS_OUTPUT=remote`（または `both`）を設定した場合に使用します。[go2rtc](https://github.com/AlexxIT/go2rtc/releases) のセットアップが必要です：
 
 1. [リリースページ](https://github.com/AlexxIT/go2rtc/releases) からバイナリをダウンロード：
    - Linux/macOS: `go2rtc_linux_amd64` / `go2rtc_darwin_amd64`
@@ -265,9 +272,9 @@ API_KEY=sk-...
 
 4. familiar-ai 起動時に go2rtc が自動起動します。カメラが双方向音声（バックチャンネル）に対応していれば、カメラのスピーカーから声が出ます。
 
-#### B) PCのスピーカーから再生（フォールバック）
+#### B) PCのスピーカーから再生
 
-go2rtc が未設定、またはカメラがバックチャンネル非対応の場合、**mpv** または **ffplay** でPCから再生します。
+デフォルト（`TTS_OUTPUT=local`）。**mpv** または **ffplay** を使用します。`TTS_OUTPUT=remote` でgo2rtcが使えない場合のフォールバックにもなります。
 
 | OS | インストール方法 |
 |----|----------------|

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -92,6 +92,7 @@ cp .env.example .env
 | `CAMERA_HOST` | ONVIF/RTSP 攝影機的 IP 位址 |
 | `CAMERA_USER` / `CAMERA_PASS` | 攝影機憑證 |
 | `ELEVENLABS_API_KEY` | 用於語音輸出 — [elevenlabs.io](https://elevenlabs.io/) |
+| `TTS_OUTPUT` | 音訊輸出位置：`local`（PC 喇叭，預設）\| `remote`（攝影機喇叭）\| `both`（兩者同時） |
 
 ### 5. 建立你的夥伴
 
@@ -231,11 +232,17 @@ API_KEY=sk-...
    ELEVENLABS_API_KEY=sk_...
    ELEVENLABS_VOICE_ID=...   # 可選，省略則使用預設聲音
    ```
-音訊有兩種播放方式：
+音訊播放位置由 `TTS_OUTPUT` 控制：
+
+```env
+TTS_OUTPUT=local    # PC 喇叭（預設）
+TTS_OUTPUT=remote   # 僅攝影機喇叭
+TTS_OUTPUT=both     # 攝影機喇叭 + PC 喇叭同時播放
+```
 
 #### A) 攝影機喇叭（透過 go2rtc）
 
-若要透過攝影機內建喇叭播放，需手動安裝 [go2rtc](https://github.com/AlexxIT/go2rtc/releases)：
+設定 `TTS_OUTPUT=remote`（或 `both`）時使用。需手動安裝 [go2rtc](https://github.com/AlexxIT/go2rtc/releases)：
 
 1. 從[發布頁面](https://github.com/AlexxIT/go2rtc/releases)下載二進位檔：
    - Linux/macOS：`go2rtc_linux_amd64` / `go2rtc_darwin_amd64`
@@ -259,9 +266,9 @@ API_KEY=sk-...
 
 4. familiar-ai 啟動時會自動啟動 go2rtc。若攝影機支援雙向音訊，聲音將從攝影機喇叭輸出。
 
-#### B) 本機 PC 喇叭（備用方案）
+#### B) 本機 PC 喇叭
 
-未設定 go2rtc 或攝影機不支援雙向音訊時，回退至 **mpv** 或 **ffplay**：
+預設方式（`TTS_OUTPUT=local`）。使用 **mpv** 或 **ffplay**。當 `TTS_OUTPUT=remote` 且 go2rtc 無法使用時也作為備用方案。
 
 | 作業系統 | 安裝方式 |
 |---------|---------|

--- a/README-zh.md
+++ b/README-zh.md
@@ -92,6 +92,7 @@ cp .env.example .env
 | `CAMERA_HOST` | ONVIF/RTSP 摄像头的 IP 地址 |
 | `CAMERA_USER` / `CAMERA_PASS` | 摄像头凭证 |
 | `ELEVENLABS_API_KEY` | 用于语音输出 — [elevenlabs.io](https://elevenlabs.io/) |
+| `TTS_OUTPUT` | 音频输出位置：`local`（PC 扬声器，默认）\| `remote`（摄像头扬声器）\| `both`（两者同时） |
 
 ### 5. 创建你的伙伴
 
@@ -231,11 +232,17 @@ API_KEY=sk-...
    ELEVENLABS_API_KEY=sk_...
    ELEVENLABS_VOICE_ID=...   # 可选，省略则使用默认声音
    ```
-音频有两种播放方式：
+音频播放位置由 `TTS_OUTPUT` 控制：
+
+```env
+TTS_OUTPUT=local    # PC 扬声器（默认）
+TTS_OUTPUT=remote   # 仅摄像头扬声器
+TTS_OUTPUT=both     # 摄像头扬声器 + PC 扬声器同时播放
+```
 
 #### A) 摄像头扬声器（通过 go2rtc）
 
-若要通过摄像头内置扬声器播放，需手动安装 [go2rtc](https://github.com/AlexxIT/go2rtc/releases)：
+设置 `TTS_OUTPUT=remote`（或 `both`）时使用。需手动安装 [go2rtc](https://github.com/AlexxIT/go2rtc/releases)：
 
 1. 从[发布页面](https://github.com/AlexxIT/go2rtc/releases)下载二进制文件：
    - Linux/macOS：`go2rtc_linux_amd64` / `go2rtc_darwin_amd64`
@@ -259,9 +266,9 @@ API_KEY=sk-...
 
 4. familiar-ai 启动时会自动启动 go2rtc。如果摄像头支持双向音频，声音将从摄像头扬声器输出。
 
-#### B) 本地 PC 扬声器（回退方案）
+#### B) 本地 PC 扬声器
 
-未配置 go2rtc 或摄像头不支持双向音频时，回退到 **mpv** 或 **ffplay**：
+默认方式（`TTS_OUTPUT=local`）。使用 **mpv** 或 **ffplay**。当 `TTS_OUTPUT=remote` 且 go2rtc 不可用时也作为回退方案。
 
 | 操作系统 | 安装方式 |
 |---------|---------|

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ cp .env.example .env
 | `CAMERA_HOST` | IP address of your ONVIF/RTSP camera |
 | `CAMERA_USER` / `CAMERA_PASS` | Camera credentials |
 | `ELEVENLABS_API_KEY` | For voice output — [elevenlabs.io](https://elevenlabs.io/) |
+| `TTS_OUTPUT` | Where to play audio: `local` (PC speaker, default) \| `remote` (camera speaker) \| `both` |
 
 ### 5. Create your familiar
 
@@ -237,11 +238,17 @@ Run `./run.sh` and start chatting. Add hardware as you go.
    ELEVENLABS_VOICE_ID=...   # optional, uses default voice if omitted
    ```
 
-There are two playback destinations:
+There are two playback destinations, controlled by `TTS_OUTPUT`:
+
+```env
+TTS_OUTPUT=local    # PC speaker (default)
+TTS_OUTPUT=remote   # camera speaker only
+TTS_OUTPUT=both     # camera speaker + PC speaker simultaneously
+```
 
 #### A) Camera speaker (via go2rtc)
 
-To play audio through the camera's built-in speaker, set up [go2rtc](https://github.com/AlexxIT/go2rtc/releases) manually:
+Set `TTS_OUTPUT=remote` (or `both`). Requires [go2rtc](https://github.com/AlexxIT/go2rtc/releases):
 
 1. Download the binary from the [releases page](https://github.com/AlexxIT/go2rtc/releases):
    - Linux/macOS: `go2rtc_linux_amd64` / `go2rtc_darwin_amd64`
@@ -266,9 +273,9 @@ To play audio through the camera's built-in speaker, set up [go2rtc](https://git
 
 4. familiar-ai starts go2rtc automatically at launch. If your camera supports two-way audio (backchannel), voice plays from the camera speaker.
 
-#### B) Local PC speaker (fallback)
+#### B) Local PC speaker
 
-If go2rtc is not set up, or the camera does not support backchannel audio, familiar-ai falls back to **mpv** or **ffplay**:
+The default (`TTS_OUTPUT=local`). Uses **mpv** or **ffplay**. Also used as a fallback when `TTS_OUTPUT=remote` and go2rtc is unavailable.
 
 | OS | Install |
 |----|---------|
@@ -276,7 +283,7 @@ If go2rtc is not set up, or the camera does not support backchannel audio, famil
 | Ubuntu / Debian | `sudo apt install mpv` |
 | Windows | [mpv.io/installation](https://mpv.io/installation/) — download and add to PATH, **or** `winget install ffmpeg` |
 
-> If neither go2rtc nor a local player is available, speech is still generated — it just won't play.
+> If no audio player is available, speech is still generated — it just won't play.
 
 ---
 

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -329,7 +329,11 @@ class EmbodiedAgent:
         tts = self.config.tts
         if tts.elevenlabs_api_key:
             self._tts = TTSTool(
-                tts.elevenlabs_api_key, tts.voice_id, tts.go2rtc_url, tts.go2rtc_stream
+                tts.elevenlabs_api_key,
+                tts.voice_id,
+                tts.go2rtc_url,
+                tts.go2rtc_stream,
+                output=tts.output,
             )
 
         from .mcp_client import MCPClientManager, _resolve_config_path

--- a/src/familiar_agent/config.py
+++ b/src/familiar_agent/config.py
@@ -61,6 +61,9 @@ class TTSConfig:
         default_factory=lambda: os.environ.get("GO2RTC_URL", "http://localhost:1984")
     )
     go2rtc_stream: str = field(default_factory=lambda: os.environ.get("GO2RTC_STREAM", "tapo_cam"))
+    # Audio output routing: "local" = PC speaker only, "remote" = camera speaker only,
+    # "both" = camera speaker + PC speaker simultaneously.
+    output: str = field(default_factory=lambda: os.environ.get("TTS_OUTPUT", "local"))
 
 
 @dataclass


### PR DESCRIPTION
Add a `TTS_OUTPUT` env var to control where audio is played:
- `local`  (default) — PC speaker via mpv/ffplay
- `remote`           — camera speaker via go2rtc only
- `both`             — camera speaker + PC speaker simultaneously

Previously, when go2rtc was reachable the agent always played through the camera speaker and returned early, making local playback impossible even when the user is sitting next to the PC.  This change lets users choose the output explicitly instead of relying on availability-based fallback logic.

Implementation:
- `TTSConfig.output` reads `TTS_OUTPUT` env var (default: `local`)
- `TTSTool.__init__` accepts `output` parameter
- `say()` drives `_play_local()` and `_play_via_go2rtc()` based on the configured output; `remote` falls back to local only on go2rtc failure, not silently
- `_play_local()` extracted as a standalone async helper
- Docs updated: README.md + ja / zh / zh-TW / fr / de + .env.example