### PR TITLE
fix(glm): default to glm-4.6v-flash (vision-enabled)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,7 +120,7 @@ ELEVENLABS_VOICE_ID=cgSgspJ2msm6clMCkdW9
 # Z.AI GLM (https://api.z.ai)
 #   PLATFORM=glm
 #   API_KEY=<your-key>            # get at https://bigmodel.cn/
-#   MODEL=glm-4.6v-flash          # default (vision); glm-4.7/glm-4.5 = text-only
+#   MODEL=glm-4.6v                # default (vision); glm-4.7/glm-4.5/glm-5 = text-only
 #
 # Moonshot AI Kimi (https://platform.moonshot.ai)
 #   PLATFORM=kimi

--- a/src/familiar_agent/backend.py
+++ b/src/familiar_agent/backend.py
@@ -830,7 +830,7 @@ class GLMBackend:
 
         PLATFORM=glm
         API_KEY=<your-key>              # from bigmodel.cn / api.z.ai
-        MODEL=glm-4.6v-flash            # default (vision-enabled)
+        MODEL=glm-4.6v                  # default (vision-enabled)
     """
 
     _BASE_URL = "https://api.z.ai/api/paas/v4"
@@ -1340,7 +1340,7 @@ def create_backend(
         return KimiBackend(api_key=config.api_key, model=model)
     if config.platform == "glm":
         # Z.AI GLM — OpenAI-compatible, native tool calling
-        model = config.model or "glm-4.6v-flash"
+        model = config.model or "glm-4.6v"
         logger.info("Using GLM backend: %s", model)
         return GLMBackend(api_key=config.api_key, model=model)
     if config.platform == "cli":


### PR DESCRIPTION
glm-4.7 is text-only and returns error 1210 when images are passed. Default to glm-4.6v-flash which supports vision inputs.