### PR TITLE
fix(mic): use device native sample rate, resample to 16 kHz

### DIFF
--- a/src/familiar_agent/tools/mic.py
+++ b/src/familiar_agent/tools/mic.py
@@ -4,25 +4,45 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Any
+
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
-SAMPLE_RATE = 16000
+TARGET_RATE = 16000  # ElevenLabs Realtime STT expects 16 kHz PCM
 CHANNELS = 1
-BLOCK_SIZE = 1600  # 100 ms at 16 kHz
+_BLOCK_MS = 100  # capture block size in milliseconds
+
+
+def _resample(pcm_bytes: bytes, from_rate: int) -> bytes:
+    """Resample int16 mono PCM from *from_rate* to TARGET_RATE (16 kHz).
+
+    Uses linear interpolation — fast, dependency-free, good enough for STT.
+    """
+    if from_rate == TARGET_RATE:
+        return pcm_bytes
+    arr = np.frombuffer(pcm_bytes, dtype=np.int16)
+    n_out = int(len(arr) * TARGET_RATE / from_rate)
+    indices = np.linspace(0, len(arr) - 1, n_out)
+    resampled = np.interp(indices, np.arange(len(arr)), arr).astype(np.int16)
+    return resampled.tobytes()
 
 
 class MicCapture:
     """Capture audio from the default microphone using *sounddevice*.
 
-    The callback converts raw CFFI buffer data to ``bytes`` and schedules
-    the async *on_audio* coroutine on the event loop.
+    Automatically detects the device's native sample rate and resamples to
+    16 kHz before handing PCM bytes to *on_audio*.  This avoids
+    ``paInvalidSampleRate`` on devices whose native rate differs from 16 kHz
+    (e.g. USB mics that default to 44 100 Hz).
     """
 
     def __init__(self, on_audio) -> None:  # noqa: ANN001 – Callable[[bytes], Awaitable]
         self._on_audio = on_audio
-        self._stream = None
+        self._stream: Any = None
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._native_rate: int = TARGET_RATE
 
     def start(self, loop: asyncio.AbstractEventLoop) -> None:
         """Start capturing from the default input device."""
@@ -30,25 +50,35 @@ class MicCapture:
 
         self._loop = loop
 
+        # Use the device's native sample rate to avoid paInvalidSampleRate
+        device_info = sd.query_devices(kind="input")
+        self._native_rate = int(device_info["default_samplerate"])
+        block_size = int(self._native_rate * _BLOCK_MS / 1000)
+
+        logger.info(
+            "Microphone capture: device=%s native_rate=%d target_rate=%d",
+            device_info.get("name", "default"),
+            self._native_rate,
+            TARGET_RATE,
+        )
+
         def _callback(indata, frames, time_info, status):  # noqa: ANN001, ARG001
             if status:
                 logger.debug("Mic status: %s", status)
-            # indata is a CFFI buffer from RawInputStream
-            pcm_bytes = bytes(indata)
+            pcm = _resample(bytes(indata), self._native_rate)
             if self._loop and not self._loop.is_closed():
                 self._loop.call_soon_threadsafe(
-                    lambda b=pcm_bytes: self._loop.create_task(self._on_audio(b))
+                    lambda b=pcm: self._loop.create_task(self._on_audio(b))
                 )
 
         self._stream = sd.RawInputStream(
-            samplerate=SAMPLE_RATE,
-            blocksize=BLOCK_SIZE,
+            samplerate=self._native_rate,
+            blocksize=block_size,
             channels=CHANNELS,
             dtype="int16",
             callback=_callback,
         )
         self._stream.start()
-        logger.info("Microphone capture started (device: default)")
 
     def stop(self) -> None:
         """Stop capturing."""


### PR DESCRIPTION
## Problem

\`mic.py\` hardcoded \`SAMPLE_RATE = 16000\`, causing \`paInvalidSampleRate\` on USB mics whose native rate differs (e.g. 44100 Hz). Same issue previously fixed in \`stt.py\`.

## Fix

- Query \`sd.query_devices(kind="input")["default_samplerate"]\` for native rate
- Capture at native rate (avoids PortAudio error)
- Linearly resample to 16 kHz via numpy before sending to ElevenLabs

Also fixes pre-existing mypy errors from #56 in \`realtime_stt_session.py\`.

## Test plan

- [x] USB mic attached → \`REALTIME_STT=true\` starts without \`paInvalidSampleRate\`
- [x] Speech transcribed and appears in TUI