### PR TITLE
fix: remove context_management from API request

### DIFF
--- a/src/familiar_agent/backend.py
+++ b/src/familiar_agent/backend.py
@@ -309,14 +309,6 @@ class AnthropicBackend:
             stream_kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
         if "thinking" in thinking_params:
             stream_kwargs["thinking"] = thinking_params["thinking"]
-            # When thinking is enabled, ask the server to strip old ThinkingBlocks from the
-            # message history — keeps context clean in long sessions.
-            # Source: Claude Code RE (context_management / tengu_marble_anvil pattern).
-            stream_kwargs["extra_body"] = {
-                "context_management": {
-                    "edits": [{"type": "clear_thinking_20251015", "keep": "all"}]
-                }
-            }
         if "output_config" in thinking_params:
             stream_kwargs["output_config"] = thinking_params["output_config"]
         flat_messages = self._flatten_messages(messages)


### PR DESCRIPTION
## Summary
- `context_management` field is not yet publicly available in the Anthropic API
- Sending it (even via `extra_body`) causes `400 - Extra inputs are not permitted`
- Removed the feature; update tests to reflect actual behaviour

## Root cause
Found via CC reverse engineering (`tengu_marble_anvil` pattern), but the API endpoint does not accept it for external callers yet.

## Test plan
- [ ] `uv run pytest tests/` — all 275 pass
- [ ] Run TUI and confirm no 400 error on first message

🤖 Generated with [Claude Code](https://claude.com/claude-code)