### PR TITLE
feat: add realtime STT via ElevenLabs Scribe v2 WebSocket 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,14 @@ ELEVENLABS_API_KEY=your-elevenlabs-key
 ELEVENLABS_VOICE_ID=cgSgspJ2msm6clMCkdW9
 
 # ──────────────────────────────────────────
+# Realtime STT (optional)
+# Always-on, hands-free voice input using ElevenLabs Scribe v2 Realtime.
+# Streams microphone audio over WebSocket; VAD auto-commits transcripts.
+# Requires ELEVENLABS_API_KEY above.
+# ──────────────────────────────────────────
+REALTIME_STT=false
+
+# ──────────────────────────────────────────
 # ElevenLabs STT — voice input (optional)
 # Reuses ELEVENLABS_API_KEY above — no extra key needed.
 # Press Ctrl+M in the TUI to start/stop recording.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
 ### Added
+- Realtime STT via ElevenLabs Scribe v2 Realtime WebSocket API
+  - Always-on, hands-free voice input with VAD auto-commit
+  - Works in both REPL (`--no-tui`) and TUI modes
+  - Filler word filtering and deduplication
+  - Opt-in via `REALTIME_STT=true` in `.env`
+  - Coexists with existing batch STT (Ctrl+T / Space PTT)
 - Support for full RTSP URLs in `CAMERA_HOST` (enables ATOMCam and other non-standard RTSP paths)
 
 ## [0.1.0] - 2026-02-22

--- a/src/familiar_agent/realtime_stt_session.py
+++ b/src/familiar_agent/realtime_stt_session.py
@@ -1,0 +1,159 @@
+"""Realtime STT session manager — shared between REPL and TUI.
+
+Manages the lifecycle of microphone capture → ElevenLabs Realtime STT →
+asyncio.Queue, with filler filtering and deduplication.
+
+Usage (both modes)::
+
+    session = create_realtime_stt_session()
+    if session:
+        session.on_partial = lambda t: ...   # display hook
+        session.on_committed = lambda t: ...  # display hook
+        await session.start(loop, input_queue)
+        ...
+        await session.stop()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+# ── Filler / short-utterance filter ──────────────────────────────────
+_FILLER_WORDS = frozenset("えー ええと えっと あの その うーん んー ま はい うん ん".split())
+
+
+def _is_only_punct_or_symbol(s: str) -> bool:
+    return all(c in "。、！？…・「」『』（）()!?,." or not c.isalnum() for c in s)
+
+
+def should_skip_stt(text: str) -> bool:
+    """Return True if the transcript should be silently discarded."""
+    text = text.strip()
+    if len(text) < 2:
+        return True
+    if _is_only_punct_or_symbol(text):
+        return True
+    if text in _FILLER_WORDS:
+        return True
+    return False
+
+
+class RealtimeSttSession:
+    """Manages microphone capture → ElevenLabs Realtime STT → output queue.
+
+    Attributes:
+        on_partial:   Optional callback ``(text) -> None`` for partial transcripts.
+        on_committed: Optional callback ``(text) -> None`` for committed transcripts
+                      (called *before* the text is placed on the queue).
+    """
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = api_key
+        self._stt_client = None
+        self._mic_capture = None
+        self._relay_task: asyncio.Task | None = None
+        self._partial_task: asyncio.Task | None = None
+        self._committed_queue: asyncio.Queue[str] | None = None
+
+        # Deduplication state
+        self._last_text = ""
+        self._last_time = 0.0
+
+        # Display callbacks (set by caller before start())
+        self.on_partial: Callable[[str], None] | None = None
+        self.on_committed: Callable[[str], None] | None = None
+
+    @property
+    def active(self) -> bool:
+        """True while the session is running."""
+        return self._stt_client is not None
+
+    async def start(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        committed_queue: asyncio.Queue[str],
+    ) -> None:
+        """Connect the STT WebSocket and start microphone capture."""
+        from .tools.realtime_stt import RealtimeSttClient  # noqa: PLC0415
+        from .tools.mic import MicCapture  # noqa: PLC0415
+
+        self._committed_queue = committed_queue
+
+        self._stt_client = RealtimeSttClient(self._api_key)
+        self._stt_client.on_committed = asyncio.Queue()
+        self._stt_client.on_partial = asyncio.Queue()
+        await self._stt_client.connect()
+
+        self._relay_task = asyncio.create_task(self._committed_relay())
+        self._partial_task = asyncio.create_task(self._partial_relay())
+
+        self._mic_capture = MicCapture(on_audio=self._stt_client.send_audio)
+        self._mic_capture.start(loop)
+        logger.info("Realtime STT session started")
+
+    async def stop(self) -> None:
+        """Stop microphone capture and close the STT WebSocket."""
+        if self._mic_capture:
+            self._mic_capture.stop()
+            self._mic_capture = None
+        for task in (self._relay_task, self._partial_task):
+            if task:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+        self._relay_task = None
+        self._partial_task = None
+        if self._stt_client:
+            await self._stt_client.close()
+            self._stt_client = None
+        logger.info("Realtime STT session stopped")
+
+    # ── internal relay tasks ─────────────────────────────────────────
+
+    async def _committed_relay(self) -> None:
+        assert self._stt_client is not None
+        assert self._committed_queue is not None
+        while True:
+            text = await self._stt_client.on_committed.get()
+            if should_skip_stt(text):
+                continue
+            now = time.time()
+            if text == self._last_text and now - self._last_time < 1.2:
+                continue
+            self._last_text = text
+            self._last_time = now
+            if self.on_committed:
+                self.on_committed(text)
+            await self._committed_queue.put(text)
+
+    async def _partial_relay(self) -> None:
+        assert self._stt_client is not None
+        while True:
+            text = await self._stt_client.on_partial.get()
+            if self.on_partial:
+                self.on_partial(text)
+
+
+def create_realtime_stt_session() -> RealtimeSttSession | None:
+    """Create a session if ``REALTIME_STT=true`` and the API key is available.
+
+    Returns ``None`` when realtime STT is not configured.
+    """
+    enabled = os.environ.get("REALTIME_STT", "").lower() in ("1", "true", "yes")
+    api_key = os.environ.get("ELEVENLABS_API_KEY", "")
+
+    if not enabled:
+        return None
+    if not api_key:
+        logger.warning("REALTIME_STT=true but ELEVENLABS_API_KEY is not set")
+        return None
+
+    return RealtimeSttSession(api_key)

--- a/src/familiar_agent/tools/mic.py
+++ b/src/familiar_agent/tools/mic.py
@@ -1,0 +1,59 @@
+"""Microphone capture — streams PCM 16 kHz 16-bit mono to an async callback."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+SAMPLE_RATE = 16000
+CHANNELS = 1
+BLOCK_SIZE = 1600  # 100 ms at 16 kHz
+
+
+class MicCapture:
+    """Capture audio from the default microphone using *sounddevice*.
+
+    The callback converts raw CFFI buffer data to ``bytes`` and schedules
+    the async *on_audio* coroutine on the event loop.
+    """
+
+    def __init__(self, on_audio) -> None:  # noqa: ANN001 – Callable[[bytes], Awaitable]
+        self._on_audio = on_audio
+        self._stream = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    def start(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Start capturing from the default input device."""
+        import sounddevice as sd
+
+        self._loop = loop
+
+        def _callback(indata, frames, time_info, status):  # noqa: ANN001, ARG001
+            if status:
+                logger.debug("Mic status: %s", status)
+            # indata is a CFFI buffer from RawInputStream
+            pcm_bytes = bytes(indata)
+            if self._loop and not self._loop.is_closed():
+                self._loop.call_soon_threadsafe(
+                    lambda b=pcm_bytes: self._loop.create_task(self._on_audio(b))
+                )
+
+        self._stream = sd.RawInputStream(
+            samplerate=SAMPLE_RATE,
+            blocksize=BLOCK_SIZE,
+            channels=CHANNELS,
+            dtype="int16",
+            callback=_callback,
+        )
+        self._stream.start()
+        logger.info("Microphone capture started (device: default)")
+
+    def stop(self) -> None:
+        """Stop capturing."""
+        if self._stream:
+            self._stream.stop()
+            self._stream.close()
+            self._stream = None
+            logger.info("Microphone capture stopped")

--- a/src/familiar_agent/tools/realtime_stt.py
+++ b/src/familiar_agent/tools/realtime_stt.py
@@ -1,0 +1,128 @@
+"""Realtime Speech-to-Text using ElevenLabs WebSocket API (Scribe v2 Realtime).
+
+Unlike the batch STT in ``stt.py`` (record → file → REST), this module keeps a
+persistent WebSocket open and streams PCM audio in real time.  ElevenLabs VAD
+detects speech boundaries and commits transcripts automatically — no button
+press required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+# ElevenLabs Realtime STT endpoint
+_STT_WS_URL = (
+    "wss://api.elevenlabs.io/v1/speech-to-text/realtime"
+    "?model_id=scribe_v2_realtime"
+    "&audio_format=pcm_16000"
+    "&commit_strategy=vad"
+    "&vad_silence_threshold_secs=1.0"
+)
+
+
+class RealtimeSttClient:
+    """ElevenLabs Realtime STT WebSocket client.
+
+    Streams PCM audio and fires callbacks on partial/committed transcripts.
+    """
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+        self._session: aiohttp.ClientSession | None = None
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._recv_task: asyncio.Task | None = None
+        self._connected = False
+
+        # Queues for transcript events
+        self.on_partial: asyncio.Queue[str] | None = None
+        self.on_committed: asyncio.Queue[str] | None = None
+
+    async def connect(self) -> None:
+        """Connect to ElevenLabs Realtime STT WebSocket."""
+        self._session = aiohttp.ClientSession()
+        headers = {"xi-api-key": self.api_key}
+        try:
+            self._ws = await self._session.ws_connect(_STT_WS_URL, headers=headers)
+            self._connected = True
+            self._recv_task = asyncio.create_task(self._recv_loop())
+            logger.info("Realtime STT WebSocket connected")
+        except Exception as e:
+            logger.error("Realtime STT WebSocket connection failed: %s", e)
+            await self._cleanup()
+            raise
+
+    async def send_audio(self, pcm16le: bytes) -> None:
+        """Send a chunk of PCM 16-bit LE audio at 16 kHz."""
+        if not self._connected or self._ws is None:
+            return
+        payload = {
+            "message_type": "input_audio_chunk",
+            "audio_base_64": base64.b64encode(pcm16le).decode("ascii"),
+            "commit": False,
+            "sample_rate": 16000,
+        }
+        try:
+            await self._ws.send_str(json.dumps(payload))
+        except Exception as e:
+            logger.warning("Realtime STT send failed: %s", e)
+
+    async def _recv_loop(self) -> None:
+        """Receive loop for WebSocket messages."""
+        if self._ws is None:
+            return
+        try:
+            async for msg in self._ws:
+                if msg.type == aiohttp.WSMsgType.TEXT:
+                    try:
+                        data = json.loads(msg.data)
+                        msg_type = data.get("message_type", "")
+                        if msg_type == "partial_transcript":
+                            text = data.get("text", "").strip()
+                            if text and self.on_partial:
+                                await self.on_partial.put(text)
+                        elif msg_type in (
+                            "committed_transcript",
+                            "committed_transcript_with_timestamps",
+                        ):
+                            text = data.get("text", "").strip()
+                            if text and self.on_committed:
+                                await self.on_committed.put(text)
+                        elif msg_type and "error" in msg_type.lower():
+                            logger.warning("Realtime STT error: %s", msg.data)
+                    except json.JSONDecodeError:
+                        pass
+                elif msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                    break
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.warning("Realtime STT recv loop error: %s", e)
+        finally:
+            self._connected = False
+
+    async def close(self) -> None:
+        """Close the WebSocket connection."""
+        self._connected = False
+        if self._recv_task:
+            self._recv_task.cancel()
+            try:
+                await self._recv_task
+            except asyncio.CancelledError:
+                pass
+        await self._cleanup()
+        logger.info("Realtime STT WebSocket closed")
+
+    async def _cleanup(self) -> None:
+        if self._ws and not self._ws.closed:
+            await self._ws.close()
+        if self._session and not self._session.closed:
+            await self._session.close()
+        self._ws = None
+        self._session = None


### PR DESCRIPTION
## What

Add always-on, hands-free voice input using ElevenLabs Scribe v2 Realtime
WebSocket API.

## Why

The existing batch STT (Ctrl+T / Space PTT) requires a button press to start
and stop recording. Realtime STT enables natural conversation where the user
simply speaks and transcripts appear automatically — no interaction needed.

## How

**New files:**
- `tools/realtime_stt.py` — ElevenLabs Realtime STT WebSocket client
- `tools/mic.py` — Microphone capture (PCM 16kHz, uses sounddevice)
- `realtime_stt_session.py` — Session manager with filler filtering,
  deduplication, and display callbacks (shared by REPL and TUI)

**Modified files:**
- `main.py` — Realtime STT integration in REPL mode
- `tui.py` — Realtime STT integration in TUI mode
- `.env.example` — Added `REALTIME_STT` option
- `CHANGELOG.md` — Updated [Unreleased]

## Design

- Opt-in via `REALTIME_STT=true` (reuses existing `ELEVENLABS_API_KEY`)
- Coexists with batch STT — both can be enabled simultaneously
- Keyboard text input remains fully functional
- Filler word filtering (Japanese) and rapid-repeat deduplication
- Clean separation: low-level client → session manager → UI integration

## Not included (future work)

- Barge-in (interrupt agent TTS playback on voice input)
- Language-specific filler word sets (currently Japanese only)