### PR TITLE
fix(windows): make uvloop conditional on non-Windows platforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "textual-autocomplete>=4.0.6",
     "mcp>=1.0.0",
     "google-generativeai>=0.8.6",
-    "uvloop>=0.22.1",
+    "uvloop>=0.22.1; sys_platform != 'win32'",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,7 @@ dependencies = [
     { name = "textual" },
     { name = "textual-autocomplete" },
     { name = "tinytuya" },
-    { name = "uvloop" },
+    { name = "uvloop", marker = "sys_platform != 'win32'" },
 ]
 
 [package.dev-dependencies]
@@ -649,7 +649,7 @@ requires-dist = [
     { name = "textual", specifier = ">=8.0.0" },
     { name = "textual-autocomplete", specifier = ">=4.0.6" },
     { name = "tinytuya", specifier = ">=1.15.0" },
-    { name = "uvloop", specifier = ">=0.22.1" },
+    { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.22.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- `uvloop` does not support Windows and fails to build with `RuntimeError: uvloop does not support Windows at the moment`
- Add `sys_platform != 'win32'` PEP 508 marker so uvloop is only installed on Linux / macOS / WSL2
- `main.py` already wraps `uvloop.install()` in a `try/except ImportError`, so Windows will fall back to the default asyncio event loop with no code changes needed

## Test plan

- [x] Verify `run.bat` installs and launches without errors on Windows
- [ ] Verify Linux/macOS still uses uvloop (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)