### PR TITLE
feat: human-like memory and reactions — context management, image compaction, companion mood

### DIFF
--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -237,8 +237,17 @@ Response:
 
 Write just the sentence. If nothing meaningful is revealed, write "nothing"."""
 
+# Companion mood prompt — classify companion's emotional state from their message
+_COMPANION_MOOD_PROMPT = """\
+Read this message and pick the single best label for the sender's mood:
+engaged / tired / frustrated / absent / happy
 
-def _interoception(started_at: float, turn_count: int) -> str:
+Message: {text}
+
+Reply with the label only (one English word)."""
+
+
+def _interoception(started_at: float, turn_count: int, companion_mood: str = "engaged") -> str:
     """Generate a felt-sense of internal state from objective signals.
 
     Like human interoception — raw signals become a felt quality, not a report.
@@ -280,11 +289,21 @@ def _interoception(started_at: float, turn_count: int) -> str:
     else:
         social_feel = "We've been talking a lot. That feels nice."
 
+    mood_feel_map = {
+        "engaged": "They're here with me.",
+        "tired": "They seem tired tonight.",
+        "frustrated": "Something's bothering them.",
+        "absent": "It's quiet. Not sure if they're really here.",
+        "happy": "They're in a good mood today.",
+    }
+    companion_feel = mood_feel_map.get(companion_mood, "They're here with me.")
+
     return (
         f"(interoception :private true\n"
         f'  (time-of-day :feel "{time_feel}")\n'
         f'  (uptime      :feel "{uptime_feel}")\n'
-        f'  (social      :feel "{social_feel}"))'
+        f'  (social      :feel "{social_feel}")\n'
+        f'  (companion   :feel "{companion_feel}"))'
     )
 
 
@@ -415,6 +434,7 @@ class EmbodiedAgent:
         morning_ctx: str = "",
         inner_voice: str = "",
         plan_ctx: str = "",
+        companion_mood: str = "engaged",
     ) -> tuple[str, str]:
         """Return (stable, variable) system prompt parts for prompt caching.
 
@@ -426,7 +446,7 @@ class EmbodiedAgent:
         stable_parts = [p for p in [self._me_md, base] if p]
         stable = "\n\n---\n\n".join(stable_parts)
 
-        intero = _interoception(self._started_at, self._turn_count)
+        intero = _interoception(self._started_at, self._turn_count, companion_mood)
         variable_parts: list[str] = [intero]
         # Morning reconstruction takes precedence on first turn; otherwise use feelings
         if morning_ctx:
@@ -455,6 +475,17 @@ class EmbodiedAgent:
         label = label.lower()
         valid = {"happy", "sad", "curious", "excited", "moved", "neutral"}
         return label if label in valid else "neutral"
+
+    async def _infer_companion_mood(self, text: str) -> str:
+        """Classify companion's emotional state from their message. Returns mood label."""
+        if not text or len(text.strip()) < 3:
+            return "absent"
+        label = await self.backend.complete(
+            _COMPANION_MOOD_PROMPT.format(text=text[:300]), max_tokens=10
+        )
+        label = label.strip().lower()
+        valid = {"engaged", "tired", "frustrated", "absent", "happy"}
+        return label if label in valid else "engaged"
 
     async def _summarize_exchange(self, user_input: str, agent_response: str) -> str:
         """Distill an exchange into one sentence for memory storage."""
@@ -573,9 +604,10 @@ class EmbodiedAgent:
 
         # Inject relevant past memories + emotional context (skip for desire-driven turns)
         if not is_desire_turn:
-            memories, feelings = await asyncio.gather(
+            memories, feelings, companion_mood = await asyncio.gather(
                 self._memory.recall_async(user_input, n=3),
                 self._memory.recent_feelings_async(n=4),
+                self._infer_companion_mood(user_input),
             )
             memory_parts = []
             if memories:
@@ -591,6 +623,7 @@ class EmbodiedAgent:
             # Desire turn: no user context needed; feelings injected via interoception
             feelings = []
             feelings_ctx = ""
+            companion_mood = "engaged"
             user_input_with_ctx = _t("desire_turn_marker")
 
         self.messages.append(self.backend.make_user_message(user_input_with_ctx))
@@ -614,7 +647,11 @@ class EmbodiedAgent:
 
             result, raw_content = await self.backend.stream_turn(
                 system=self._system_prompt(
-                    feelings_ctx, morning_ctx, inner_voice=inner_voice, plan_ctx=plan_ctx
+                    feelings_ctx,
+                    morning_ctx,
+                    inner_voice=inner_voice,
+                    plan_ctx=plan_ctx,
+                    companion_mood=companion_mood,
                 ),
                 messages=self.messages,
                 tools=self._all_tool_defs,
@@ -660,6 +697,10 @@ class EmbodiedAgent:
                                 "Worry signal detected (%.2f): boosting worry_companion",
                                 worry_boost,
                             )
+                        # Companion mood: frustrated → boost worry_companion (LLM-based check)
+                        if companion_mood == "frustrated":
+                            desires.boost("worry_companion", 0.3)
+                            logger.debug("Companion mood frustrated: boosting worry_companion")
 
                 # Extract curiosity target only when camera was actually used
                 if desires is not None and final_text and camera_used:

--- a/src/familiar_agent/backend.py
+++ b/src/familiar_agent/backend.py
@@ -220,6 +220,45 @@ class AnthropicBackend:
         return flat
 
     @staticmethod
+    def compact_images(messages: list[dict], keep_last: int = 3) -> list[dict]:
+        """Strip base64 image data from old tool results, keeping the last `keep_last`.
+
+        Human-like forgetting: the text description of what was seen is preserved;
+        only the raw pixel data (base64) is dropped from older turns.
+
+        Inspired by Claude Code's Dk() microcompact (KEEP_LAST=3).
+        """
+        import copy
+
+        # Collect (msg_idx, tool_result_idx, sub_idx) for every image sub-item
+        positions: list[tuple[int, int, int]] = []
+        for i, msg in enumerate(messages):
+            if not isinstance(msg, dict) or msg.get("role") != "user":
+                continue
+            content = msg.get("content", [])
+            if not isinstance(content, list):
+                continue
+            for j, item in enumerate(content):
+                if not isinstance(item, dict) or item.get("type") != "tool_result":
+                    continue
+                for k, sub in enumerate(item.get("content", [])):
+                    if isinstance(sub, dict) and sub.get("type") == "image":
+                        positions.append((i, j, k))
+
+        n_clear = max(0, len(positions) - keep_last)
+        to_clear = positions[:n_clear]
+        if not to_clear:
+            return messages
+
+        messages = copy.deepcopy(messages)
+        for msg_i, item_j, sub_k in to_clear:
+            messages[msg_i]["content"][item_j]["content"][sub_k] = {
+                "type": "text",
+                "text": "[image cleared]",
+            }
+        return messages
+
+    @staticmethod
     def _build_system_param(system: str | tuple[str, str]) -> str | list[dict]:
         """Convert system prompt to Anthropic API format, adding cache_control when possible.
 
@@ -268,8 +307,17 @@ class AnthropicBackend:
             stream_kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
         if "thinking" in thinking_params:
             stream_kwargs["thinking"] = thinking_params["thinking"]
+            # When thinking is enabled, ask the server to strip old ThinkingBlocks from the
+            # message history — keeps context clean in long sessions.
+            # Source: Claude Code RE (context_management / tengu_marble_anvil pattern).
+            stream_kwargs["context_management"] = {
+                "edits": [{"type": "clear_thinking_20251015", "keep": "all"}]
+            }
         if "output_config" in thinking_params:
             stream_kwargs["output_config"] = thinking_params["output_config"]
+        flat_messages = self._flatten_messages(messages)
+        flat_messages = self.compact_images(flat_messages)
+        stream_kwargs["messages"] = cast(list[MessageParam], flat_messages)
         async with self.client.messages.stream(**stream_kwargs) as stream:  # type: ignore[arg-type]
             async for chunk in stream.text_stream:
                 if on_text:

--- a/tests/test_companion_mood.py
+++ b/tests/test_companion_mood.py
@@ -1,0 +1,266 @@
+"""Tests for companion mood classifier and interoception companion field.
+
+Feature: _infer_companion_mood() classifies the companion's emotional state
+from their message text, and injects it into _interoception() as a felt quality.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ── Tests for _interoception() companion field ────────────────────────────────
+
+
+class TestInteroceptionCompanionField:
+    """_interoception() includes a companion field when mood is provided."""
+
+    def _call_interoception(self, companion_mood: str) -> str:
+        from familiar_agent.agent import _interoception
+
+        return _interoception(started_at=time.time(), turn_count=1, companion_mood=companion_mood)
+
+    def test_contains_companion_field(self):
+        result = self._call_interoception("engaged")
+        assert "companion" in result
+
+    def test_engaged_mood(self):
+        result = self._call_interoception("engaged")
+        assert (
+            "here with me" in result.lower()
+            or "engaged" in result.lower()
+            or "here" in result.lower()
+        )
+
+    def test_tired_mood(self):
+        result = self._call_interoception("tired")
+        assert "tired" in result.lower()
+
+    def test_frustrated_mood(self):
+        result = self._call_interoception("frustrated")
+        assert "frustrated" in result.lower() or "bothering" in result.lower()
+
+    def test_absent_mood(self):
+        result = self._call_interoception("absent")
+        assert "quiet" in result.lower() or "absent" in result.lower() or "here" in result.lower()
+
+    def test_happy_mood(self):
+        result = self._call_interoception("happy")
+        assert "happy" in result.lower() or "good mood" in result.lower()
+
+    def test_default_mood_engaged(self):
+        """No companion_mood argument → defaults to engaged."""
+        from familiar_agent.agent import _interoception
+
+        result = _interoception(started_at=time.time(), turn_count=1)
+        assert "companion" in result
+
+    def test_result_is_sexpr_format(self):
+        """Result is in S-expression format used by the rest of interoception."""
+        result = self._call_interoception("happy")
+        assert result.startswith("(interoception")
+        assert ":private true" in result
+        assert "(companion" in result
+
+
+# ── Tests for _infer_companion_mood() ────────────────────────────────────────
+
+
+class TestInferCompanionMood:
+    """_infer_companion_mood() returns a valid mood label from LLM backend."""
+
+    def _make_agent_with_mock_backend(self, complete_return: str):
+        """Create an EmbodiedAgent with a mock backend that returns complete_return."""
+        from familiar_agent.agent import EmbodiedAgent
+        from familiar_agent.config import AgentConfig
+
+        config = AgentConfig.__new__(AgentConfig)
+        config.camera = MagicMock()
+        config.camera.host = None
+        config.mobility = MagicMock()
+        config.mobility.api_key = None
+        config.tts = MagicMock()
+        config.tts.elevenlabs_api_key = None
+        config.stt = MagicMock()
+        config.stt.elevenlabs_api_key = None
+        config.coding = MagicMock()
+        config.coding.enabled = False
+        config.max_tokens = 1024
+        config.companion_name = "Kouta"
+
+        agent = EmbodiedAgent.__new__(EmbodiedAgent)
+        agent.config = config
+        agent.messages = []
+        agent._started_at = time.time()
+        agent._turn_count = 0
+        agent._me_md = ""
+        agent._camera = None
+        agent._mobility = None
+        agent._tts = None
+        agent._stt = None
+        agent._mcp = None
+
+        from familiar_agent.tools.memory import ObservationMemory, MemoryTool
+        from familiar_agent.tools.tom import ToMTool
+        from familiar_agent.tools.coding import CodingTool
+
+        agent._memory = MagicMock(spec=ObservationMemory)
+        agent._memory_tool = MagicMock(spec=MemoryTool)
+        agent._tom_tool = MagicMock(spec=ToMTool)
+        agent._coding = MagicMock(spec=CodingTool)
+
+        mock_backend = MagicMock()
+        mock_backend.complete = AsyncMock(return_value=complete_return)
+        agent.backend = mock_backend
+
+        return agent
+
+    @pytest.mark.asyncio
+    async def test_returns_engaged(self):
+        agent = self._make_agent_with_mock_backend("engaged")
+        result = await agent._infer_companion_mood("Let's work on this together!")
+        assert result == "engaged"
+
+    @pytest.mark.asyncio
+    async def test_returns_tired(self):
+        agent = self._make_agent_with_mock_backend("tired")
+        result = await agent._infer_companion_mood("I'm so tired today...")
+        assert result == "tired"
+
+    @pytest.mark.asyncio
+    async def test_returns_frustrated(self):
+        agent = self._make_agent_with_mock_backend("frustrated")
+        result = await agent._infer_companion_mood("This isn't working at all!")
+        assert result == "frustrated"
+
+    @pytest.mark.asyncio
+    async def test_returns_absent(self):
+        agent = self._make_agent_with_mock_backend("absent")
+        result = await agent._infer_companion_mood("...")
+        assert result == "absent"
+
+    @pytest.mark.asyncio
+    async def test_returns_happy(self):
+        agent = self._make_agent_with_mock_backend("happy")
+        result = await agent._infer_companion_mood("That worked perfectly!")
+        assert result == "happy"
+
+    @pytest.mark.asyncio
+    async def test_empty_string_returns_absent(self):
+        """Empty input → absent without calling backend."""
+        agent = self._make_agent_with_mock_backend("happy")
+        result = await agent._infer_companion_mood("")
+        assert result == "absent"
+        agent.backend.complete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_returns_absent(self):
+        agent = self._make_agent_with_mock_backend("happy")
+        result = await agent._infer_companion_mood("   ")
+        assert result == "absent"
+        agent.backend.complete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_very_short_returns_absent(self):
+        """Messages shorter than 3 chars → absent."""
+        agent = self._make_agent_with_mock_backend("happy")
+        result = await agent._infer_companion_mood("ok")
+        assert result == "absent"
+
+    @pytest.mark.asyncio
+    async def test_invalid_backend_response_falls_back_to_engaged(self):
+        """If backend returns garbage, fall back to 'engaged'."""
+        agent = self._make_agent_with_mock_backend("UNKNOWN_LABEL_XYZ")
+        result = await agent._infer_companion_mood("Hello there friend!")
+        assert result == "engaged"
+
+    @pytest.mark.asyncio
+    async def test_label_stripped_and_lowercased(self):
+        """Backend returning '  Tired  ' (with spaces/caps) is normalised."""
+        agent = self._make_agent_with_mock_backend("  Tired  ")
+        result = await agent._infer_companion_mood("I'm exhausted")
+        assert result == "tired"
+
+
+# ── Tests for frustrated → desire boost ──────────────────────────────────────
+
+
+class TestFrustratedBoostsDesire:
+    """When companion_mood is frustrated, worry_companion desire is boosted."""
+
+    @pytest.mark.asyncio
+    async def test_frustrated_boosts_worry_companion(self):
+        """frustrated mood → desires.boost('worry_companion') called."""
+        from familiar_agent.desires import DesireSystem
+        from familiar_agent.agent import EmbodiedAgent
+
+        # Lightweight agent setup
+        agent = EmbodiedAgent.__new__(EmbodiedAgent)
+        agent._memory = MagicMock()
+        agent._memory.recall_async = AsyncMock(return_value=[])
+        agent._memory.recent_feelings_async = AsyncMock(return_value=[])
+        agent._memory.recall_self_model_async = AsyncMock(return_value=[])
+        agent._memory.recall_curiosities_async = AsyncMock(return_value=[])
+        agent._memory.save_async = AsyncMock(return_value=True)
+        agent._memory.format_for_context = MagicMock(return_value="")
+        agent._memory.format_feelings_for_context = MagicMock(return_value="")
+        agent._memory.format_self_model_for_context = MagicMock(return_value="")
+        agent._memory.format_curiosities_for_context = MagicMock(return_value="")
+
+        mock_backend = MagicMock()
+        # complete() for _infer_companion_mood → "frustrated"
+        mock_backend.complete = AsyncMock(return_value="frustrated")
+
+        from familiar_agent.backend import TurnResult
+
+        mock_backend.stream_turn = AsyncMock(
+            return_value=(TurnResult(stop_reason="end_turn", text="ok", tool_calls=[]), [])
+        )
+        mock_backend.make_user_message = MagicMock(
+            side_effect=lambda x: {"role": "user", "content": x}
+        )
+        mock_backend.make_assistant_message = MagicMock(
+            return_value={"role": "assistant", "content": []}
+        )
+
+        agent.backend = mock_backend
+        agent.config = MagicMock()
+        agent.config.max_tokens = 512
+        agent.config.companion_name = "Kouta"
+        agent.messages = []
+        agent._started_at = time.time()
+        agent._turn_count = 0
+        agent._me_md = ""
+        agent._camera = None
+        agent._mobility = None
+        agent._tts = None
+        agent._stt = None
+        agent._mcp = None
+
+        from familiar_agent.tools.memory import MemoryTool
+        from familiar_agent.tools.tom import ToMTool
+        from familiar_agent.tools.coding import CodingTool
+
+        agent._memory_tool = MagicMock(spec=MemoryTool)
+        agent._memory_tool.get_tool_definitions = MagicMock(return_value=[])
+        agent._tom_tool = MagicMock(spec=ToMTool)
+        agent._tom_tool.get_tool_definitions = MagicMock(return_value=[])
+        agent._coding = MagicMock(spec=CodingTool)
+        agent._coding.get_tool_definitions = MagicMock(return_value=[])
+
+        desires = MagicMock(spec=DesireSystem)
+        desires.curiosity_target = None
+
+        await agent.run(
+            user_input="This is absolutely broken and I'm really frustrated!",
+            desires=desires,
+        )
+
+        # desires.boost should have been called with worry_companion
+        boost_calls = [
+            call for call in desires.boost.call_args_list if call.args[0] == "worry_companion"
+        ]
+        assert len(boost_calls) >= 1, "worry_companion desire should be boosted when frustrated"

--- a/tests/test_context_management.py
+++ b/tests/test_context_management.py
@@ -1,0 +1,191 @@
+"""Tests for context_management / thinking token cleanup in AnthropicBackend.
+
+Feature: When thinking is enabled, stream_turn adds context_management to the API request
+so the server removes old ThinkingBlocks from the message history (like CC's tengu_marble_anvil).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_backend(thinking_mode: str = "adaptive", model: str = "claude-sonnet-4-6"):
+    from familiar_agent.backend import AnthropicBackend
+
+    with patch("anthropic.AsyncAnthropic"):
+        b = AnthropicBackend.__new__(AnthropicBackend)
+        b.client = MagicMock()
+        b.model = model
+        b.thinking_mode = thinking_mode
+        b.thinking_budget = 10000
+        b.thinking_effort = "high"
+        return b
+
+
+def _make_stream_response(stop_reason: str = "end_turn"):
+    """Return a mock that mimics the anthropic streaming context manager."""
+    block = MagicMock()
+    block.type = "text"
+    block.text = "hello"
+
+    final_message = MagicMock()
+    final_message.stop_reason = stop_reason
+    final_message.content = [block]
+
+    stream_cm = MagicMock()
+    stream_cm.__aenter__ = AsyncMock(return_value=stream_cm)
+    stream_cm.__aexit__ = AsyncMock(return_value=False)
+    stream_cm.text_stream = _async_iter(["hello"])
+    stream_cm.get_final_message = AsyncMock(return_value=final_message)
+    return stream_cm
+
+
+async def _async_iter(items):
+    for item in items:
+        yield item
+
+
+# ── Feature 1: context_management ────────────────────────────────────────────
+
+
+class TestContextManagementAdded:
+    """context_management is added to API call when thinking is enabled."""
+
+    @pytest.mark.asyncio
+    async def test_adaptive_mode_adds_context_management(self):
+        """adaptive thinking → context_management added."""
+        backend = _make_backend(thinking_mode="adaptive")
+        captured: dict = {}
+
+        def capture_kwargs(**kwargs):
+            captured.update(kwargs)
+            return _make_stream_response()
+
+        backend.client.messages.stream = MagicMock(side_effect=capture_kwargs)
+
+        await backend.stream_turn(
+            system="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            max_tokens=1024,
+            on_text=None,
+        )
+
+        assert "context_management" in captured
+        assert captured["context_management"] == {
+            "edits": [{"type": "clear_thinking_20251015", "keep": "all"}]
+        }
+
+    @pytest.mark.asyncio
+    async def test_extended_mode_adds_context_management(self):
+        """extended thinking → context_management added."""
+        backend = _make_backend(thinking_mode="extended")
+        captured: dict = {}
+
+        def capture_kwargs(**kwargs):
+            captured.update(kwargs)
+            return _make_stream_response()
+
+        backend.client.messages.stream = MagicMock(side_effect=capture_kwargs)
+
+        await backend.stream_turn(
+            system="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            max_tokens=16000,
+            on_text=None,
+        )
+
+        assert "context_management" in captured
+        assert captured["context_management"]["edits"][0]["type"] == "clear_thinking_20251015"
+
+    @pytest.mark.asyncio
+    async def test_disabled_mode_no_context_management(self):
+        """thinking disabled → context_management NOT added."""
+        backend = _make_backend(thinking_mode="disabled")
+        captured: dict = {}
+
+        def capture_kwargs(**kwargs):
+            captured.update(kwargs)
+            return _make_stream_response()
+
+        backend.client.messages.stream = MagicMock(side_effect=capture_kwargs)
+
+        await backend.stream_turn(
+            system="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            max_tokens=1024,
+            on_text=None,
+        )
+
+        assert "context_management" not in captured
+
+    @pytest.mark.asyncio
+    async def test_auto_mode_sonnet4_adds_context_management(self):
+        """auto + sonnet-4 → adaptive → context_management added."""
+        backend = _make_backend(thinking_mode="auto", model="claude-sonnet-4-6")
+        captured: dict = {}
+
+        def capture_kwargs(**kwargs):
+            captured.update(kwargs)
+            return _make_stream_response()
+
+        backend.client.messages.stream = MagicMock(side_effect=capture_kwargs)
+
+        await backend.stream_turn(
+            system="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            max_tokens=1024,
+            on_text=None,
+        )
+
+        assert "context_management" in captured
+
+    @pytest.mark.asyncio
+    async def test_auto_mode_haiku_no_context_management(self):
+        """auto + haiku → disabled → context_management NOT added."""
+        backend = _make_backend(thinking_mode="auto", model="claude-haiku-4-5-20251001")
+        captured: dict = {}
+
+        def capture_kwargs(**kwargs):
+            captured.update(kwargs)
+            return _make_stream_response()
+
+        backend.client.messages.stream = MagicMock(side_effect=capture_kwargs)
+
+        await backend.stream_turn(
+            system="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            max_tokens=1024,
+            on_text=None,
+        )
+
+        assert "context_management" not in captured
+
+    @pytest.mark.asyncio
+    async def test_context_management_edit_keep_all(self):
+        """The edit has keep='all' (preserve latest thinking per turn)."""
+        backend = _make_backend(thinking_mode="adaptive")
+        captured: dict = {}
+
+        def capture_kwargs(**kwargs):
+            captured.update(kwargs)
+            return _make_stream_response()
+
+        backend.client.messages.stream = MagicMock(side_effect=capture_kwargs)
+
+        await backend.stream_turn(
+            system="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            max_tokens=1024,
+            on_text=None,
+        )
+
+        edit = captured["context_management"]["edits"][0]
+        assert edit["keep"] == "all"

--- a/tests/test_image_compact.py
+++ b/tests/test_image_compact.py
@@ -1,0 +1,296 @@
+"""Tests for image microcompact in AnthropicBackend.
+
+Feature: compact_images() strips base64 image data from old tool results,
+keeping only the last `keep_last` images (human-like forgetting).
+
+Inspired by Claude Code's Dk() microcompact function:
+  KEEP_LAST=3, images replaced with [image cleared]
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from familiar_agent.backend import AnthropicBackend
+
+
+def _tool_result_msg(tool_use_id: str, text: str, image_b64: str | None = None) -> dict:
+    """Build a flattened tool-result user message like make_tool_results() produces."""
+    content_items: list[dict] = [{"type": "text", "text": text}]
+    if image_b64:
+        content_items.append(
+            {
+                "type": "image",
+                "source": {"type": "base64", "media_type": "image/jpeg", "data": image_b64},
+            }
+        )
+    return {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": tool_use_id,
+                "content": content_items,
+            }
+        ],
+    }
+
+
+def _user_msg(text: str) -> dict:
+    return {"role": "user", "content": text}
+
+
+def _assistant_msg(text: str) -> dict:
+    return {"role": "assistant", "content": [{"type": "text", "text": text}]}
+
+
+# ── Unit tests for compact_images() ──────────────────────────────────────────
+
+
+class TestCompactImagesNoImages:
+    def test_no_images_returns_same_messages(self):
+        """Messages without images are returned unchanged."""
+        messages = [_user_msg("hi"), _assistant_msg("hello")]
+        result = AnthropicBackend.compact_images(messages, keep_last=3)
+        assert result == messages
+
+    def test_text_only_tool_results_unchanged(self):
+        """Tool results with only text (no image) are not modified."""
+        messages = [_tool_result_msg("tc1", "I looked around")]
+        result = AnthropicBackend.compact_images(messages, keep_last=3)
+        assert result == messages
+
+
+class TestCompactImagesBelowThreshold:
+    def test_fewer_images_than_keep_last_unchanged(self):
+        """2 images with keep_last=3 → nothing cleared."""
+        messages = [
+            _tool_result_msg("tc1", "saw a cat", "BASE64_IMG_1"),
+            _tool_result_msg("tc2", "saw a dog", "BASE64_IMG_2"),
+        ]
+        result = AnthropicBackend.compact_images(messages, keep_last=3)
+        # Images preserved
+        assert result[0]["content"][0]["content"][1]["type"] == "image"
+        assert result[1]["content"][0]["content"][1]["type"] == "image"
+
+    def test_exactly_keep_last_images_unchanged(self):
+        """Exactly 3 images with keep_last=3 → nothing cleared."""
+        messages = [
+            _tool_result_msg("tc1", "saw a cat", "IMG1"),
+            _tool_result_msg("tc2", "saw a dog", "IMG2"),
+            _tool_result_msg("tc3", "saw a bird", "IMG3"),
+        ]
+        result = AnthropicBackend.compact_images(messages, keep_last=3)
+        for i, msg in enumerate(result):
+            img_items = [
+                s
+                for s in msg["content"][0]["content"]
+                if isinstance(s, dict) and s.get("type") == "image"
+            ]
+            assert len(img_items) == 1, f"Image at index {i} should be preserved"
+
+
+class TestCompactImagesClearsOld:
+    def test_one_extra_image_clears_oldest(self):
+        """4 images, keep_last=3 → oldest 1 cleared."""
+        messages = [
+            _tool_result_msg("tc1", "saw a cat", "OLD_IMG"),
+            _tool_result_msg("tc2", "saw a dog", "IMG2"),
+            _tool_result_msg("tc3", "saw a bird", "IMG3"),
+            _tool_result_msg("tc4", "saw a fish", "IMG4"),
+        ]
+        result = AnthropicBackend.compact_images(messages, keep_last=3)
+
+        # First message: image should be cleared
+        cleared_content = result[0]["content"][0]["content"]
+        assert not any(s.get("type") == "image" for s in cleared_content if isinstance(s, dict))
+        cleared_texts = [s["text"] for s in cleared_content if s.get("type") == "text"]
+        assert "[image cleared]" in cleared_texts
+
+        # Last 3 messages: images preserved
+        for msg in result[1:]:
+            img_items = [
+                s
+                for s in msg["content"][0]["content"]
+                if isinstance(s, dict) and s.get("type") == "image"
+            ]
+            assert len(img_items) == 1
+
+    def test_two_extra_images_clears_two_oldest(self):
+        """5 images, keep_last=3 → oldest 2 cleared."""
+        messages = [
+            _tool_result_msg("tc1", "old1", "OLD1"),
+            _tool_result_msg("tc2", "old2", "OLD2"),
+            _tool_result_msg("tc3", "keep1", "KEEP1"),
+            _tool_result_msg("tc4", "keep2", "KEEP2"),
+            _tool_result_msg("tc5", "keep3", "KEEP3"),
+        ]
+        result = AnthropicBackend.compact_images(messages, keep_last=3)
+
+        # First 2: cleared
+        for msg in result[:2]:
+            content = msg["content"][0]["content"]
+            assert not any(s.get("type") == "image" for s in content if isinstance(s, dict))
+            texts = [s["text"] for s in content if isinstance(s, dict) and s.get("type") == "text"]
+            assert "[image cleared]" in texts
+
+        # Last 3: preserved
+        for msg in result[2:]:
+            content = msg["content"][0]["content"]
+            img_items = [s for s in content if isinstance(s, dict) and s.get("type") == "image"]
+            assert len(img_items) == 1
+
+    def test_text_description_preserved_after_clear(self):
+        """Text description in the tool result is preserved when image is cleared."""
+        messages = [
+            _tool_result_msg("tc1", "I saw a sleeping cat on the couch", "IMG_DATA"),
+            _tool_result_msg("tc2", "img2", "IMG2"),
+            _tool_result_msg("tc3", "img3", "IMG3"),
+            _tool_result_msg("tc4", "img4", "IMG4"),
+        ]
+        result = AnthropicBackend.compact_images(messages, keep_last=3)
+
+        # The text describing the image should still be there
+        content = result[0]["content"][0]["content"]
+        texts = [s["text"] for s in content if isinstance(s, dict) and s.get("type") == "text"]
+        assert "I saw a sleeping cat on the couch" in texts
+
+
+class TestCompactImagesImmutability:
+    def test_original_messages_not_mutated(self):
+        """compact_images() does a deep copy — original messages unchanged."""
+        messages = [
+            _tool_result_msg("tc1", "img1", "IMG_DATA_1"),
+            _tool_result_msg("tc2", "img2", "IMG_DATA_2"),
+            _tool_result_msg("tc3", "img3", "IMG_DATA_3"),
+            _tool_result_msg("tc4", "img4", "IMG_DATA_4"),
+        ]
+        original = copy.deepcopy(messages)
+        AnthropicBackend.compact_images(messages, keep_last=3)
+        assert messages == original
+
+    def test_returns_new_list(self):
+        """compact_images() returns a new list object."""
+        messages = [
+            _tool_result_msg("tc1", "img1", "IMG1"),
+            _tool_result_msg("tc2", "img2", "IMG2"),
+            _tool_result_msg("tc3", "img3", "IMG3"),
+            _tool_result_msg("tc4", "img4", "IMG4"),
+        ]
+        result = AnthropicBackend.compact_images(messages, keep_last=3)
+        assert result is not messages
+
+
+class TestCompactImagesEdgeCases:
+    def test_keep_last_zero_clears_all(self):
+        """keep_last=0 → all images cleared."""
+        messages = [
+            _tool_result_msg("tc1", "img1", "IMG1"),
+            _tool_result_msg("tc2", "img2", "IMG2"),
+        ]
+        result = AnthropicBackend.compact_images(messages, keep_last=0)
+        for msg in result:
+            content = msg["content"][0]["content"]
+            assert not any(s.get("type") == "image" for s in content if isinstance(s, dict))
+
+    def test_mixed_with_without_images(self):
+        """Messages mix tool results with and without images."""
+        messages = [
+            _tool_result_msg("tc1", "text only"),  # no image
+            _tool_result_msg("tc2", "saw a cat", "IMG1"),
+            _tool_result_msg("tc3", "text only 2"),  # no image
+            _tool_result_msg("tc4", "saw a dog", "IMG2"),
+            _tool_result_msg("tc5", "saw a fish", "IMG3"),
+            _tool_result_msg("tc6", "saw a bird", "IMG4"),
+        ]
+        result = AnthropicBackend.compact_images(messages, keep_last=3)
+
+        # Only tc2 (index 1) should have its image cleared
+        def has_image(msg):
+            content = msg["content"][0]["content"]
+            return any(isinstance(s, dict) and s.get("type") == "image" for s in content)
+
+        assert not has_image(result[1])  # tc2 cleared
+        assert has_image(result[3])  # tc4 kept
+        assert has_image(result[4])  # tc5 kept
+        assert has_image(result[5])  # tc6 kept
+
+    def test_non_tool_result_messages_ignored(self):
+        """Non-tool-result messages (user text, assistant) are not touched."""
+        messages = [
+            _user_msg("hello"),
+            _assistant_msg("hi there"),
+            _tool_result_msg("tc1", "saw a cat", "IMG1"),
+            _tool_result_msg("tc2", "saw a dog", "IMG2"),
+            _tool_result_msg("tc3", "saw a bird", "IMG3"),
+            _tool_result_msg("tc4", "saw a fish", "IMG4"),
+        ]
+        result = AnthropicBackend.compact_images(messages, keep_last=3)
+        # User and assistant messages unchanged
+        assert result[0] == _user_msg("hello")
+        assert result[1] == _assistant_msg("hi there")
+
+
+class TestCompactImagesAppliedInStreamTurn:
+    """compact_images() is actually called inside stream_turn()."""
+
+    @pytest.mark.asyncio
+    async def test_stream_turn_compacts_old_images(self):
+        """stream_turn passes compacted messages (old images removed) to the API."""
+        from unittest.mock import AsyncMock, MagicMock
+        from unittest.mock import patch
+
+        from familiar_agent.backend import AnthropicBackend
+
+        with patch("anthropic.AsyncAnthropic"):
+            backend = AnthropicBackend.__new__(AnthropicBackend)
+            backend.client = MagicMock()
+            backend.model = "claude-haiku-4-5-20251001"  # simple: no thinking
+            backend.thinking_mode = "disabled"
+            backend.thinking_budget = 10000
+            backend.thinking_effort = "high"
+
+        block = MagicMock()
+        block.type = "text"
+        block.text = "done"
+        final_message = MagicMock()
+        final_message.stop_reason = "end_turn"
+        final_message.content = [block]
+
+        stream_cm = MagicMock()
+        stream_cm.__aenter__ = AsyncMock(return_value=stream_cm)
+        stream_cm.__aexit__ = AsyncMock(return_value=False)
+
+        async def _text_stream():
+            yield "done"
+
+        stream_cm.text_stream = _text_stream()
+        stream_cm.get_final_message = AsyncMock(return_value=final_message)
+
+        captured_messages: list = []
+
+        def capture(**kwargs):
+            captured_messages.extend(kwargs.get("messages", []))
+            return stream_cm
+
+        backend.client.messages.stream = MagicMock(side_effect=capture)
+
+        # Build messages with 4 tool results containing images (keep_last=3 → first cleared)
+        tool_msgs = []
+        for i in range(4):
+            tool_msgs.append(_tool_result_msg(f"tc{i}", f"image {i}", f"BASE64_{i}"))
+
+        await backend.stream_turn(
+            system="sys",
+            messages=tool_msgs,
+            tools=[],
+            max_tokens=512,
+            on_text=None,
+        )
+
+        # The first tool result should have had its image cleared
+        first_msg = captured_messages[0]
+        content = first_msg["content"][0]["content"]
+        assert not any(isinstance(s, dict) and s.get("type") == "image" for s in content)


### PR DESCRIPTION
## Summary

Three features that make familiar-ai feel more human-like in how it remembers and responds:

- **Context management** — Strips old thinking tokens from message history server-side when extended thinking is enabled, preventing token accumulation across long sessions.

- **Image compaction** — `AnthropicBackend.compact_images()` strips raw pixel data from old camera tool results, keeping the last 3 images. Text descriptions are preserved ("I saw a cat" stays, the pixels go). Applied automatically on every API call.

- **Companion mood classifier** — `_infer_companion_mood()` classifies the companion's emotional state (`engaged / tired / frustrated / absent / happy`) from their message using a lightweight LLM call. Result is injected into `_interoception()` as a `companion` felt-quality. Runs in parallel with memory recall. When frustrated, `worry_companion` desire is also boosted.

## Test plan

- [x] 38 new tests added (TDD: tests written first, then implementation)
- [x] 212 total tests pass
- [x] ruff + mypy pre-commit hooks pass
- [x] All 3 features unit-tested in isolation with mock backends
- [x] Integration test: `stream_turn` applies `compact_images` before API call
- [x] Integration test: `frustrated` companion mood → `desires.boost("worry_companion")` called

🤖 Generated with [Claude Code](https://claude.com/claude-code)