### PR TITLE
fix(tui): catch AttributeError for SIGQUIT on Windows

### DIFF
--- a/src/familiar_agent/tui.py
+++ b/src/familiar_agent/tui.py
@@ -233,8 +233,8 @@ class FamiliarApp(App):
             _signal.signal(_signal.SIGINT, lambda *_: os._exit(0))
             _signal.signal(_signal.SIGQUIT, lambda *_: os._exit(0))  # Ctrl+\
             _signal.signal(_signal.SIGTSTP, _signal.SIG_IGN)  # Ctrl+Z (ignore suspend)
-        except (OSError, ValueError):
-            pass  # Not in main thread (shouldn't happen, but guard anyway)
+        except (OSError, ValueError, AttributeError):
+            pass  # Not in main thread or signal not available on this OS (e.g. Windows)
 
         self.query_one("#input-bar", Input).focus()
         # Show startup banner


### PR DESCRIPTION
## Summary

- `SIGQUIT` does not exist on Windows, causing `AttributeError` on startup when running `run.bat`
- Fix: add `AttributeError` to the existing `except (OSError, ValueError)` clause

## Root cause

```
AttributeError: module 'signal' has no attribute 'SIGQUIT'
```

Windows only supports a subset of POSIX signals. The existing guard caught `OSError` and `ValueError` but not `AttributeError`, which is what Python raises when accessing a non-existent signal constant.

## Test plan

- [x] `run.bat` starts without traceback on Windows
- [x] `Ctrl+C` still exits cleanly on Linux/macOS (unaffected)