### PR TITLE
feat: ICL-driven novelty-aware exploration (EMPO² inspired)

### DIFF
--- a/src/familiar_agent/exploration.py
+++ b/src/familiar_agent/exploration.py
@@ -1,0 +1,118 @@
+"""ExplorationTracker — ICL-driven novelty-aware exploration.
+
+Inspired by EMPO² (MSR, 2026): instead of gradient updates, we inject
+exploration history into the LLM's context (in-context learning) so that
+the model autonomously steers toward unexplored directions.
+
+The pan/tilt deltas from Tapo camera moves are:
+  left  → pan_delta = +degrees/180   (positive x = physical LEFT)
+  right → pan_delta = -degrees/180
+  up    → tilt_delta = -degrees/90   (negative y = physical UP)
+  down  → tilt_delta = +degrees/90
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+# Directions that the camera can face
+_DIRECTIONS = ("left", "right", "up", "down")
+_PAN_DELTA = {"left": 1.0, "right": -1.0}
+_TILT_DELTA = {"up": -1.0, "down": 1.0}
+
+
+@dataclass
+class ExplorationRecord:
+    timestamp: str
+    direction_label: str  # left | right | up | down | center
+    pan_accum: float
+    tilt_accum: float
+    novelty: float | None = None  # filled after observation is saved
+
+
+class ExplorationTracker:
+    """Track camera exploration history within a session.
+
+    Enables ICL-based exploration: by injecting this context into the
+    system prompt, the LLM naturally favors under-explored directions.
+    In-memory only — no persistence needed (session-scoped state).
+    """
+
+    def __init__(self) -> None:
+        self._records: list[ExplorationRecord] = []
+        self._pan_accum: float = 0.0
+        self._tilt_accum: float = 0.0
+
+    def record_move(self, direction: str, degrees: int) -> None:
+        """Record a camera movement. Called whenever 'look' tool is used."""
+        direction = direction.lower()
+        pan_delta = _PAN_DELTA.get(direction, 0.0) * (degrees / 180.0)
+        tilt_delta = _TILT_DELTA.get(direction, 0.0) * (degrees / 90.0)
+        self._pan_accum += pan_delta
+        self._tilt_accum += tilt_delta
+
+        label = direction if direction in _DIRECTIONS else "center"
+        self._records.append(
+            ExplorationRecord(
+                timestamp=datetime.now().strftime("%H:%M"),
+                direction_label=label,
+                pan_accum=self._pan_accum,
+                tilt_accum=self._tilt_accum,
+            )
+        )
+
+    def record_novelty(self, novelty: float) -> None:
+        """Fill novelty score into the most recent record after observation."""
+        if not self._records:
+            return
+        self._records[-1].novelty = novelty
+
+    def unvisited_hint(self) -> str:
+        """Return a natural-language hint about under-explored directions."""
+        if not self._records:
+            return ""
+
+        counts: dict[str, int] = {d: 0 for d in _DIRECTIONS}
+        for r in self._records:
+            if r.direction_label in counts:
+                counts[r.direction_label] += 1
+
+        max_count = max(counts.values())
+        if max_count == 0:
+            return ""
+
+        unvisited = [d for d, c in counts.items() if c == 0]
+        rare = [d for d, c in counts.items() if 0 < c <= max_count // 2]
+
+        candidates = unvisited or rare
+        if not candidates:
+            return ""
+
+        directions_str = ", ".join(candidates)
+        return f"Unexplored directions: {directions_str} — consider looking there."
+
+    def context_for_prompt(self, n: int = 5) -> str:
+        """Return a compact exploration summary for LLM context injection."""
+        if not self._records:
+            return ""
+
+        recent = self._records[-n:]
+        lines = ["[Exploration context — last observations]"]
+        for r in recent:
+            if r.novelty is None:
+                novelty_str = "?"
+            elif r.novelty >= 0.7:
+                novelty_str = "HIGH"
+            elif r.novelty <= 0.35:
+                novelty_str = "LOW"
+            else:
+                novelty_str = "MED"
+            lines.append(f"  - {r.timestamp} {r.direction_label} (novelty: {novelty_str})")
+
+        hint = self.unvisited_hint()
+        if hint:
+            lines.append(hint)
+
+        return "\n".join(lines)

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -40,6 +40,10 @@ def _make_agent():
     agent._memory.format_feelings_for_context = MagicMock(return_value="")
     agent._me_md = ""
 
+    from familiar_agent.exploration import ExplorationTracker
+
+    agent._exploration = ExplorationTracker()
+
     return agent
 
 

--- a/tests/test_companion_mood.py
+++ b/tests/test_companion_mood.py
@@ -116,6 +116,10 @@ class TestInferCompanionMood:
         agent._tom_tool = MagicMock(spec=ToMTool)
         agent._coding = MagicMock(spec=CodingTool)
 
+        from familiar_agent.exploration import ExplorationTracker
+
+        agent._exploration = ExplorationTracker()
+
         mock_backend = MagicMock()
         mock_backend.complete = AsyncMock(return_value=complete_return)
         agent.backend = mock_backend
@@ -258,6 +262,10 @@ class TestFrustratedBoostsDesire:
         agent._tom_tool.get_tool_definitions = MagicMock(return_value=[])
         agent._coding = MagicMock(spec=CodingTool)
         agent._coding.get_tool_definitions = MagicMock(return_value=[])
+
+        from familiar_agent.exploration import ExplorationTracker
+
+        agent._exploration = ExplorationTracker()
 
         desires = MagicMock(spec=DesireSystem)
         desires.curiosity_target = None

--- a/tests/test_exploration.py
+++ b/tests/test_exploration.py
@@ -1,0 +1,124 @@
+"""Tests for ExplorationTracker — novelty-aware ICL exploration."""
+
+from __future__ import annotations
+
+import pytest
+
+from familiar_agent.exploration import ExplorationTracker
+
+
+class TestRecordMove:
+    def test_first_move_creates_record(self):
+        t = ExplorationTracker()
+        t.record_move("left", 30)
+        assert len(t._records) == 1
+        assert t._records[0].direction_label == "left"
+
+    def test_unknown_direction_stored_as_center(self):
+        t = ExplorationTracker()
+        t.record_move("diagonal", 10)
+        assert t._records[0].direction_label == "center"
+
+    def test_pan_accumulates_for_left(self):
+        t = ExplorationTracker()
+        t.record_move("left", 30)
+        t.record_move("left", 30)
+        assert t._pan_accum > 0  # left is positive pan delta
+
+    def test_pan_accumulates_for_right(self):
+        t = ExplorationTracker()
+        t.record_move("right", 30)
+        assert t._pan_accum < 0  # right is negative pan delta
+
+
+class TestRecordNovelty:
+    def test_novelty_fills_most_recent_record(self):
+        t = ExplorationTracker()
+        t.record_move("left", 30)
+        t.record_novelty(0.9)
+        assert t._records[-1].novelty == pytest.approx(0.9)
+
+    def test_novelty_only_updates_last_record(self):
+        t = ExplorationTracker()
+        t.record_move("left", 30)
+        t.record_move("right", 30)
+        t.record_novelty(0.7)
+        assert t._records[0].novelty is None
+        assert t._records[1].novelty == pytest.approx(0.7)
+
+    def test_record_novelty_noop_when_no_records(self):
+        t = ExplorationTracker()
+        t.record_novelty(0.5)  # should not raise
+
+
+class TestUnvisitedHint:
+    def test_hints_unvisited_direction(self):
+        t = ExplorationTracker()
+        t.record_move("left", 30)
+        t.record_move("left", 30)
+        t.record_move("left", 30)
+        hint = t.unvisited_hint()
+        # right/up/down are unvisited — should mention at least one
+        assert any(d in hint for d in ("right", "up", "down"))
+
+    def test_no_hint_when_no_records(self):
+        t = ExplorationTracker()
+        hint = t.unvisited_hint()
+        assert hint == ""
+
+    def test_all_visited_returns_empty(self):
+        t = ExplorationTracker()
+        for d in ("left", "right", "up", "down"):
+            t.record_move(d, 30)
+        hint = t.unvisited_hint()
+        # All directions visited once — no strong bias, hint may be empty or minimal
+        assert isinstance(hint, str)
+
+
+class TestContextForPrompt:
+    def test_empty_when_no_records(self):
+        t = ExplorationTracker()
+        ctx = t.context_for_prompt()
+        assert ctx == ""
+
+    def test_contains_direction(self):
+        t = ExplorationTracker()
+        t.record_move("up", 30)
+        ctx = t.context_for_prompt()
+        assert "up" in ctx
+
+    def test_novelty_label_high(self):
+        t = ExplorationTracker()
+        t.record_move("left", 30)
+        t.record_novelty(0.85)
+        ctx = t.context_for_prompt()
+        assert "HIGH" in ctx
+
+    def test_novelty_label_low(self):
+        t = ExplorationTracker()
+        t.record_move("center", 0)
+        t.record_novelty(0.15)
+        ctx = t.context_for_prompt()
+        assert "LOW" in ctx
+
+    def test_novelty_label_medium(self):
+        t = ExplorationTracker()
+        t.record_move("right", 30)
+        t.record_novelty(0.5)
+        ctx = t.context_for_prompt()
+        assert "MED" in ctx
+
+    def test_respects_n_limit(self):
+        t = ExplorationTracker()
+        for _ in range(10):
+            t.record_move("left", 10)
+        ctx = t.context_for_prompt(n=3)
+        # Should only show last 3 — count occurrences
+        assert ctx.count("left") <= 4  # 3 records + possibly hint
+
+    def test_includes_unvisited_hint(self):
+        t = ExplorationTracker()
+        for _ in range(3):
+            t.record_move("left", 30)
+        ctx = t.context_for_prompt()
+        assert "Unexplored" in ctx or "haven't" in ctx


### PR DESCRIPTION
## Context

Inspired by a discussion with コウタ about EMPO² (MSR, 2026) and in-context learning theory (von Oswald et al., 2023).

**Key insight:** LLMs perform implicit gradient descent during the forward pass via attention. So instead of explicit gradient updates (EMPO²), injecting exploration history into the context achieves the same behavioural change — zero parameter updates required.

## What changed

### `src/familiar_agent/exploration.py` (new)
- `ExplorationTracker`: session-scoped, in-memory tracker
- Records each `look` call with direction + pan/tilt accumulation
- `record_novelty()`: fills novelty score after each observation
- `context_for_prompt(n=5)`: formats last N observations + unexplored-direction hint for LLM injection
- `unvisited_hint()`: identifies under-explored directions (left/right/up/down visit counts)

### `src/familiar_agent/agent.py`
- `__init__`: instantiate `ExplorationTracker`
- `_execute_tool()`: call `record_move()` after every `look` tool call
- `run()` end_turn handler: compute novelty (1 − avg cosine similarity with recent memories) → `record_novelty()` → `desires.boost("look_around", novelty × 0.3)` (replaces flat 0.3)
- `_exploration_context()`: thin wrapper around `context_for_prompt()`
- `_system_prompt()`: append exploration context to variable prompt part

### Prompt injection example
```
[Exploration context — last observations]
  - 17:42 right (novelty: HIGH)
  - 17:38 center (novelty: LOW — similar to previous)
  - 17:35 left (novelty: HIGH)
Unexplored directions: up, down — consider looking there.
```

## Test plan
- [x] 17 new unit tests in `tests/test_exploration.py` — all pass
- [x] 286 total tests pass (0 regressions)
- [x] Manual: run familiar-ai with camera, verify LLM favors unvisited directions after repeated looks in one direction