### PR TITLE
docs: add GLM backend and Realtime STT to all README translations

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -23,6 +23,7 @@ Es nimmt die reale Welt durch Kameras wahr, bewegt sich auf einem Roboter, spric
 - 🔄 **Umschauen** — schwenkt und neigt die Kamera, um die Umgebung zu erkunden
 - 🦿 **Bewegen** — steuert einen Roboterstaubsauger durchs Zimmer
 - 🗣 **Sprechen** — spricht via ElevenLabs TTS
+- 🎙 **Zuhören** — freihändige Spracheingabe via ElevenLabs Realtime STT (opt-in)
 - 🧠 **Erinnern** — speichert und ruft aktiv Erinnerungen mit semantischer Suche ab (SQLite + Embeddings)
 - 🫀 **Theory of Mind** — berücksichtigt die Perspektive des anderen, bevor es antwortet
 - 💭 **Wünsche** — hat eigene innere Antriebe, die autonomes Verhalten auslösen
@@ -80,7 +81,7 @@ cp .env.example .env
 
 | Variable | Beschreibung |
 |----------|-------------|
-| `PLATFORM` | `anthropic` (Standard) \| `gemini` \| `openai` \| `kimi` |
+| `PLATFORM` | `anthropic` (Standard) \| `gemini` \| `openai` \| `kimi` \| `glm` |
 | `API_KEY` | Dein API-Schlüssel für die gewählte Plattform |
 
 **Optional:**
@@ -92,6 +93,7 @@ cp .env.example .env
 | `CAMERA_HOST` | IP-Adresse deiner ONVIF/RTSP-Kamera |
 | `CAMERA_USER` / `CAMERA_PASS` | Anmeldedaten der Kamera |
 | `ELEVENLABS_API_KEY` | Für Sprachausgabe — [elevenlabs.io](https://elevenlabs.io/) |
+| `REALTIME_STT` | `true` für freihändige Echtzeit-Spracheingabe (benötigt `ELEVENLABS_API_KEY`) |
 | `TTS_OUTPUT` | Audioziel: `local` (PC-Lautsprecher, Standard) \| `remote` (Kameralautsprecher) \| `both` (beides gleichzeitig) |
 | `THINKING_MODE` | Nur Anthropic — `auto` (Standard) \| `adaptive` \| `extended` \| `disabled` |
 | `THINKING_EFFORT` | Tiefe des adaptiven Denkens: `high` (Standard) \| `medium` \| `low` \| `max` (nur Opus 4.6) |
@@ -119,6 +121,7 @@ cp persona-template/en.md ME.md
 | Plattform | `PLATFORM=` | Standardmodell | Wo man den Schlüssel bekommt |
 |----------|------------|---------------|-----------------|
 | **Moonshot Kimi K2.5** | `kimi` | `kimi-k2.5` | [platform.moonshot.ai](https://platform.moonshot.ai) |
+| Z.AI GLM | `glm` | `glm-4.6v` | [api.z.ai](https://api.z.ai) |
 | Anthropic Claude | `anthropic` | `claude-haiku-4-5-20251001` | [console.anthropic.com](https://console.anthropic.com) |
 | Google Gemini | `gemini` | `gemini-2.5-flash` | [aistudio.google.com](https://aistudio.google.com) |
 | OpenAI | `openai` | `gpt-4o-mini` | [platform.openai.com](https://platform.openai.com) |
@@ -130,6 +133,14 @@ cp persona-template/en.md ME.md
 ```env
 PLATFORM=kimi
 API_KEY=sk-...   # von platform.moonshot.ai
+AGENT_NAME=Yukine
+```
+
+**Z.AI GLM `.env`-Beispiel:**
+```env
+PLATFORM=glm
+API_KEY=...   # from api.z.ai
+MODEL=glm-4.6v   # vision-enabled; glm-4.7 / glm-5 = text-only
 AGENT_NAME=Yukine
 ```
 
@@ -280,6 +291,17 @@ Standard (`TTS_OUTPUT=local`). Probiert der Reihe nach: **paplay** → **mpv** �
 | Windows | [mpv.io/installation](https://mpv.io/installation/) — herunterladen und zu PATH hinzufügen, **oder** `winget install ffmpeg` |
 
 > Ohne go2rtc und lokalen Player funktioniert die Sprachgenerierung (ElevenLabs API) weiterhin — die Wiedergabe wird lediglich übersprungen.
+
+### Spracheingabe (Realtime STT)
+
+Setze `REALTIME_STT=true` in `.env` für freihändige, dauerhafte Spracheingabe:
+
+```env
+REALTIME_STT=true
+ELEVENLABS_API_KEY=sk_...   # gleicher Key wie für TTS
+```
+
+familiar-ai überträgt Mikrofon-Audio an ElevenLabs Scribe v2 und bestätigt Transkripte automatisch bei Sprachpausen. Kein Tastendruck erforderlich. Funktioniert gleichzeitig mit dem Push-to-Talk-Modus (Ctrl+T).
 
 ---
 

--- a/README-fr.md
+++ b/README-fr.md
@@ -23,6 +23,7 @@ Elle perçoit le monde réel par des caméras, se déplace sur un corps de robot
 - 🔄 **Regarder autour** — incline et fait pivoter la caméra pour explorer ses alentours
 - 🦿 **Se déplacer** — conduit un aspirateur robot pour explorer la pièce
 - 🗣 **Parler** — s'exprime via la synthèse vocale ElevenLabs
+- 🎙 **Écouter** — saisie vocale mains libres via ElevenLabs STT temps réel (optionnel)
 - 🧠 **Se souvenir** — enregistre et rappelle activement les souvenirs avec recherche sémantique (SQLite + embeddings)
 - 🫀 **Théorie de l'esprit** — adopte la perspective d'autrui avant de répondre
 - 💭 **Désirs** — possède ses propres motivations internes qui déclenchent un comportement autonome
@@ -80,7 +81,7 @@ cp .env.example .env
 
 | Variable | Description |
 |----------|-------------|
-| `PLATFORM` | `anthropic` (défaut) \| `gemini` \| `openai` \| `kimi` |
+| `PLATFORM` | `anthropic` (défaut) \| `gemini` \| `openai` \| `kimi` \| `glm` |
 | `API_KEY` | Votre clé API pour la plateforme choisie |
 
 **Optionnel :**
@@ -92,6 +93,7 @@ cp .env.example .env
 | `CAMERA_HOST` | Adresse IP de votre caméra ONVIF/RTSP |
 | `CAMERA_USER` / `CAMERA_PASS` | Identifiants de la caméra |
 | `ELEVENLABS_API_KEY` | Pour la sortie vocale — [elevenlabs.io](https://elevenlabs.io/) |
+| `REALTIME_STT` | `true` pour activer la saisie vocale mains libres en temps réel (nécessite `ELEVENLABS_API_KEY`) |
 | `TTS_OUTPUT` | Destination audio : `local` (haut-parleur PC, défaut) \| `remote` (haut-parleur caméra) \| `both` (les deux simultanément) |
 | `THINKING_MODE` | Anthropic uniquement — `auto` (défaut) \| `adaptive` \| `extended` \| `disabled` |
 | `THINKING_EFFORT` | Profondeur de la réflexion adaptative : `high` (défaut) \| `medium` \| `low` \| `max` (Opus 4.6 uniquement) |
@@ -119,6 +121,7 @@ cp persona-template/en.md ME.md
 | Plateforme | `PLATFORM=` | Modèle par défaut | Où obtenir la clé |
 |----------|------------|---------------|-----------------|
 | **Moonshot Kimi K2.5** | `kimi` | `kimi-k2.5` | [platform.moonshot.ai](https://platform.moonshot.ai) |
+| Z.AI GLM | `glm` | `glm-4.6v` | [api.z.ai](https://api.z.ai) |
 | Anthropic Claude | `anthropic` | `claude-haiku-4-5-20251001` | [console.anthropic.com](https://console.anthropic.com) |
 | Google Gemini | `gemini` | `gemini-2.5-flash` | [aistudio.google.com](https://aistudio.google.com) |
 | OpenAI | `openai` | `gpt-4o-mini` | [platform.openai.com](https://platform.openai.com) |
@@ -130,6 +133,14 @@ cp persona-template/en.md ME.md
 ```env
 PLATFORM=kimi
 API_KEY=sk-...   # from platform.moonshot.ai
+AGENT_NAME=Yukine
+```
+
+**Exemple `.env` Z.AI GLM :**
+```env
+PLATFORM=glm
+API_KEY=...   # from api.z.ai
+MODEL=glm-4.6v   # vision-enabled; glm-4.7 / glm-5 = text-only
 AGENT_NAME=Yukine
 ```
 
@@ -280,6 +291,17 @@ Mode par défaut (`TTS_OUTPUT=local`). Essaie dans l'ordre : **paplay** → **mp
 | Windows | [mpv.io/installation](https://mpv.io/installation/) — télécharger et ajouter au PATH, **ou** `winget install ffmpeg` |
 
 > Sans go2rtc ni lecteur local, la génération vocale (appel API ElevenLabs) fonctionne toujours — la lecture est simplement ignorée.
+
+### Saisie vocale (STT temps réel)
+
+Définissez `REALTIME_STT=true` dans `.env` pour une saisie vocale mains libres en continu :
+
+```env
+REALTIME_STT=true
+ELEVENLABS_API_KEY=sk_...   # même clé que pour TTS
+```
+
+familiar-ai diffuse l'audio du microphone vers ElevenLabs Scribe v2 et valide les transcriptions automatiquement lorsque vous faites une pause. Aucune pression de touche requise. Compatible avec le mode push-to-talk (Ctrl+T).
 
 ---
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -26,6 +26,7 @@ familiar-ai はあなたの家に暮らすAIコンパニオンです。
 - 🔄 **周囲を見回す** — カメラをパン・チルトさせて周囲を探索
 - 🦿 **動く** — ロボット掃除機で部屋を移動
 - 🗣 **話す** — ElevenLabs TTSで声を出す
+- 🎙 **聞く** — ElevenLabs リアルタイムSTTによるハンズフリー音声入力（オプション）
 - 🧠 **覚える** — セマンティック検索を使って能動的に記憶を保存・想起（SQLite + embeddings）
 - 🫀 **心の理論** — 相手の立場に立ってから返答
 - 💭 **欲望** — 自律的な行動をトリガーする内的動機を持つ
@@ -84,7 +85,7 @@ cp .env.example .env
 
 | 変数 | 説明 |
 |------|------|
-| `PLATFORM` | `anthropic`（デフォルト）\| `gemini` \| `openai` \| `kimi` |
+| `PLATFORM` | `anthropic`（デフォルト）\| `gemini` \| `openai` \| `kimi` \| `glm` |
 | `API_KEY` | 選んだプラットフォームのAPIキー |
 
 **オプション：**
@@ -96,6 +97,7 @@ cp .env.example .env
 | `CAMERA_HOST` | ONVIF/RTSPカメラのIPアドレス |
 | `CAMERA_USER` / `CAMERA_PASS` | カメラの認証情報 |
 | `ELEVENLABS_API_KEY` | 音声出力用 — [elevenlabs.io](https://elevenlabs.io/) |
+| `REALTIME_STT` | `true` でハンズフリー常時音声入力を有効化（`ELEVENLABS_API_KEY` 必須） |
 | `TTS_OUTPUT` | 音声出力先：`local`（PCスピーカー、デフォルト）\| `remote`（カメラスピーカー）\| `both`（両方同時） |
 | `THINKING_MODE` | Anthropic専用 — `auto`（デフォルト）\| `adaptive` \| `extended` \| `disabled` |
 | `THINKING_EFFORT` | Adaptive thinking の深度：`high`（デフォルト）\| `medium` \| `low` \| `max`（Opus 4.6のみ） |
@@ -123,6 +125,7 @@ cp persona-template/en.md ME.md
 | プラットフォーム | `PLATFORM=` | デフォルトモデル | キーを取得 |
 |------------|------------|---------------|----------|
 | **Moonshot Kimi K2.5** | `kimi` | `kimi-k2.5` | [platform.moonshot.ai](https://platform.moonshot.ai) |
+| Z.AI GLM | `glm` | `glm-4.6v` | [api.z.ai](https://api.z.ai) |
 | Anthropic Claude | `anthropic` | `claude-haiku-4-5-20251001` | [console.anthropic.com](https://console.anthropic.com) |
 | Google Gemini | `gemini` | `gemini-2.5-flash` | [aistudio.google.com](https://aistudio.google.com) |
 | OpenAI | `openai` | `gpt-4o-mini` | [platform.openai.com](https://platform.openai.com) |
@@ -134,6 +137,14 @@ cp persona-template/en.md ME.md
 ```env
 PLATFORM=kimi
 API_KEY=sk-...   # platform.moonshot.ai から取得
+AGENT_NAME=ユキネ
+```
+
+**Z.AI GLM `.env` の例：**
+```env
+PLATFORM=glm
+API_KEY=...   # from api.z.ai
+MODEL=glm-4.6v   # vision-enabled; glm-4.7 / glm-5 = text-only
 AGENT_NAME=ユキネ
 ```
 
@@ -286,6 +297,17 @@ TTS_OUTPUT=both     # カメラスピーカー + PCスピーカー同時再生
 | Windows | [mpv.io/installation](https://mpv.io/installation/) からダウンロードしてPATHに追加、**または** `winget install ffmpeg` |
 
 > go2rtc・mpv・ffplay がいずれも未設定でも、音声生成自体（ElevenLabs API呼び出し）は動作します。再生がスキップされるだけです。
+
+### 音声入力（リアルタイムSTT）
+
+`.env` で `REALTIME_STT=true` を設定すると、ハンズフリーの常時音声入力が有効になります：
+
+```env
+REALTIME_STT=true
+ELEVENLABS_API_KEY=sk_...   # TTSと同じキー
+```
+
+話し終えて間を置くと、ElevenLabs Scribe v2 が自動的にテキストに変換します。ボタン操作は不要。プッシュトゥトーク（Ctrl+T）と同時に使用できます。
 
 ---
 

--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -23,6 +23,7 @@ Familiar AI 是一個住在你家裡的 AI 夥伴。
 - 🔄 **四處張望** — 透過雲台攝影機的旋轉平移來探索周圍環境
 - 🦿 **移動** — 驅動掃地機器人在房間裡漫遊
 - 🗣 **說話** — 透過 ElevenLabs TTS 朗讀文字
+- 🎙 **聆聽** — 透過 ElevenLabs 即時 STT 實現免提語音輸入（選用）
 - 🧠 **記住** — 主動儲存和回憶記憶，支援語義搜尋（SQLite + 向量嵌入）
 - 🫀 **心智理論** — 在回應前換位思考
 - 💭 **慾望** — 有自己的內在驅動，會觸發自主行為
@@ -80,7 +81,7 @@ cp .env.example .env
 
 | 變數 | 說明 |
 |------|------|
-| `PLATFORM` | `anthropic`（預設）\| `gemini` \| `openai` \| `kimi` |
+| `PLATFORM` | `anthropic`（預設）\| `gemini` \| `openai` \| `kimi` \| `glm` |
 | `API_KEY` | 選定平台的 API 金鑰 |
 
 **可選設定：**
@@ -92,6 +93,7 @@ cp .env.example .env
 | `CAMERA_HOST` | ONVIF/RTSP 攝影機的 IP 位址 |
 | `CAMERA_USER` / `CAMERA_PASS` | 攝影機憑證 |
 | `ELEVENLABS_API_KEY` | 用於語音輸出 — [elevenlabs.io](https://elevenlabs.io/) |
+| `REALTIME_STT` | `true` 啟用免提即時語音輸入（需要 `ELEVENLABS_API_KEY`） |
 | `TTS_OUTPUT` | 音訊輸出位置：`local`（PC 喇叭，預設）\| `remote`（攝影機喇叭）\| `both`（兩者同時） |
 | `THINKING_MODE` | 僅 Anthropic — `auto`（預設）\| `adaptive` \| `extended` \| `disabled` |
 | `THINKING_EFFORT` | Adaptive thinking 深度：`high`（預設）\| `medium` \| `low` \| `max`（僅 Opus 4.6） |
@@ -119,6 +121,7 @@ cp persona-template/en.md ME.md
 | 平台 | `PLATFORM=` | 預設模型 | 取得金鑰 |
 |------|-----------|---------|--------|
 | **Moonshot Kimi K2.5** | `kimi` | `kimi-k2.5` | [platform.moonshot.ai](https://platform.moonshot.ai) |
+| Z.AI GLM | `glm` | `glm-4.6v` | [api.z.ai](https://api.z.ai) |
 | Anthropic Claude | `anthropic` | `claude-haiku-4-5-20251001` | [console.anthropic.com](https://console.anthropic.com) |
 | Google Gemini | `gemini` | `gemini-2.5-flash` | [aistudio.google.com](https://aistudio.google.com) |
 | OpenAI | `openai` | `gpt-4o-mini` | [platform.openai.com](https://platform.openai.com) |
@@ -130,6 +133,14 @@ cp persona-template/en.md ME.md
 ```env
 PLATFORM=kimi
 API_KEY=sk-...   # 來自 platform.moonshot.ai
+AGENT_NAME=Yukine
+```
+
+**Z.AI GLM `.env` 範例：**
+```env
+PLATFORM=glm
+API_KEY=...   # from api.z.ai
+MODEL=glm-4.6v   # vision-enabled; glm-4.7 / glm-5 = text-only
 AGENT_NAME=Yukine
 ```
 
@@ -280,6 +291,17 @@ TTS_OUTPUT=both     # 攝影機喇叭 + PC 喇叭同時播放
 | Windows | 從 [mpv.io/installation](https://mpv.io/installation/) 下載並加入 PATH，**或** `winget install ffmpeg` |
 
 > 即使沒有 go2rtc 或本機播放器，語音生成本身（ElevenLabs API 呼叫）仍可正常運作，只是不會播放。
+
+### 語音輸入（即時 STT）
+
+在 `.env` 中設定 `REALTIME_STT=true` 可啟用免提即時語音輸入：
+
+```env
+REALTIME_STT=true
+ELEVENLABS_API_KEY=sk_...   # 與 TTS 相同的金鑰
+```
+
+說話暫停後，ElevenLabs Scribe v2 會自動轉錄。無需按鍵操作。可與按鍵通話（Ctrl+T）同時使用。
 
 ---
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -23,6 +23,7 @@ Familiar AI 是一个住在你家里的 AI 伙伴。
 - 🔄 **四处张望** — 通过云台摄像头的旋转平移来探索周围环境
 - 🦿 **移动** — 驱动扫地机器人在房间里漫游
 - 🗣 **说话** — 通过 ElevenLabs TTS 朗读文本
+- 🎙 **聆听** — 通过 ElevenLabs 实时 STT 实现免提语音输入（可选）
 - 🧠 **记住** — 主动储存和回忆记忆，支持语义搜索（SQLite + 向量嵌入）
 - 🫀 **心智理论** — 在回应前换位思考
 - 💭 **欲望** — 有自己的内在驱动，会触发自主行为
@@ -80,7 +81,7 @@ cp .env.example .env
 
 | 变量 | 说明 |
 |------|------|
-| `PLATFORM` | `anthropic`（默认）\| `gemini` \| `openai` \| `kimi` |
+| `PLATFORM` | `anthropic`（默认）\| `gemini` \| `openai` \| `kimi` \| `glm` |
 | `API_KEY` | 选定平台的 API 密钥 |
 
 **可选配置：**
@@ -92,6 +93,7 @@ cp .env.example .env
 | `CAMERA_HOST` | ONVIF/RTSP 摄像头的 IP 地址 |
 | `CAMERA_USER` / `CAMERA_PASS` | 摄像头凭证 |
 | `ELEVENLABS_API_KEY` | 用于语音输出 — [elevenlabs.io](https://elevenlabs.io/) |
+| `REALTIME_STT` | `true` 启用免提实时语音输入（需要 `ELEVENLABS_API_KEY`） |
 | `TTS_OUTPUT` | 音频输出位置：`local`（PC 扬声器，默认）\| `remote`（摄像头扬声器）\| `both`（两者同时） |
 | `THINKING_MODE` | 仅 Anthropic — `auto`（默认）\| `adaptive` \| `extended` \| `disabled` |
 | `THINKING_EFFORT` | Adaptive thinking 深度：`high`（默认）\| `medium` \| `low` \| `max`（仅 Opus 4.6） |
@@ -119,6 +121,7 @@ cp persona-template/en.md ME.md
 | 平台 | `PLATFORM=` | 默认模型 | 获取密钥 |
 |------|-----------|---------|--------|
 | **Moonshot Kimi K2.5** | `kimi` | `kimi-k2.5` | [platform.moonshot.ai](https://platform.moonshot.ai) |
+| Z.AI GLM | `glm` | `glm-4.6v` | [api.z.ai](https://api.z.ai) |
 | Anthropic Claude | `anthropic` | `claude-haiku-4-5-20251001` | [console.anthropic.com](https://console.anthropic.com) |
 | Google Gemini | `gemini` | `gemini-2.5-flash` | [aistudio.google.com](https://aistudio.google.com) |
 | OpenAI | `openai` | `gpt-4o-mini` | [platform.openai.com](https://platform.openai.com) |
@@ -130,6 +133,14 @@ cp persona-template/en.md ME.md
 ```env
 PLATFORM=kimi
 API_KEY=sk-...   # 来自 platform.moonshot.ai
+AGENT_NAME=Yukine
+```
+
+**Z.AI GLM `.env` 示例：**
+```env
+PLATFORM=glm
+API_KEY=...   # from api.z.ai
+MODEL=glm-4.6v   # vision-enabled; glm-4.7 / glm-5 = text-only
 AGENT_NAME=Yukine
 ```
 
@@ -280,6 +291,17 @@ TTS_OUTPUT=both     # 摄像头扬声器 + PC 扬声器同时播放
 | Windows | 从 [mpv.io/installation](https://mpv.io/installation/) 下载并添加到 PATH，**或** `winget install ffmpeg` |
 
 > 即使没有 go2rtc 或本地播放器，语音生成本身（ElevenLabs API 调用）仍可正常工作，只是不会播放。
+
+### 语音输入（实时 STT）
+
+在 `.env` 中设置 `REALTIME_STT=true` 可启用免提实时语音输入：
+
+```env
+REALTIME_STT=true
+ELEVENLABS_API_KEY=sk_...   # 与 TTS 相同的密钥
+```
+
+说话停顿后，ElevenLabs Scribe v2 会自动转录。无需按键操作。可与按键通话（Ctrl+T）同时使用。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It perceives the real world through cameras, moves around on a robot body, speak
 - 🔄 **Look around** — pans and tilts the camera to explore its surroundings
 - 🦿 **Move** — drives a robot vacuum to roam the room
 - 🗣 **Speak** — talks via ElevenLabs TTS
+- 🎙 **Listen** — hands-free voice input via ElevenLabs Realtime STT (opt-in)
 - 🧠 **Remember** — actively stores and recalls memories with semantic search (SQLite + embeddings)
 - 🫀 **Theory of Mind** — takes the other person's perspective before responding
 - 💭 **Desire** — has its own internal drives that trigger autonomous behavior
@@ -85,7 +86,7 @@ cp .env.example .env
 
 | Variable | Description |
 |----------|-------------|
-| `PLATFORM` | `anthropic` (default) \| `gemini` \| `openai` \| `kimi` |
+| `PLATFORM` | `anthropic` (default) \| `gemini` \| `openai` \| `kimi` \| `glm` |
 | `API_KEY` | Your API key for the chosen platform |
 
 **Optional:**
@@ -97,6 +98,7 @@ cp .env.example .env
 | `CAMERA_HOST` | IP address of your ONVIF/RTSP camera |
 | `CAMERA_USER` / `CAMERA_PASS` | Camera credentials |
 | `ELEVENLABS_API_KEY` | For voice output — [elevenlabs.io](https://elevenlabs.io/) |
+| `REALTIME_STT` | `true` to enable always-on hands-free voice input (requires `ELEVENLABS_API_KEY`) |
 | `TTS_OUTPUT` | Where to play audio: `local` (PC speaker, default) \| `remote` (camera speaker) \| `both` |
 | `THINKING_MODE` | Anthropic only — `auto` (default) \| `adaptive` \| `extended` \| `disabled` |
 | `THINKING_EFFORT` | Adaptive thinking effort: `high` (default) \| `medium` \| `low` \| `max` (Opus 4.6 only) |
@@ -124,6 +126,7 @@ cp persona-template/en.md ME.md
 | Platform | `PLATFORM=` | Default model | Where to get key |
 |----------|------------|---------------|-----------------|
 | **Moonshot Kimi K2.5** | `kimi` | `kimi-k2.5` | [platform.moonshot.ai](https://platform.moonshot.ai) |
+| Z.AI GLM | `glm` | `glm-4.6v` | [api.z.ai](https://api.z.ai) |
 | Anthropic Claude | `anthropic` | `claude-haiku-4-5-20251001` | [console.anthropic.com](https://console.anthropic.com) |
 | Google Gemini | `gemini` | `gemini-2.5-flash` | [aistudio.google.com](https://aistudio.google.com) |
 | OpenAI | `openai` | `gpt-4o-mini` | [platform.openai.com](https://platform.openai.com) |
@@ -135,6 +138,14 @@ cp persona-template/en.md ME.md
 ```env
 PLATFORM=kimi
 API_KEY=sk-...   # from platform.moonshot.ai
+AGENT_NAME=Yukine
+```
+
+**Z.AI GLM `.env` example:**
+```env
+PLATFORM=glm
+API_KEY=...   # from api.z.ai
+MODEL=glm-4.6v   # vision-enabled; glm-4.7 / glm-5 = text-only
 AGENT_NAME=Yukine
 ```
 
@@ -287,6 +298,17 @@ The default (`TTS_OUTPUT=local`). Tries players in order: **paplay** → **mpv**
 | Windows | [mpv.io/installation](https://mpv.io/installation/) — download and add to PATH, **or** `winget install ffmpeg` |
 
 > If no audio player is available, speech is still generated — it just won't play.
+
+### Voice input (Realtime STT)
+
+Set `REALTIME_STT=true` in `.env` for always-on, hands-free voice input:
+
+```env
+REALTIME_STT=true
+ELEVENLABS_API_KEY=sk_...   # same key as TTS
+```
+
+familiar-ai streams microphone audio to ElevenLabs Scribe v2 and auto-commits transcripts when you pause speaking. No button press required. Coexists with the push-to-talk mode (Ctrl+T).
 
 ---
 


### PR DESCRIPTION
Updates all 6 README files (EN, JA, ZH, ZH-TW, FR, DE) to reflect recent additions:

**GLM backend (PR #53–55)**
- Added `glm` to PLATFORM options in configuration table
- Added Z.AI GLM row to LLM selection table (`glm-4.6v` default, vision-enabled)
- Added GLM `.env` example

**Realtime STT (PR #56–57)**
- Added 🎙 Listen to "What it can do" capabilities list
- Added `REALTIME_STT` to optional variables table
- Added "Voice input (Realtime STT)" subsection with setup instructions