### PR TITLE
fix(tts): switch to eleven_v3 for audio tag support

### DIFF
--- a/src/familiar_agent/tools/tts.py
+++ b/src/familiar_agent/tools/tts.py
@@ -97,7 +97,7 @@ class TTSTool:
         headers = {"xi-api-key": self.api_key, "Content-Type": "application/json"}
         payload = {
             "text": text,
-            "model_id": "eleven_flash_v2_5",
+            "model_id": "eleven_v3",
             "voice_settings": {"stability": 0.5, "similarity_boost": 0.75},
         }
 


### PR DESCRIPTION
## Summary
- `eleven_flash_v2_5` reads audio tags like `[gently]` as literal text
- `eleven_v3` interprets them as voice expression modifiers
- One-line change: `eleven_flash_v2_5` → `eleven_v3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)