### PR TITLE
fix(ui): stabilize interrupt handling and add stress coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `src/familiar_agent/`: main application code. Key modules include `main.py` (entry point), `agent.py` (core loop), `tools/` (tool integrations), and `gui.py` / `tui.py` (interfaces).
+- `tests/`: pytest-based test suite. Follow existing `test_*.py` organization.
+- `benchmarks/`: benchmark scenarios and prompt sets.
+- `scripts/`: maintenance and automation scripts.
+- `persona-template/` and `readme-l10n/`: persona starter files and localized READMEs.
+- `dev/`: local helper commands for development workflows.
+
+## Build, Test, and Development Commands
+- `uv sync`: install project and dev dependencies from `pyproject.toml` / `uv.lock`.
+- `./run.sh` (Linux/macOS/WSL2) or `run.bat` (Windows): start the app.
+- `./run.sh --no-tui` or `run.bat --no-tui`: run in plain REPL mode.
+- `uv run ruff check .`: lint Python code.
+- `uv run ruff format .`: apply formatting.
+- `uv run --group dev mypy src/familiar_agent`: static type checks.
+- `uv run pytest -v`: run unit tests.
+- `uvx pre-commit install`: install local hooks (Ruff + Ruff format + mypy).
+
+## Coding Style & Naming Conventions
+- Target Python 3.10+.
+- Formatting/linting standard: Ruff, line length `100`.
+- Naming rules: modules/functions/variables in `snake_case`, classes in `PascalCase`, constants in `UPPER_SNAKE_CASE`.
+- Keep changes consistent with the existing async-first architecture (`asyncio` flows in agent/tool code).
+- Add type hints for new or modified public-facing functions.
+
+## Testing Guidelines
+- Frameworks: `pytest` and `pytest-asyncio`.
+- Test files: `tests/test_<feature>.py`; test names: `test_<behavior>`.
+- Add tests with each behavior change, especially around tool integrations, MCP client behavior, and UI callbacks.
+- There is no enforced coverage threshold in CI; maintain practical coverage for changed paths.
+
+## Commit & Pull Request Guidelines
+- Follow Conventional Commits, as used in history (for example: `feat(gui): ...`, `fix(windows): ...`).
+- Keep PRs focused and single-purpose.
+- Before opening a PR, run: Ruff check, Ruff format, mypy, and pytest.
+- Update `CHANGELOG.md` under `[Unreleased]` when behavior changes.
+- PR descriptions should include scope, testing performed, and linked issue context. Include screenshots/GIFs for GUI/TUI visual changes.

--- a/src/familiar_agent/_ui_helpers.py
+++ b/src/familiar_agent/_ui_helpers.py
@@ -3,6 +3,7 @@
 This module is the single source of truth for:
   - ACTION_ICONS: icon mapping for tool calls
   - format_action(): human-readable tool-call label
+  - should_fire_idle_desire(): shared gate for autonomous desire turns
   - desire_tick_prompt(): extract the current dominant desire prompt (UI-agnostic)
 
 Keeping these here prevents duplication across tui.py, gui.py, and main.py.
@@ -90,6 +91,22 @@ def format_action(name: str, tool_input: dict) -> str:
 
 IDLE_CHECK_INTERVAL: float = 10.0  # seconds between desire checks when idle
 DESIRE_COOLDOWN: float = 90.0  # seconds after last user interaction before desires fire
+
+
+def should_fire_idle_desire(
+    *,
+    agent_running: bool,
+    has_pending_input: bool,
+    last_interaction: float,
+    now: float,
+    cooldown: float = DESIRE_COOLDOWN,
+) -> bool:
+    """Return True when an autonomous desire turn is allowed to fire."""
+    if agent_running:
+        return False
+    if has_pending_input:
+        return False
+    return now - last_interaction >= cooldown
 
 
 def desire_tick_prompt(

--- a/src/familiar_agent/gui.py
+++ b/src/familiar_agent/gui.py
@@ -53,6 +53,7 @@ from ._ui_helpers import (
     IDLE_CHECK_INTERVAL,
     desire_tick_prompt,
     format_action,
+    should_fire_idle_desire,
 )
 
 if TYPE_CHECKING:
@@ -723,15 +724,19 @@ class FamiliarWindow(QMainWindow):
         self._desires = desires
         self._input_queue: asyncio.Queue[str | None] = asyncio.Queue()
         self._agent_running = False
+        self._closing = False
+        self._agent_task: asyncio.Task[str] | None = None
+        self._queue_task: asyncio.Task[None] | None = None
+        self._init_task: asyncio.Task[None] | None = None
 
         self.setWindowTitle("familiar-ai")
         self.resize(1020, 720)
         self.setStyleSheet(f"background: {_BG_BASE};")
         self._build_ui()
 
-        asyncio.ensure_future(self._process_queue())
+        self._queue_task = asyncio.create_task(self._process_queue())
         if not self._agent.is_embedding_ready:
-            asyncio.ensure_future(self._show_init_status())
+            self._init_task = asyncio.create_task(self._show_init_status())
 
     # ------------------------------------------------------------------
     # UI construction
@@ -894,20 +899,29 @@ class FamiliarWindow(QMainWindow):
             try:
                 text = await asyncio.wait_for(self._input_queue.get(), timeout=IDLE_CHECK_INTERVAL)
             except asyncio.TimeoutError:
-                if not self._agent_running and time.time() - last_interaction >= DESIRE_COOLDOWN:
-                    pending: list[str] = []
+                now = time.time()
+                if self._closing:
+                    continue
+                if not should_fire_idle_desire(
+                    agent_running=self._agent_running,
+                    has_pending_input=not self._input_queue.empty(),
+                    last_interaction=last_interaction,
+                    now=now,
+                    cooldown=DESIRE_COOLDOWN,
+                ):
+                    continue
+
+                tick = desire_tick_prompt(self._desires, [])
+                if tick:
+                    # If user input arrived meanwhile, prioritize that over autonomous desire.
                     if not self._input_queue.empty():
-                        item = self._input_queue.get_nowait()
-                        if item is not None:
-                            pending.append(item)
-                    tick = desire_tick_prompt(self._desires, pending)
-                    if tick:
-                        desire_name, prompt, _ = tick
-                        self._log.append_line(f"… {desire_name}")
-                        await self._run_agent("", inner_voice=prompt)
-                        self._desires.satisfy(desire_name)
-                        self._desires.curiosity_target = None
-                        last_interaction = time.time()
+                        continue
+                    desire_name, prompt, _ = tick
+                    self._log.append_line(f"… {desire_name}")
+                    await self._run_agent("", inner_voice=prompt)
+                    self._desires.satisfy(desire_name)
+                    self._desires.curiosity_target = None
+                    last_interaction = time.time()
                 continue
 
             if text is None:
@@ -917,7 +931,6 @@ class FamiliarWindow(QMainWindow):
 
     async def _run_agent(self, user_input: str, inner_voice: str = "") -> None:
         self._agent_running = True
-        self._send_btn.setEnabled(False)
 
         def on_text(chunk: str) -> None:
             self._stream.append_chunk(chunk)
@@ -932,15 +945,18 @@ class FamiliarWindow(QMainWindow):
             self._camera.update_image(b64)
 
         try:
-            final_text = await self._agent.run(
-                user_input,
-                on_action=on_action,
-                on_text=on_text,
-                on_image=on_image,
-                desires=self._desires,
-                inner_voice=inner_voice,
-                interrupt_queue=self._input_queue,
+            self._agent_task = asyncio.create_task(
+                self._agent.run(
+                    user_input,
+                    on_action=on_action,
+                    on_text=on_text,
+                    on_image=on_image,
+                    desires=self._desires,
+                    inner_voice=inner_voice,
+                    interrupt_queue=self._input_queue,
+                )
             )
+            final_text = await self._agent_task
             committed = self._stream.commit_and_clear()
             display = committed.strip() or final_text.strip()
             if display:
@@ -952,8 +968,8 @@ class FamiliarWindow(QMainWindow):
             logger.exception("Agent run error")
             self._log.append_line(f"[error] {exc}")
         finally:
+            self._agent_task = None
             self._agent_running = False
-            self._send_btn.setEnabled(True)
 
     async def _show_init_status(self) -> None:
         """Update window title with elapsed time until embedding model is ready."""
@@ -975,9 +991,28 @@ class FamiliarWindow(QMainWindow):
     # ------------------------------------------------------------------
 
     def closeEvent(self, event) -> None:  # type: ignore[override]
-        asyncio.ensure_future(self._agent.close())
+        self._closing = True
         self._input_queue.put_nowait(None)
+        if self._queue_task and not self._queue_task.done():
+            self._queue_task.cancel()
+        if self._init_task and not self._init_task.done():
+            self._init_task.cancel()
+        if self._agent_task and not self._agent_task.done():
+            self._agent_task.cancel()
+        asyncio.create_task(self._shutdown())
         event.accept()
+
+    async def _shutdown(self) -> None:
+        """Best-effort async cleanup on window close."""
+        try:
+            if self._agent_task and not self._agent_task.done():
+                try:
+                    await asyncio.wait_for(asyncio.shield(self._agent_task), timeout=1.0)
+                except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                    pass
+            await asyncio.wait_for(self._agent.close(), timeout=3.0)
+        except (asyncio.TimeoutError, Exception):
+            pass
 
 
 # ---------------------------------------------------------------------------

--- a/src/familiar_agent/main.py
+++ b/src/familiar_agent/main.py
@@ -19,6 +19,7 @@ from ._ui_helpers import (
     IDLE_CHECK_INTERVAL,
     desire_tick_prompt,
     format_action as _format_action,
+    should_fire_idle_desire,
 )
 
 
@@ -135,7 +136,13 @@ async def repl(agent: EmbodiedAgent, desires: DesireSystem, debug: bool = False)
 
             if queued_input is None and input_queue.empty():
                 # Genuine idle — check desires, but respect cooldown after conversation
-                if time.time() - last_interaction_time < DESIRE_COOLDOWN:
+                if not should_fire_idle_desire(
+                    agent_running=False,
+                    has_pending_input=not input_queue.empty(),
+                    last_interaction=last_interaction_time,
+                    now=time.time(),
+                    cooldown=DESIRE_COOLDOWN,
+                ):
                     continue  # Still in post-conversation cooldown
 
                 # Peek at any pending input before firing desire

--- a/src/familiar_agent/tui.py
+++ b/src/familiar_agent/tui.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import re
@@ -25,6 +26,7 @@ from ._ui_helpers import (
     IDLE_CHECK_INTERVAL as _IDLE_CHECK_INTERVAL,
     desire_tick_prompt,
     format_action as _format_action,
+    should_fire_idle_desire,
 )
 from .realtime_stt_session import create_realtime_stt_session, RealtimeSttSession
 
@@ -180,6 +182,7 @@ class FamiliarApp(App):
         self._recording = False
         self._stop_recording: asyncio.Event = asyncio.Event()
         self._last_toggle_listen: float = 0.0  # debounce Ctrl+T key-repeat
+        self._closing = False
         # ESC cancel support
         self._cancel_event: asyncio.Event = asyncio.Event()
         self._agent_task: asyncio.Task | None = None
@@ -256,15 +259,23 @@ class FamiliarApp(App):
         if self.agent.is_embedding_ready:
             return
         start = time.time()
-        stream: Static = self.query_one("#stream", Static)
-        while not self.agent.is_embedding_ready:
+        with contextlib.suppress(Exception):
+            stream: Static = self.query_one("#stream", Static)
+        if "stream" not in locals():
+            return
+        while not self.agent.is_embedding_ready and not self._closing:
             elapsed = int(time.time() - start)
-            stream.update(f"[dim]{_t('initializing')}... ({elapsed}s)[/dim]")
+            with contextlib.suppress(Exception):
+                stream.update(f"[dim]{_t('initializing')}... ({elapsed}s)[/dim]")
             await asyncio.sleep(0.5)
+        if self._closing:
+            return
         elapsed = int(time.time() - start)
-        stream.update(f"[dim]{_t('initializing_done')} ({elapsed}s)[/dim]")
+        with contextlib.suppress(Exception):
+            stream.update(f"[dim]{_t('initializing_done')} ({elapsed}s)[/dim]")
         await asyncio.sleep(2.0)
-        stream.update("")
+        with contextlib.suppress(Exception):
+            stream.update("")
 
     # ── logging helpers ────────────────────────────────────────────
 
@@ -328,6 +339,10 @@ class FamiliarApp(App):
     async def _process_queue(self) -> None:
         """Main loop: dequeue user messages and run agent."""
         while True:
+            if self._agent_running:
+                # Keep incoming input in queue so agent.run() can consume it via interrupt_queue.
+                await asyncio.sleep(0.05)
+                continue
             text = await self._input_queue.get()
             if text is None:
                 break
@@ -451,29 +466,42 @@ class FamiliarApp(App):
             self._write_log(f"[red]エラー: {e}[/red]")
         finally:
             watcher.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await watcher
             self._agent_task = None
             _stop_spinner()
+            if not spinner_task.done():
+                with contextlib.suppress(asyncio.TimeoutError):
+                    await asyncio.wait_for(spinner_task, timeout=0.2)
+            if not spinner_task.done():
+                spinner_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await spinner_task
             stream.update("")
             self._agent_running = False
 
     async def _desire_tick(self) -> None:
         """Check desires and fire autonomous actions when idle."""
-        if self._agent_running:
-            return
-        if not self._input_queue.empty():
-            return
-        if time.time() - self._last_interaction < DESIRE_COOLDOWN:
+        now = time.time()
+        if not should_fire_idle_desire(
+            agent_running=self._agent_running,
+            has_pending_input=not self._input_queue.empty(),
+            last_interaction=self._last_interaction,
+            now=now,
+            cooldown=DESIRE_COOLDOWN,
+        ):
             return
 
-        # Peek at pending input without removing it from the queue
-        pending_items: list[str] = []
-        if not self._input_queue.empty():
-            item = self._input_queue.get_nowait()
-            if item:
-                pending_items.append(item)
-
-        tick = desire_tick_prompt(self.desires, pending_items)
+        tick = desire_tick_prompt(self.desires, [])
         if tick is None:
+            return
+        if not should_fire_idle_desire(
+            agent_running=self._agent_running,
+            has_pending_input=not self._input_queue.empty(),
+            last_interaction=self._last_interaction,
+            now=time.time(),
+            cooldown=DESIRE_COOLDOWN,
+        ):
             return
 
         desire_name, prompt, _pending = tick
@@ -608,6 +636,7 @@ class FamiliarApp(App):
         self._stop_recording.set()
 
     async def action_quit(self) -> None:
+        self._closing = True
         try:
             self._input_queue.put_nowait(None)
             # Cancel the running agent task first (mirrors action_cancel_turn logic).

--- a/tests/test_tui_interrupt_stress.py
+++ b/tests/test_tui_interrupt_stress.py
@@ -1,0 +1,66 @@
+"""Stress tests for TUI interrupt handling under rapid input and ESC spam."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_app():
+    from familiar_agent.tui import FamiliarApp
+
+    agent = MagicMock()
+    agent.config.agent_name = "A"
+    agent.config.companion_name = "U"
+    desires = MagicMock()
+
+    with patch("familiar_agent.tui._make_banner", return_value=""):
+        return FamiliarApp(agent, desires)
+
+
+@pytest.mark.asyncio
+async def test_rapid_inputs_and_escape_spam_keep_inputs_for_processing():
+    """Rapid input during a running turn must remain queued for later processing."""
+    app = _make_app()
+
+    processed: list[str] = []
+
+    async def _fake_run_agent(text: str) -> None:
+        processed.append(text)
+        await asyncio.sleep(0)
+
+    app._run_agent = _fake_run_agent  # type: ignore[method-assign]
+    app._log_system = MagicMock()
+    app._agent_running = True
+    app._agent_task = asyncio.create_task(asyncio.sleep(10))
+
+    queue_worker = asyncio.create_task(app._process_queue())
+
+    burst = [f"msg-{i}" for i in range(25)]
+    for msg in burst:
+        await app._input_queue.put(msg)
+
+    # ESC spam while a turn is considered running.
+    for _ in range(30):
+        app.action_cancel_turn()
+
+    await asyncio.sleep(0.1)
+    assert processed == []
+    assert app._cancel_event.is_set()
+
+    # Let cancellation propagate to the dummy running task.
+    if app._agent_task:
+        try:
+            await app._agent_task
+        except asyncio.CancelledError:
+            pass
+
+    # Release queue processing and verify all queued inputs are processed in order.
+    app._agent_running = False
+    await asyncio.sleep(0.2)
+    await app._input_queue.put(None)
+    await asyncio.wait_for(queue_worker, timeout=2.0)
+
+    assert processed == burst

--- a/tests/test_tui_ptt.py
+++ b/tests/test_tui_ptt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 
@@ -66,7 +67,12 @@ class TestSpaceKeyBinding:
         app._log_system = MagicMock()
         app._recording = False
         app._ptt_active = False
-        app.run_worker = MagicMock()
+
+        def _consume_worker(coro, **_kwargs):
+            if asyncio.iscoroutine(coro):
+                coro.close()
+
+        app.run_worker = MagicMock(side_effect=_consume_worker)
         app.query_one = MagicMock(return_value=MagicMock())
 
         # action_start_ptt should set _ptt_active

--- a/tests/test_tui_stt_interrupt_stress.py
+++ b/tests/test_tui_stt_interrupt_stress.py
@@ -1,0 +1,105 @@
+"""Stress tests for TUI with realtime STT + rapid input + ESC spam."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class _ManualRealtimeStt:
+    """Minimal controllable realtime STT session stub for TUI tests."""
+
+    def __init__(self) -> None:
+        self.on_partial = None
+        self.on_committed = None
+        self._queue: asyncio.Queue[str | None] | None = None
+        self.started = False
+
+    async def start(self, _loop: asyncio.AbstractEventLoop, committed_queue) -> None:
+        self._queue = committed_queue
+        self.started = True
+
+    async def stop(self) -> None:
+        self.started = False
+
+    async def emit_committed(self, text: str) -> None:
+        assert self._queue is not None
+        if self.on_committed:
+            self.on_committed(text)
+        await self._queue.put(text)
+
+
+def _make_app():
+    from familiar_agent.tui import FamiliarApp
+
+    agent = MagicMock()
+    agent.config.agent_name = "A"
+    agent.config.companion_name = "U"
+    desires = MagicMock()
+
+    with patch("familiar_agent.tui._make_banner", return_value=""):
+        return FamiliarApp(agent, desires)
+
+
+@pytest.mark.asyncio
+async def test_stt_on_rapid_inputs_and_escape_spam_no_drop_no_crash():
+    """With STT ON, rapid typed+voice inputs should survive ESC spam while running."""
+    app = _make_app()
+    fake_stt = _ManualRealtimeStt()
+    app._realtime_stt = fake_stt  # type: ignore[assignment]
+
+    processed: list[str] = []
+
+    async def _fake_run_agent(text: str) -> None:
+        processed.append(text)
+        await asyncio.sleep(0)
+
+    app._run_agent = _fake_run_agent  # type: ignore[method-assign]
+    app._write_log = MagicMock()
+    fake_stream = MagicMock()
+    app.query_one = MagicMock(return_value=fake_stream)
+
+    await app._start_realtime_stt()
+    assert fake_stt.started
+
+    app._agent_running = True
+    app._agent_task = asyncio.create_task(asyncio.sleep(10))
+    queue_worker = asyncio.create_task(app._process_queue())
+
+    burst = [
+        ("typed", "typed-0"),
+        ("stt", "voice-0"),
+        ("typed", "typed-1"),
+        ("stt", "voice-1"),
+        ("typed", "typed-2"),
+        ("stt", "voice-2"),
+    ]
+
+    for source, text in burst:
+        if source == "typed":
+            await app._input_queue.put(text)
+        else:
+            await fake_stt.emit_committed(text)
+
+    for _ in range(40):
+        app.action_cancel_turn()
+
+    await asyncio.sleep(0.1)
+    assert app._cancel_event.is_set()
+    assert processed == []
+
+    if app._agent_task:
+        try:
+            await app._agent_task
+        except asyncio.CancelledError:
+            pass
+
+    app._agent_running = False
+    await asyncio.sleep(0.2)
+    await app._input_queue.put(None)
+    await asyncio.wait_for(queue_worker, timeout=2.0)
+
+    expected = [text for _, text in burst]
+    assert processed == expected

--- a/tests/test_ui_helpers.py
+++ b/tests/test_ui_helpers.py
@@ -11,6 +11,7 @@ from familiar_agent._ui_helpers import (
     ACTION_ICONS,
     desire_tick_prompt,
     format_action,
+    should_fire_idle_desire,
 )
 
 
@@ -174,3 +175,46 @@ class TestDesireTickPrompt:
         assert result is not None
         desire_name, _, _ = result
         assert desire_name == "unknown_desire_xyz"
+
+
+# ---------------------------------------------------------------------------
+# should_fire_idle_desire tests
+# ---------------------------------------------------------------------------
+
+
+class TestShouldFireIdleDesire:
+    def test_false_while_agent_running(self):
+        assert not should_fire_idle_desire(
+            agent_running=True,
+            has_pending_input=False,
+            last_interaction=0.0,
+            now=999.0,
+            cooldown=90.0,
+        )
+
+    def test_false_with_pending_input(self):
+        assert not should_fire_idle_desire(
+            agent_running=False,
+            has_pending_input=True,
+            last_interaction=0.0,
+            now=999.0,
+            cooldown=90.0,
+        )
+
+    def test_false_before_cooldown(self):
+        assert not should_fire_idle_desire(
+            agent_running=False,
+            has_pending_input=False,
+            last_interaction=100.0,
+            now=150.0,
+            cooldown=90.0,
+        )
+
+    def test_true_after_cooldown(self):
+        assert should_fire_idle_desire(
+            agent_running=False,
+            has_pending_input=False,
+            last_interaction=100.0,
+            now=190.0,
+            cooldown=90.0,
+        )


### PR DESCRIPTION
## Summary
- harden GUI/TUI async handling around interrupt queues and shutdown
- prevent autonomous desire ticks from consuming pending user input
- centralize idle-desire gate logic in `_ui_helpers.should_fire_idle_desire()` and reuse in GUI/TUI/REPL
- add stress tests for rapid input + ESC spam and STT+ESC mixed bursts
- add `AGENTS.md` contributor guide

## Validation
- `uv run ruff check src/familiar_agent/_ui_helpers.py src/familiar_agent/gui.py src/familiar_agent/main.py src/familiar_agent/tui.py tests/test_ui_helpers.py tests/test_tui_interrupt_stress.py tests/test_tui_stt_interrupt_stress.py tests/test_tui_ptt.py`
- `uv run pytest -q tests/test_tui_stt_interrupt_stress.py tests/test_tui_interrupt_stress.py tests/test_tui_*.py tests/test_ui_helpers.py tests/test_gui_callbacks.py`
- pre-commit hooks during commit: ruff / ruff-format / mypy all passed
