### PR TITLE
fix(tui): pass Input widget directly to AutoComplete instead of CSS selector

### DIFF
--- a/src/familiar_agent/tui.py
+++ b/src/familiar_agent/tui.py
@@ -146,11 +146,12 @@ class FamiliarApp(App):
     def compose(self) -> ComposeResult:
         yield RichLog(id="log", highlight=False, markup=True, wrap=True)
         yield Static("", id="stream")
-        yield Input(
+        input_bar = Input(
             placeholder=_t("input_placeholder"),
             id="input-bar",
         )
-        yield AutoComplete("#input-bar", candidates=_slash_candidates)
+        yield input_bar
+        yield AutoComplete(input_bar, candidates=_slash_candidates)
         yield Footer()
 
     def on_mount(self) -> None:


### PR DESCRIPTION
## Summary

Fixes #26

**Root cause:** `textual_autocomplete` strips the leading `#` from the target string before calling `screen.query_one()`, turning `'#input-bar'` into `'input-bar'`. A bare `'input-bar'` is not a valid CSS selector (no `#` prefix), so Textual raises `InvalidQueryFormat` on startup.

**Fix:** Pass the `Input` widget instance directly to `AutoComplete()` instead of a CSS selector string. The library checks `isinstance(self._target, Input)` first and skips the string lookup entirely.

```python
# Before
yield Input(placeholder=..., id="input-bar")
yield AutoComplete("#input-bar", candidates=_slash_candidates)

# After
input_bar = Input(placeholder=..., id="input-bar")
yield input_bar
yield AutoComplete(input_bar, candidates=_slash_candidates)
```

## Test plan

- [x] `./run.sh` starts without `InvalidQueryFormat` error
- [x] `/clear` and `/transcribe` autocomplete still works in the input bar