### PR TITLE
fix(tui): ESC cancel works on repeated presses

### DIFF
--- a/src/familiar_agent/tui.py
+++ b/src/familiar_agent/tui.py
@@ -522,6 +522,10 @@ class FamiliarApp(App):
         if not self._agent_running:
             return
         self._cancel_event.set()
+        # Directly cancel the task on every ESC press — the watcher only fires once,
+        # so repeated ESC presses must hit the task directly.
+        if self._agent_task and not self._agent_task.done():
+            self._agent_task.cancel()
         self._log_system(f"[dim]{INTERRUPT_MSG}[/dim]")
 
     def action_start_ptt(self) -> None:


### PR DESCRIPTION
## Summary
- `_cancel_watcher` only fires once after the first ESC, so subsequent ESC presses had no effect
- Fix: call `_agent_task.cancel()` directly in `action_cancel_turn` on every press
- `_cancel_event.set()` is kept so the agent's own cancellation path also triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)