### PR TITLE
feat(gui): harden async lifecycle, cancellation, and stability metrics

### DIFF
--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -25,6 +25,21 @@ from ._i18n import _t
 logger = logging.getLogger(__name__)
 
 MAX_ITERATIONS = 50
+_DEFAULT_TOOL_TIMEOUT = 20.0
+_TOOL_TIMEOUTS: dict[str, float] = {
+    "see": 12.0,
+    "look": 8.0,
+    "walk": 12.0,
+    "say": 25.0,
+    "remember": 20.0,
+    "recall": 20.0,
+    "tom": 20.0,
+    "read_file": 30.0,
+    "edit_file": 30.0,
+    "glob": 20.0,
+    "grep": 20.0,
+    "bash": 45.0,
+}
 
 SYSTEM_PROMPT = """
 (agent :type embodied
@@ -456,6 +471,23 @@ class EmbodiedAgent:
             return await self._mcp.call(name, tool_input)
         else:
             return f"Tool '{name}' not available (check configuration).", None
+
+    @staticmethod
+    def _tool_timeout_seconds(name: str) -> float:
+        """Return per-tool timeout budget in seconds."""
+        return _TOOL_TIMEOUTS.get(name, _DEFAULT_TOOL_TIMEOUT)
+
+    @staticmethod
+    def _drain_interrupt_queue(
+        interrupt_queue: asyncio.Queue[str | None], max_items: int = 6
+    ) -> list[str]:
+        """Drain pending user interrupts, preserving queue order."""
+        interrupts: list[str] = []
+        while len(interrupts) < max_items and not interrupt_queue.empty():
+            item = interrupt_queue.get_nowait()
+            if item:
+                interrupts.append(item)
+        return interrupts
 
     def _load_me_md(self) -> str:
         """Load ME.md personality file if it exists."""
@@ -975,8 +1007,17 @@ class EmbodiedAgent:
                     if on_action:
                         on_action(tc.name, tc.input)
 
+                    timeout_s = self._tool_timeout_seconds(tc.name)
                     try:
-                        text, image = await self._execute_tool(tc.name, tc.input)
+                        text, image = await asyncio.wait_for(
+                            self._execute_tool(tc.name, tc.input), timeout=timeout_s
+                        )
+                    except asyncio.TimeoutError:
+                        logger.warning("Tool %s timed out after %.1fs", tc.name, timeout_s)
+                        text, image = (
+                            f"Tool timeout: {tc.name} exceeded {timeout_s:.1f}s.",
+                            None,
+                        )
                     except Exception as e:
                         logger.warning("Tool %s failed: %s", tc.name, e)
                         text, image = f"Tool error: {e}", None
@@ -1008,11 +1049,15 @@ class EmbodiedAgent:
 
                 # Check for user interrupt (typed while agent was busy)
                 if interrupt_queue is not None and not interrupt_queue.empty():
-                    interrupt = interrupt_queue.get_nowait()
-                    if interrupt:
+                    interrupts = self._drain_interrupt_queue(interrupt_queue)
+                    if interrupts:
+                        head = " / ".join(interrupts[:3])
+                        if len(interrupts) > 3:
+                            head += f" (+{len(interrupts) - 3} more)"
+                        logger.debug("Consumed %d queued interrupts", len(interrupts))
                         self.messages.append(
                             self.backend.make_user_message(
-                                f"[User interrupted]: {interrupt}. "
+                                f"[User interrupted x{len(interrupts)}]: {head}. "
                                 "Respond to this directly with say() now."
                             )
                         )

--- a/src/familiar_agent/gui.py
+++ b/src/familiar_agent/gui.py
@@ -20,6 +20,7 @@ import asyncio
 import base64
 import html as _html
 import logging
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -94,6 +95,9 @@ _DESIRE_COLORS: dict[str, str] = {
 
 # Flush streamed text at most this often (ms)
 _STREAM_FLUSH_INTERVAL_MS = 50
+_GUI_LOOP_LAG_CHECK_SEC = 1.0
+_GUI_LOOP_LAG_WARN_SEC = 0.35
+_GUI_QUEUE_WARN_SIZE = 20
 
 # Resolve .env path: project root, then cwd fallback
 _ENV_PATH: Path = Path(__file__).resolve().parents[2] / ".env"
@@ -725,9 +729,18 @@ class FamiliarWindow(QMainWindow):
         self._input_queue: asyncio.Queue[str | None] = asyncio.Queue()
         self._agent_running = False
         self._closing = False
+        self._shutdown_requested = False
+        self._shutdown_done = False
+        self._shutdown_task: asyncio.Task[None] | None = None
+        self._cancel_requested = False
         self._agent_task: asyncio.Task[str] | None = None
         self._queue_task: asyncio.Task[None] | None = None
         self._init_task: asyncio.Task[None] | None = None
+        self._last_lag_tick = time.perf_counter()
+        self._lag_timer = QTimer(self)
+        self._lag_timer.setInterval(int(_GUI_LOOP_LAG_CHECK_SEC * 1000))
+        self._lag_timer.timeout.connect(self._report_event_loop_lag)
+        self._lag_timer.start()
 
         self.setWindowTitle("familiar-ai")
         self.resize(1020, 720)
@@ -836,6 +849,28 @@ class FamiliarWindow(QMainWindow):
         )
         self._send_btn.clicked.connect(self._on_send)
         input_row.addWidget(self._send_btn)
+
+        self._stop_btn = QPushButton("■")
+        self._stop_btn.setFixedSize(44, 44)
+        self._stop_btn.setObjectName("stopBtn")
+        self._stop_btn.setToolTip("Cancel current turn (Esc)")
+        self._stop_btn.setStyleSheet(
+            f"QPushButton#stopBtn {{"
+            f" background: rgba(230,57,70,0.20);"
+            f" border-radius: 22px; border: 1px solid rgba(230,57,70,0.45);"
+            f" font-size: 14px; color: #ff7b86;"
+            f"}}"
+            f"QPushButton#stopBtn:hover {{"
+            f" background: rgba(230,57,70,0.28); color: #ff9aa3;"
+            f"}}"
+            f"QPushButton#stopBtn:disabled {{"
+            f" background: rgba(255,255,255,0.04); color: {_TEXT_SECONDARY};"
+            f" border-color: rgba(255,255,255,0.08);"
+            f"}}"
+        )
+        self._stop_btn.setEnabled(False)
+        self._stop_btn.clicked.connect(self._on_cancel_clicked)
+        input_row.addWidget(self._stop_btn)
         left_layout.addLayout(input_row)
 
         # ── Right panel ─────────────────────────────────────────
@@ -885,6 +920,38 @@ class FamiliarWindow(QMainWindow):
         self._input.clear()
         self._log.append_line(f"[You] {text}")
         self._input_queue.put_nowait(text)
+        qsize = self._input_queue.qsize()
+        if qsize >= _GUI_QUEUE_WARN_SIZE:
+            logger.warning("GUI input queue backlog: %d", qsize)
+        else:
+            logger.debug("GUI input queued (size=%d)", qsize)
+
+    def _on_cancel_clicked(self) -> None:
+        self._cancel_turn(reason="user")
+
+    def keyPressEvent(self, event) -> None:  # type: ignore[override]
+        if event.key() == Qt.Key.Key_Escape:
+            self._cancel_turn(reason="user")
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+    def _cancel_turn(self, reason: str = "user") -> None:
+        """Cancel current turn if running.
+
+        reason: "user" (explicit cancel) or "shutdown" (window/app exit).
+        """
+        if not self._agent_running:
+            return
+        self._cancel_requested = True
+        if self._agent_task and not self._agent_task.done():
+            self._agent_task.cancel()
+        if reason == "user":
+            self._log.append_line("[interrupted]")
+        logger.info("GUI turn cancel requested (%s), queue=%d", reason, self._input_queue.qsize())
+
+    def _set_turn_ui_state(self, running: bool) -> None:
+        self._stop_btn.setEnabled(running)
 
     # ------------------------------------------------------------------
     # Agent loop
@@ -892,8 +959,6 @@ class FamiliarWindow(QMainWindow):
 
     async def _process_queue(self) -> None:
         """Dequeue user messages and run the agent; fire desires when idle."""
-        import time
-
         last_interaction = time.time()
         while True:
             try:
@@ -927,10 +992,24 @@ class FamiliarWindow(QMainWindow):
             if text is None:
                 break
             last_interaction = time.time()
+            logger.debug(
+                "GUI dequeued input (remaining queue=%d, running=%s)",
+                self._input_queue.qsize(),
+                self._agent_running,
+            )
             await self._run_agent(text)
 
     async def _run_agent(self, user_input: str, inner_voice: str = "") -> None:
+        turn_started = time.perf_counter()
         self._agent_running = True
+        self._cancel_requested = False
+        self._set_turn_ui_state(True)
+        logger.info(
+            "GUI turn start (user_input=%d chars, inner_voice=%s, queue=%d)",
+            len(user_input),
+            bool(inner_voice),
+            self._input_queue.qsize(),
+        )
 
         def on_text(chunk: str) -> None:
             self._stream.append_chunk(chunk)
@@ -963,18 +1042,25 @@ class FamiliarWindow(QMainWindow):
                 self._log.append_line(f"[Agent] {display}")
         except asyncio.CancelledError:
             self._stream.commit_and_clear()
-            self._log.append_line("[interrupted]")
+            if not self._cancel_requested:
+                self._log.append_line("[interrupted]")
         except Exception as exc:
             logger.exception("Agent run error")
             self._log.append_line(f"[error] {exc}")
         finally:
             self._agent_task = None
             self._agent_running = False
+            self._set_turn_ui_state(False)
+            logger.info(
+                "GUI turn end (duration=%.2fs, cancelled=%s, queue=%d)",
+                time.perf_counter() - turn_started,
+                self._cancel_requested,
+                self._input_queue.qsize(),
+            )
+            self._cancel_requested = False
 
     async def _show_init_status(self) -> None:
         """Update window title with elapsed time until embedding model is ready."""
-        import time
-
         if self._agent.is_embedding_ready:
             return
         start = time.time()
@@ -991,19 +1077,53 @@ class FamiliarWindow(QMainWindow):
     # ------------------------------------------------------------------
 
     def closeEvent(self, event) -> None:  # type: ignore[override]
+        if self._shutdown_done:
+            event.accept()
+            return
+        if self._shutdown_requested:
+            event.ignore()
+            return
+        self._shutdown_requested = True
         self._closing = True
+        self.setEnabled(False)
+        self.setWindowTitle("familiar-ai  ⏳ shutting down...")
+        self._ensure_shutdown_task()
+        event.ignore()
+
+    def _ensure_shutdown_task(self) -> asyncio.Task[None]:
+        if self._shutdown_task and not self._shutdown_task.done():
+            return self._shutdown_task
+        self._shutdown_task = asyncio.create_task(self._shutdown())
+        self._shutdown_task.add_done_callback(lambda _task: self._finalize_close())
+        return self._shutdown_task
+
+    def _finalize_close(self) -> None:
+        if not self._shutdown_done:
+            return
+        self.close()
+
+    def _report_event_loop_lag(self) -> None:
+        now = time.perf_counter()
+        elapsed = now - self._last_lag_tick
+        self._last_lag_tick = now
+        lag = elapsed - _GUI_LOOP_LAG_CHECK_SEC
+        if lag > _GUI_LOOP_LAG_WARN_SEC:
+            logger.warning(
+                "GUI event-loop lag detected: %.3fs (queue=%d running=%s)",
+                lag,
+                self._input_queue.qsize(),
+                self._agent_running,
+            )
+
+    async def _shutdown(self) -> None:
+        """Best-effort async cleanup on window close."""
+        self._lag_timer.stop()
+        self._cancel_turn(reason="shutdown")
         self._input_queue.put_nowait(None)
         if self._queue_task and not self._queue_task.done():
             self._queue_task.cancel()
         if self._init_task and not self._init_task.done():
             self._init_task.cancel()
-        if self._agent_task and not self._agent_task.done():
-            self._agent_task.cancel()
-        asyncio.create_task(self._shutdown())
-        event.accept()
-
-    async def _shutdown(self) -> None:
-        """Best-effort async cleanup on window close."""
         try:
             if self._agent_task and not self._agent_task.done():
                 try:
@@ -1013,6 +1133,7 @@ class FamiliarWindow(QMainWindow):
             await asyncio.wait_for(self._agent.close(), timeout=3.0)
         except (asyncio.TimeoutError, Exception):
             pass
+        self._shutdown_done = True
 
 
 # ---------------------------------------------------------------------------
@@ -1033,6 +1154,7 @@ def run_gui(agent: "EmbodiedAgent", desires: "DesireSystem") -> None:
 
     window = FamiliarWindow(agent, desires)
     window.show()
+    qt_app.aboutToQuit.connect(window._ensure_shutdown_task)
 
     with loop:
         loop.run_forever()

--- a/tests/test_gui_async_stability.py
+++ b/tests/test_gui_async_stability.py
@@ -1,0 +1,124 @@
+"""Regression tests for GUI async stability (burst input, cancel, shutdown)."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from familiar_agent.gui import FamiliarWindow
+
+
+class _FakeCloseEvent:
+    def __init__(self) -> None:
+        self.accepted = False
+        self.ignored = False
+
+    def accept(self) -> None:
+        self.accepted = True
+
+    def ignore(self) -> None:
+        self.ignored = True
+
+
+def _make_window_stub() -> FamiliarWindow:
+    win = FamiliarWindow.__new__(FamiliarWindow)
+    win._input_queue = asyncio.Queue()
+    win._agent_running = False
+    win._closing = False
+    win._shutdown_requested = False
+    win._shutdown_done = False
+    win._shutdown_task = None
+    win._cancel_requested = False
+    win._agent_task = None
+    win._queue_task = None
+    win._init_task = None
+    win._desires = MagicMock()
+    win._log = MagicMock()
+    win._send_btn = MagicMock()
+    win._stop_btn = MagicMock()
+    win._lag_timer = MagicMock()
+    win._last_lag_tick = time.perf_counter()
+    win.setEnabled = MagicMock()
+    win.setWindowTitle = MagicMock()
+    win.close = MagicMock()
+    return win
+
+
+@pytest.mark.asyncio
+async def test_gui_process_queue_handles_burst_in_order():
+    win = _make_window_stub()
+    processed: list[str] = []
+
+    async def _fake_run_agent(text: str, inner_voice: str = "") -> None:
+        assert inner_voice == ""
+        processed.append(text)
+        await asyncio.sleep(0)
+
+    win._run_agent = _fake_run_agent  # type: ignore[method-assign]
+
+    burst = [f"msg-{i}" for i in range(30)]
+    for msg in burst:
+        await win._input_queue.put(msg)
+    await win._input_queue.put(None)
+
+    await asyncio.wait_for(FamiliarWindow._process_queue(win), timeout=1.0)
+    assert processed == burst
+
+
+@pytest.mark.asyncio
+async def test_gui_cancel_turn_cancels_running_task_and_logs():
+    win = _make_window_stub()
+    win._agent_running = True
+    win._agent_task = asyncio.create_task(asyncio.sleep(10))
+
+    FamiliarWindow._cancel_turn(win, reason="user")
+    assert win._cancel_requested is True
+    win._log.append_line.assert_called_with("[interrupted]")
+
+    if win._agent_task:
+        with contextlib.suppress(asyncio.CancelledError):
+            await win._agent_task
+        assert win._agent_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_gui_close_event_waits_shutdown_before_accepting():
+    win = _make_window_stub()
+
+    async def _fake_shutdown() -> None:
+        await asyncio.sleep(0)
+        win._shutdown_done = True
+
+    win._shutdown = _fake_shutdown  # type: ignore[method-assign]
+
+    first = _FakeCloseEvent()
+    FamiliarWindow.closeEvent(win, first)
+    assert first.ignored is True
+    assert win._shutdown_requested is True
+    assert win._closing is True
+    assert win._shutdown_task is not None
+
+    await asyncio.wait_for(win._shutdown_task, timeout=1.0)
+    await asyncio.sleep(0)
+    win.close.assert_called_once()
+
+    second = _FakeCloseEvent()
+    FamiliarWindow.closeEvent(win, second)
+    assert second.accepted is True
+
+
+def test_gui_event_loop_lag_warning_emits_log(caplog: pytest.LogCaptureFixture):
+    win = _make_window_stub()
+    win._agent_running = True
+    win._last_lag_tick = time.perf_counter() - 2.0
+    win._input_queue.put_nowait("pending")
+
+    with caplog.at_level(logging.WARNING):
+        FamiliarWindow._report_event_loop_lag(win)
+
+    assert "event-loop lag detected" in caplog.text


### PR DESCRIPTION
## Summary
- add explicit GUI cancellation UX and behavior
  - stop button in the input row
  - `Esc` key cancellation path
  - running-turn cancellation now cancels the active agent task deterministically
- harden GUI shutdown lifecycle
  - defer close until async cleanup finishes
  - wire `aboutToQuit` to ensure async shutdown task is scheduled
- add GUI runtime stability metrics
  - queue backlog logging on enqueue/dequeue
  - per-turn duration logging
  - event-loop lag watchdog logging
- harden agent execution loop
  - per-tool timeout budgets via `asyncio.wait_for`
  - drain multiple interrupt-queue entries instead of consuming only one
- add GUI async regression tests
  - burst input order preservation
  - cancel path cancellation correctness
  - close/shutdown flow
  - event-loop lag warning emission

## Validation
- `uv run ruff check src/familiar_agent/gui.py src/familiar_agent/agent.py tests/test_gui_async_stability.py`
- `uv run --group dev mypy src/familiar_agent`
- `uv run pytest -q tests/test_gui_async_stability.py tests/test_gui_callbacks.py tests/test_tui_interrupt_stress.py tests/test_tui_stt_interrupt_stress.py tests/test_tui_*.py tests/test_ui_helpers.py`

## Notes
- Running the full suite (`uv run pytest -q`) currently shows existing failures in `tests/test_compaction.py` and `tests/test_companion_mood.py` unrelated to this change set.
