### PR TITLE
feat: adaptive thinking, effort control, and TTS fixes

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -93,6 +93,8 @@ cp .env.example .env
 | `CAMERA_USER` / `CAMERA_PASS` | Anmeldedaten der Kamera |
 | `ELEVENLABS_API_KEY` | Für Sprachausgabe — [elevenlabs.io](https://elevenlabs.io/) |
 | `TTS_OUTPUT` | Audioziel: `local` (PC-Lautsprecher, Standard) \| `remote` (Kameralautsprecher) \| `both` (beides gleichzeitig) |
+| `THINKING_MODE` | Nur Anthropic — `auto` (Standard) \| `adaptive` \| `extended` \| `disabled` |
+| `THINKING_EFFORT` | Tiefe des adaptiven Denkens: `high` (Standard) \| `medium` \| `low` \| `max` (nur Opus 4.6) |
 
 ### 5. Erstelle deinen Familiar
 
@@ -268,12 +270,13 @@ Setze `TTS_OUTPUT=remote` (oder `both`). [go2rtc](https://github.com/AlexxIT/go2
 
 #### B) Lokaler PC-Lautsprecher
 
-Standard (`TTS_OUTPUT=local`). Verwendet **mpv** oder **ffplay**. Wird auch als Fallback genutzt, wenn `TTS_OUTPUT=remote` und go2rtc nicht verfügbar ist.
+Standard (`TTS_OUTPUT=local`). Probiert der Reihe nach: **paplay** → **mpv** → **ffplay**. Wird auch als Fallback genutzt, wenn `TTS_OUTPUT=remote` und go2rtc nicht verfügbar ist.
 
 | OS | Installation |
 |----|-------------|
 | macOS | `brew install mpv` |
-| Ubuntu / Debian | `sudo apt install mpv` |
+| Ubuntu / Debian | `sudo apt install mpv` (oder `paplay` via `pulseaudio-utils`) |
+| WSL2 / WSLg | `sudo apt install pulseaudio-utils` — `PULSE_SERVER=unix:/mnt/wslg/PulseServer` in `.env` setzen |
 | Windows | [mpv.io/installation](https://mpv.io/installation/) — herunterladen und zu PATH hinzufügen, **oder** `winget install ffmpeg` |
 
 > Ohne go2rtc und lokalen Player funktioniert die Sprachgenerierung (ElevenLabs API) weiterhin — die Wiedergabe wird lediglich übersprungen.

--- a/README-fr.md
+++ b/README-fr.md
@@ -93,6 +93,8 @@ cp .env.example .env
 | `CAMERA_USER` / `CAMERA_PASS` | Identifiants de la caméra |
 | `ELEVENLABS_API_KEY` | Pour la sortie vocale — [elevenlabs.io](https://elevenlabs.io/) |
 | `TTS_OUTPUT` | Destination audio : `local` (haut-parleur PC, défaut) \| `remote` (haut-parleur caméra) \| `both` (les deux simultanément) |
+| `THINKING_MODE` | Anthropic uniquement — `auto` (défaut) \| `adaptive` \| `extended` \| `disabled` |
+| `THINKING_EFFORT` | Profondeur de la réflexion adaptative : `high` (défaut) \| `medium` \| `low` \| `max` (Opus 4.6 uniquement) |
 
 ### 5. Créer votre compagne
 
@@ -268,12 +270,13 @@ Utilisez `TTS_OUTPUT=remote` (ou `both`). Installez [go2rtc](https://github.com/
 
 #### B) Haut-parleur PC local
 
-Mode par défaut (`TTS_OUTPUT=local`). Utilise **mpv** ou **ffplay**. Également utilisé en repli quand `TTS_OUTPUT=remote` et que go2rtc est indisponible.
+Mode par défaut (`TTS_OUTPUT=local`). Essaie dans l'ordre : **paplay** → **mpv** → **ffplay**. Également utilisé en repli quand `TTS_OUTPUT=remote` et que go2rtc est indisponible.
 
 | OS | Installation |
 |----|-------------|
 | macOS | `brew install mpv` |
-| Ubuntu / Debian | `sudo apt install mpv` |
+| Ubuntu / Debian | `sudo apt install mpv` (ou `paplay` via `pulseaudio-utils`) |
+| WSL2 / WSLg | `sudo apt install pulseaudio-utils` — définir `PULSE_SERVER=unix:/mnt/wslg/PulseServer` dans `.env` |
 | Windows | [mpv.io/installation](https://mpv.io/installation/) — télécharger et ajouter au PATH, **ou** `winget install ffmpeg` |
 
 > Sans go2rtc ni lecteur local, la génération vocale (appel API ElevenLabs) fonctionne toujours — la lecture est simplement ignorée.

--- a/README-ja.md
+++ b/README-ja.md
@@ -97,6 +97,8 @@ cp .env.example .env
 | `CAMERA_USER` / `CAMERA_PASS` | カメラの認証情報 |
 | `ELEVENLABS_API_KEY` | 音声出力用 — [elevenlabs.io](https://elevenlabs.io/) |
 | `TTS_OUTPUT` | 音声出力先：`local`（PCスピーカー、デフォルト）\| `remote`（カメラスピーカー）\| `both`（両方同時） |
+| `THINKING_MODE` | Anthropic専用 — `auto`（デフォルト）\| `adaptive` \| `extended` \| `disabled` |
+| `THINKING_EFFORT` | Adaptive thinking の深度：`high`（デフォルト）\| `medium` \| `low` \| `max`（Opus 4.6のみ） |
 
 ### 5. familiarを作る
 
@@ -274,12 +276,13 @@ TTS_OUTPUT=both     # カメラスピーカー + PCスピーカー同時再生
 
 #### B) PCのスピーカーから再生
 
-デフォルト（`TTS_OUTPUT=local`）。**mpv** または **ffplay** を使用します。`TTS_OUTPUT=remote` でgo2rtcが使えない場合のフォールバックにもなります。
+デフォルト（`TTS_OUTPUT=local`）。**paplay** → **mpv** → **ffplay** の順で試みます。`TTS_OUTPUT=remote` でgo2rtcが使えない場合のフォールバックにもなります。
 
 | OS | インストール方法 |
 |----|----------------|
 | macOS | `brew install mpv` |
-| Ubuntu / Debian | `sudo apt install mpv` |
+| Ubuntu / Debian | `sudo apt install mpv`（または `pulseaudio-utils` で paplay）|
+| WSL2 / WSLg | `sudo apt install pulseaudio-utils` — `.env` に `PULSE_SERVER=unix:/mnt/wslg/PulseServer` を設定 |
 | Windows | [mpv.io/installation](https://mpv.io/installation/) からダウンロードしてPATHに追加、**または** `winget install ffmpeg` |
 
 > go2rtc・mpv・ffplay がいずれも未設定でも、音声生成自体（ElevenLabs API呼び出し）は動作します。再生がスキップされるだけです。

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -93,6 +93,8 @@ cp .env.example .env
 | `CAMERA_USER` / `CAMERA_PASS` | 攝影機憑證 |
 | `ELEVENLABS_API_KEY` | 用於語音輸出 — [elevenlabs.io](https://elevenlabs.io/) |
 | `TTS_OUTPUT` | 音訊輸出位置：`local`（PC 喇叭，預設）\| `remote`（攝影機喇叭）\| `both`（兩者同時） |
+| `THINKING_MODE` | 僅 Anthropic — `auto`（預設）\| `adaptive` \| `extended` \| `disabled` |
+| `THINKING_EFFORT` | Adaptive thinking 深度：`high`（預設）\| `medium` \| `low` \| `max`（僅 Opus 4.6） |
 
 ### 5. 建立你的夥伴
 
@@ -268,12 +270,13 @@ TTS_OUTPUT=both     # 攝影機喇叭 + PC 喇叭同時播放
 
 #### B) 本機 PC 喇叭
 
-預設方式（`TTS_OUTPUT=local`）。使用 **mpv** 或 **ffplay**。當 `TTS_OUTPUT=remote` 且 go2rtc 無法使用時也作為備用方案。
+預設方式（`TTS_OUTPUT=local`）。依序嘗試 **paplay** → **mpv** → **ffplay**。當 `TTS_OUTPUT=remote` 且 go2rtc 無法使用時也作為備用方案。
 
 | 作業系統 | 安裝方式 |
 |---------|---------|
 | macOS | `brew install mpv` |
-| Ubuntu / Debian | `sudo apt install mpv` |
+| Ubuntu / Debian | `sudo apt install mpv`（或透過 `pulseaudio-utils` 使用 paplay）|
+| WSL2 / WSLg | `sudo apt install pulseaudio-utils` — 在 `.env` 中設定 `PULSE_SERVER=unix:/mnt/wslg/PulseServer` |
 | Windows | 從 [mpv.io/installation](https://mpv.io/installation/) 下載並加入 PATH，**或** `winget install ffmpeg` |
 
 > 即使沒有 go2rtc 或本機播放器，語音生成本身（ElevenLabs API 呼叫）仍可正常運作，只是不會播放。

--- a/README-zh.md
+++ b/README-zh.md
@@ -93,6 +93,8 @@ cp .env.example .env
 | `CAMERA_USER` / `CAMERA_PASS` | 摄像头凭证 |
 | `ELEVENLABS_API_KEY` | 用于语音输出 — [elevenlabs.io](https://elevenlabs.io/) |
 | `TTS_OUTPUT` | 音频输出位置：`local`（PC 扬声器，默认）\| `remote`（摄像头扬声器）\| `both`（两者同时） |
+| `THINKING_MODE` | 仅 Anthropic — `auto`（默认）\| `adaptive` \| `extended` \| `disabled` |
+| `THINKING_EFFORT` | Adaptive thinking 深度：`high`（默认）\| `medium` \| `low` \| `max`（仅 Opus 4.6） |
 
 ### 5. 创建你的伙伴
 
@@ -268,12 +270,13 @@ TTS_OUTPUT=both     # 摄像头扬声器 + PC 扬声器同时播放
 
 #### B) 本地 PC 扬声器
 
-默认方式（`TTS_OUTPUT=local`）。使用 **mpv** 或 **ffplay**。当 `TTS_OUTPUT=remote` 且 go2rtc 不可用时也作为回退方案。
+默认方式（`TTS_OUTPUT=local`）。依次尝试 **paplay** → **mpv** → **ffplay**。当 `TTS_OUTPUT=remote` 且 go2rtc 不可用时也作为回退方案。
 
 | 操作系统 | 安装方式 |
 |---------|---------|
 | macOS | `brew install mpv` |
-| Ubuntu / Debian | `sudo apt install mpv` |
+| Ubuntu / Debian | `sudo apt install mpv`（或通过 `pulseaudio-utils` 使用 paplay）|
+| WSL2 / WSLg | `sudo apt install pulseaudio-utils` — 在 `.env` 中设置 `PULSE_SERVER=unix:/mnt/wslg/PulseServer` |
 | Windows | 从 [mpv.io/installation](https://mpv.io/installation/) 下载并添加到 PATH，**或** `winget install ffmpeg` |
 
 > 即使没有 go2rtc 或本地播放器，语音生成本身（ElevenLabs API 调用）仍可正常工作，只是不会播放。

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ cp .env.example .env
 | `CAMERA_USER` / `CAMERA_PASS` | Camera credentials |
 | `ELEVENLABS_API_KEY` | For voice output — [elevenlabs.io](https://elevenlabs.io/) |
 | `TTS_OUTPUT` | Where to play audio: `local` (PC speaker, default) \| `remote` (camera speaker) \| `both` |
+| `THINKING_MODE` | Anthropic only — `auto` (default) \| `adaptive` \| `extended` \| `disabled` |
+| `THINKING_EFFORT` | Adaptive thinking effort: `high` (default) \| `medium` \| `low` \| `max` (Opus 4.6 only) |
 
 ### 5. Create your familiar
 
@@ -275,12 +277,13 @@ Set `TTS_OUTPUT=remote` (or `both`). Requires [go2rtc](https://github.com/AlexxI
 
 #### B) Local PC speaker
 
-The default (`TTS_OUTPUT=local`). Uses **mpv** or **ffplay**. Also used as a fallback when `TTS_OUTPUT=remote` and go2rtc is unavailable.
+The default (`TTS_OUTPUT=local`). Tries players in order: **paplay** → **mpv** → **ffplay**. Also used as a fallback when `TTS_OUTPUT=remote` and go2rtc is unavailable.
 
 | OS | Install |
 |----|---------|
 | macOS | `brew install mpv` |
-| Ubuntu / Debian | `sudo apt install mpv` |
+| Ubuntu / Debian | `sudo apt install mpv` (or `paplay` via `pulseaudio-utils`) |
+| WSL2 / WSLg | `sudo apt install pulseaudio-utils` — set `PULSE_SERVER=unix:/mnt/wslg/PulseServer` in `.env` |
 | Windows | [mpv.io/installation](https://mpv.io/installation/) — download and add to PATH, **or** `winget install ffmpeg` |
 
 > If no audio player is available, speech is still generated — it just won't play.


### PR DESCRIPTION
## Summary

- **Adaptive thinking for Anthropic backend** — adds `THINKING_MODE` and `THINKING_EFFORT` env vars; supports `auto` (default), `adaptive`, `extended`, `disabled` modes on Claude Sonnet 4.6 / Opus 4.6
- **TTS fixes** — paplay support (WSL2/PulseAudio), serialized `say()` via `asyncio.Lock` to prevent audio overlap, ffplay false-positive detection
- **Docs** — updated all README files (en/ja/zh/zh-TW/fr/de) with new env vars and paplay/WSL2 instructions

## What's new

### Adaptive thinking (`src/familiar_agent/backend.py`, `config.py`)
- `THINKING_MODE=auto` (default): enables `adaptive` on Sonnet 4.6 / Opus 4.6; disabled on Haiku
- `THINKING_MODE=adaptive`: `thinking: {type: "adaptive"}` — no beta header required (GA feature)
- `THINKING_MODE=extended`: `thinking: {type: "enabled", budget_tokens: N}` with `interleaved-thinking-2025-05-14` beta on Sonnet 4.6
- `THINKING_EFFORT=high|medium|low|max` controls thinking depth via `output_config.effort`
- 34 tests in `tests/test_adaptive_thinking.py`

### TTS fixes (`src/familiar_agent/tools/tts.py`)
- `asyncio.Lock` wraps entire `say()` body — concurrent calls queue instead of overlapping
- `paplay` (PulseAudio native) added as first-priority player; best for WSL2/WSLg when `PULSE_SERVER` is set
- `PULSE_SERVER` / `PULSE_SINK` explicitly propagated to subprocess env
- ffplay exits 0 even on audio failure — now checks stderr for `"audio open failed"` and falls through to next player

## Test plan

- [x] `uv run pytest tests/test_adaptive_thinking.py` — 34 tests pass
- [x] `uv run pytest tests/` — full suite passes
- [x] `THINKING_MODE=adaptive uv run familiar` with Sonnet 4.6 — verify `usage.thinking_input_tokens` is non-zero
- [x] WSL2: `PULSE_SERVER=unix:/mnt/wslg/PulseServer` + `sudo apt install pulseaudio-utils` → paplay works
- [ ] Rapid consecutive `say()` calls → audio plays sequentially, no overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)