### PR TITLE
feat(memory): add startup SQLite migrations and async memory job pipeline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,17 @@ uv run pytest -v           # tests
 
 All three must pass cleanly.
 
+## Database migrations
+
+When changing SQLite schema/data, add a new migration script under `migration/`.
+
+```bash
+scripts/new_migration.sh add_memory_jobs_table
+# => migration/YYYY-MM-DD-XXX_add_memory_jobs_table.py
+```
+
+Then implement `upgrade(conn)` in the generated file. Migrations are applied automatically at startup and tracked in `schema_migrations`.
+
 ## Commit messages
 
 Use [Conventional Commits](https://www.conventionalcommits.org/) in **English**:

--- a/migration/2026-03-03-001_observations_baseline.py
+++ b/migration/2026-03-03-001_observations_baseline.py
@@ -1,0 +1,51 @@
+"""Create and backfill the baseline observations schema."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(str(r[1]) == column for r in rows)
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS observations (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            timestamp TEXT NOT NULL,
+            date TEXT NOT NULL,
+            time TEXT NOT NULL,
+            direction TEXT NOT NULL DEFAULT 'unknown',
+            kind TEXT NOT NULL DEFAULT 'observation',
+            emotion TEXT NOT NULL DEFAULT 'neutral',
+            image_path TEXT,
+            image_data TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS obs_embeddings (
+            obs_id TEXT PRIMARY KEY REFERENCES observations(id) ON DELETE CASCADE,
+            vector BLOB NOT NULL
+        )
+        """
+    )
+
+    # Existing users may already have observations without newer columns.
+    for col, definition in [
+        ("kind", "TEXT NOT NULL DEFAULT 'observation'"),
+        ("emotion", "TEXT NOT NULL DEFAULT 'neutral'"),
+        ("image_path", "TEXT"),
+        ("image_data", "TEXT"),
+    ]:
+        if not _has_column(conn, "observations", col):
+            conn.execute(f"ALTER TABLE observations ADD COLUMN {col} {definition}")
+
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_obs_timestamp ON observations(timestamp)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_obs_date ON observations(date)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_obs_kind ON observations(kind)")

--- a/migration/2026-03-03-002_memory_events_jobs.py
+++ b/migration/2026-03-03-002_memory_events_jobs.py
@@ -1,0 +1,57 @@
+"""Add durable event log + async memory job queue tables."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memory_events (
+            event_id TEXT PRIMARY KEY,
+            created_at TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            dedupe_key TEXT,
+            payload_json TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_events_dedupe
+        ON memory_events(dedupe_key)
+        WHERE dedupe_key IS NOT NULL
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_events_created_at ON memory_events(created_at)"
+    )
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memory_jobs (
+            job_id TEXT PRIMARY KEY,
+            event_id TEXT NOT NULL REFERENCES memory_events(event_id) ON DELETE CASCADE,
+            job_type TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            attempts INTEGER NOT NULL DEFAULT 0,
+            available_at TEXT NOT NULL,
+            last_error TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_jobs_event_type
+        ON memory_jobs(event_id, job_type)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_memory_jobs_status_available
+        ON memory_jobs(status, available_at)
+        """
+    )

--- a/scripts/new_migration.sh
+++ b/scripts/new_migration.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Create a new SQLite migration script.
+
+Usage:
+  scripts/new_migration.sh <name> [--date YYYY-MM-DD] [--dir migration]
+
+Examples:
+  scripts/new_migration.sh add_memory_index
+  scripts/new_migration.sh "add memory jobs table" --date 2026-03-03
+EOF
+}
+
+name=""
+migration_date="$(date +%F)"
+migration_dir="migration"
+
+while (($#)); do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --date)
+      shift
+      if (($# == 0)); then
+        echo "missing value for --date" >&2
+        exit 1
+      fi
+      migration_date="$1"
+      ;;
+    --dir)
+      shift
+      if (($# == 0)); then
+        echo "missing value for --dir" >&2
+        exit 1
+      fi
+      migration_dir="$1"
+      ;;
+    --*)
+      echo "unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      if [[ -n "$name" ]]; then
+        echo "multiple names provided: '$name' and '$1'" >&2
+        usage
+        exit 1
+      fi
+      name="$1"
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "$name" ]]; then
+  echo "migration name is required" >&2
+  usage
+  exit 1
+fi
+
+if [[ ! "$migration_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  echo "invalid --date format: $migration_date (expected YYYY-MM-DD)" >&2
+  exit 1
+fi
+
+slug="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
+if [[ -z "$slug" ]]; then
+  slug="migration"
+fi
+
+mkdir -p "$migration_dir"
+
+max_seq=0
+shopt -s nullglob
+for path in "$migration_dir/${migration_date}-"*.py; do
+  base="$(basename "$path")"
+  if [[ "$base" =~ ^${migration_date}-([0-9]{3})(_[a-z0-9_]+)?\.py$ ]]; then
+    seq="${BASH_REMATCH[1]}"
+    seq_num=$((10#$seq))
+    if ((seq_num > max_seq)); then
+      max_seq=$seq_num
+    fi
+  fi
+done
+shopt -u nullglob
+
+next_seq="$(printf '%03d' "$((max_seq + 1))")"
+target="$migration_dir/${migration_date}-${next_seq}_${slug}.py"
+
+if [[ -e "$target" ]]; then
+  echo "refusing to overwrite existing file: $target" >&2
+  exit 1
+fi
+
+cat > "$target" <<'PY'
+"""TODO: describe migration."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    """Apply schema/data changes."""
+    # Example:
+    # conn.execute("CREATE TABLE example (id INTEGER PRIMARY KEY)")
+    pass
+PY
+
+echo "$target"

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -12,6 +12,7 @@ from .backend import create_backend, create_utility_backend
 from .config import AgentConfig
 from .desires import detect_worry_signal
 from .exploration import ExplorationTracker
+from .memory_worker import MemoryJobWorker
 from .tape import check_plan_blocked, generate_plan, generate_replan
 from .tools.camera import CameraTool
 from .tools.coding import CodingTool
@@ -376,6 +377,7 @@ class EmbodiedAgent:
         self._stt: STTTool | None = None
         self._me_md: str = self._load_me_md()  # loaded once; restart to pick up changes
         self._memory = ObservationMemory()
+        self._memory_worker = MemoryJobWorker(self._memory)
         self._memory_tool = MemoryTool(self._memory)
         self._tom_tool = ToMTool(self._memory, default_person=config.companion_name)
         self._coding = CodingTool(config.coding)
@@ -703,6 +705,7 @@ class EmbodiedAgent:
                     kind="day_summary",
                     emotion="neutral",
                     override_date=date,
+                    materialize_now=False,
                 )
                 logger.info("Day summary generated for %s: %s", date, summary[:80])
             else:
@@ -727,7 +730,11 @@ class EmbodiedAgent:
             )
             if insight and insight.lower() != "nothing":
                 await self._memory.save_async(
-                    insight, direction="内省", kind="self_model", emotion=emotion
+                    insight,
+                    direction="内省",
+                    kind="self_model",
+                    emotion=emotion,
+                    materialize_now=False,
                 )
                 logger.info("Self-model updated: %s", insight[:60])
         except Exception as e:
@@ -816,6 +823,12 @@ class EmbodiedAgent:
                 await self._generate_day_summary(today)
             except Exception as e:
                 logger.warning("Failed to generate today's day summary on shutdown: %s", e)
+        memory_worker = getattr(self, "_memory_worker", None)
+        if memory_worker:
+            try:
+                await asyncio.wait_for(memory_worker.stop(), timeout=1.5)
+            except (asyncio.TimeoutError, Exception):
+                pass
         if self._mcp:
             try:
                 await asyncio.wait_for(self._mcp.stop(), timeout=2.0)
@@ -845,6 +858,9 @@ class EmbodiedAgent:
         # Start MCP connections on first turn (lazy, idempotent)
         if self._mcp and not self._mcp.is_started:
             await self._mcp.start()
+        memory_worker = getattr(self, "_memory_worker", None)
+        if memory_worker and not memory_worker.is_running:
+            await memory_worker.start()
 
         # First turn: morning reconstruction — bridge yesterday's self to today's
         morning_ctx = ""
@@ -958,7 +974,11 @@ class EmbodiedAgent:
                     emotion = await self._infer_emotion(final_text)
                     summary = await self._summarize_exchange(user_input, final_text)
                     await self._memory.save_async(
-                        summary, direction="会話", kind="conversation", emotion=emotion
+                        summary,
+                        direction="会話",
+                        kind="conversation",
+                        emotion=emotion,
+                        materialize_now=False,
                     )
 
                     # Update self-model when something actually moved us (Conway's working self)
@@ -987,7 +1007,11 @@ class EmbodiedAgent:
                         desires.boost("look_around", 0.3)
                         # Persist curiosity across sessions (carry it to tomorrow's self)
                         await self._memory.save_async(
-                            curiosity, direction="好奇心", kind="curiosity", emotion="curious"
+                            curiosity,
+                            direction="好奇心",
+                            kind="curiosity",
+                            emotion="curious",
+                            materialize_now=False,
                         )
                         logger.info("Curiosity persisted: %s", curiosity)
 

--- a/src/familiar_agent/memory_worker.py
+++ b/src/familiar_agent/memory_worker.py
@@ -1,0 +1,89 @@
+"""Background worker for durable memory jobs."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from .tools.memory import ObservationMemory
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class MemoryWorkerConfig:
+    poll_interval_sec: float = 0.5
+    batch_size: int = 8
+    retry_delay_sec: float = 10.0
+    max_attempts: int = 3
+
+
+class MemoryJobWorker:
+    """Executes pending jobs from ObservationMemory.memory_jobs."""
+
+    def __init__(self, memory: ObservationMemory, config: MemoryWorkerConfig | None = None) -> None:
+        self._memory = memory
+        self._config = config or MemoryWorkerConfig()
+        self._task: asyncio.Task[None] | None = None
+
+    @property
+    def is_running(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    async def start(self) -> None:
+        """Start the worker loop if not already running."""
+        if self.is_running:
+            return
+        self._task = asyncio.create_task(self._run_loop(), name="memory-job-worker")
+
+    async def stop(self) -> None:
+        """Stop the worker loop and wait for cancellation."""
+        if not self._task:
+            return
+        self._task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+
+    async def run_once(self) -> int:
+        """Claim and process one batch of jobs. Returns processed job count."""
+        jobs = await asyncio.to_thread(self._memory.claim_pending_jobs, self._config.batch_size)
+        for job in jobs:
+            job_id = str(job["job_id"])
+            try:
+                await self._process_job(job)
+                await asyncio.to_thread(self._memory.mark_job_done, job_id)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                status = await asyncio.to_thread(
+                    self._memory.mark_job_failed,
+                    job_id,
+                    str(e),
+                    self._config.retry_delay_sec,
+                    self._config.max_attempts,
+                )
+                logger.warning("Memory job failed (job_id=%s, status=%s): %s", job_id, status, e)
+        return len(jobs)
+
+    async def _run_loop(self) -> None:
+        while True:
+            processed = await self.run_once()
+            sleep_s = 0.0 if processed > 0 else max(self._config.poll_interval_sec, 0.05)
+            await asyncio.sleep(sleep_s)
+
+    async def _process_job(self, job: dict[str, Any]) -> None:
+        job_type = str(job.get("job_type", ""))
+        event_id = str(job.get("event_id", ""))
+        if not event_id:
+            raise RuntimeError("memory job missing event_id")
+
+        if job_type != "materialize_observation":
+            raise RuntimeError(f"unsupported memory job_type: {job_type}")
+
+        ok = await asyncio.to_thread(self._memory.materialize_event, event_id)
+        if not ok:
+            raise RuntimeError(f"failed to materialize event: {event_id}")

--- a/src/familiar_agent/sqlite_migrations.py
+++ b/src/familiar_agent/sqlite_migrations.py
@@ -1,0 +1,109 @@
+"""Simple timestamped SQLite migration runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import os
+import re
+import sqlite3
+from pathlib import Path
+from types import ModuleType
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+_MIGRATIONS_TABLE = "schema_migrations"
+
+
+def default_migration_dir() -> Path:
+    """Return the first existing `migration/` directory found upwards."""
+    env = os.getenv("FAMILIAR_AI_MIGRATION_DIR")
+    if env:
+        return Path(env).expanduser()
+
+    cwd_dir = Path.cwd() / "migration"
+    if cwd_dir.exists():
+        return cwd_dir
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "migration"
+        if candidate.exists():
+            return candidate
+    return Path("migration")
+
+
+def _ensure_migrations_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_MIGRATIONS_TABLE} (
+            id TEXT PRIMARY KEY,
+            applied_at TEXT NOT NULL
+        )
+        """
+    )
+
+
+def _applied_ids(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute(f"SELECT id FROM {_MIGRATIONS_TABLE}").fetchall()
+    return {str(r[0]) for r in rows}
+
+
+def _load_migration_module(path: Path) -> ModuleType:
+    module_name = "migration_" + re.sub(r"[^a-zA-Z0-9_]", "_", path.stem)
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if not spec or not spec.loader:
+        raise RuntimeError(f"Could not load migration: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _get_upgrade_fn(module: ModuleType, path: Path) -> Callable[[sqlite3.Connection], None]:
+    upgrade = getattr(module, "upgrade", None)
+    if not callable(upgrade):
+        raise RuntimeError(f"Migration missing upgrade(conn): {path}")
+    return upgrade
+
+
+def apply_migrations(conn: sqlite3.Connection, migration_dir: Path | None = None) -> int:
+    """Apply pending migration scripts from `migration/*.py` in lexical order."""
+    mig_dir = migration_dir or default_migration_dir()
+    _ensure_migrations_table(conn)
+
+    if not mig_dir.exists():
+        logger.warning("Migration directory not found: %s", mig_dir)
+        return 0
+
+    files = sorted(p for p in mig_dir.glob("*.py") if p.is_file() and not p.name.startswith("_"))
+    if not files:
+        logger.warning("No migration scripts found in: %s", mig_dir)
+        return 0
+
+    applied = _applied_ids(conn)
+    applied_count = 0
+
+    for path in files:
+        migration_id = path.stem
+        if migration_id in applied:
+            continue
+
+        module = _load_migration_module(path)
+        upgrade = _get_upgrade_fn(module, path)
+        try:
+            conn.execute("BEGIN")
+            upgrade(conn)
+            conn.execute(
+                f"INSERT INTO {_MIGRATIONS_TABLE} (id, applied_at) VALUES (?, datetime('now'))",
+                (migration_id,),
+            )
+            conn.commit()
+            applied.add(migration_id)
+            applied_count += 1
+            logger.info("Applied migration: %s", migration_id)
+        except Exception:
+            conn.rollback()
+            logger.exception("Failed migration: %s", migration_id)
+            raise
+
+    return applied_count

--- a/src/familiar_agent/tools/memory.py
+++ b/src/familiar_agent/tools/memory.py
@@ -10,43 +10,22 @@ Architecture inspired by memory-mcp (Phase 11: SQLite+numpy).
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import sqlite3
 import threading
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 import numpy as np
+from ..sqlite_migrations import apply_migrations, default_migration_dir
 
 logger = logging.getLogger(__name__)
 
 DB_PATH = str(Path.home() / ".familiar_ai" / "observations.db")
 EMBEDDING_MODEL = "intfloat/multilingual-e5-small"
-
-_DDL = """
-CREATE TABLE IF NOT EXISTS observations (
-    id TEXT PRIMARY KEY,
-    content TEXT NOT NULL,
-    timestamp TEXT NOT NULL,
-    date TEXT NOT NULL,
-    time TEXT NOT NULL,
-    direction TEXT NOT NULL DEFAULT 'unknown',
-    kind TEXT NOT NULL DEFAULT 'observation',
-    emotion TEXT NOT NULL DEFAULT 'neutral',
-    image_path TEXT,
-    image_data TEXT
-);
-CREATE INDEX IF NOT EXISTS idx_obs_timestamp ON observations(timestamp);
-CREATE INDEX IF NOT EXISTS idx_obs_date ON observations(date);
-CREATE INDEX IF NOT EXISTS idx_obs_kind ON observations(kind);
-
-CREATE TABLE IF NOT EXISTS obs_embeddings (
-    obs_id TEXT PRIMARY KEY REFERENCES observations(id) ON DELETE CASCADE,
-    vector BLOB NOT NULL
-);
-"""
 
 _THUMB_SIZE = (320, 240)
 
@@ -188,24 +167,272 @@ class ObservationMemory:
             self._db.execute("PRAGMA journal_mode = WAL")
             self._db.execute("PRAGMA synchronous = NORMAL")
             self._db.execute("PRAGMA foreign_keys = ON")
-            for stmt in _DDL.strip().split(";"):
-                stmt = stmt.strip()
-                if stmt:
-                    self._db.execute(stmt)
-            # Add columns if upgrading from old schema
-            for col, definition in [
-                ("kind", "TEXT NOT NULL DEFAULT 'observation'"),
-                ("emotion", "TEXT NOT NULL DEFAULT 'neutral'"),
-                ("image_path", "TEXT"),
-                ("image_data", "TEXT"),
-            ]:
-                try:
-                    self._db.execute(f"ALTER TABLE observations ADD COLUMN {col} {definition}")
-                    self._db.commit()
-                except Exception:
-                    pass
+            apply_migrations(self._db, default_migration_dir())
             self._db.commit()
         return self._db
+
+    @staticmethod
+    def _now_iso() -> str:
+        return datetime.now().isoformat()
+
+    @staticmethod
+    def _serialize_event_payload(payload: dict[str, Any]) -> str:
+        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+    def _enqueue_memory_job_locked(
+        self,
+        db: sqlite3.Connection,
+        event_id: str,
+        job_type: str,
+        now_iso: str,
+    ) -> bool:
+        """Insert a pending job for an event. Returns False when duplicate."""
+        try:
+            db.execute(
+                "INSERT INTO memory_jobs "
+                "(job_id, event_id, job_type, status, attempts, available_at, last_error, created_at, updated_at) "
+                "VALUES (?, ?, ?, 'pending', 0, ?, NULL, ?, ?)",
+                (str(uuid.uuid4()), event_id, job_type, now_iso, now_iso, now_iso),
+            )
+            return True
+        except sqlite3.IntegrityError:
+            return False
+
+    def append_memory_event(
+        self,
+        event_type: str,
+        payload: dict[str, Any],
+        dedupe_key: str | None = None,
+        queue_job: bool = True,
+        job_type: str = "materialize_observation",
+    ) -> tuple[str | None, bool]:
+        """Append a durable memory event and optional pending job.
+
+        Returns:
+            (event_id, created_new). If dedupe_key matches an existing event,
+            created_new is False and the existing event_id is returned.
+        """
+        now_iso = self._now_iso()
+        payload_json = self._serialize_event_payload(payload)
+        try:
+            with self._db_lock:
+                db = self._ensure_connected()
+                if dedupe_key:
+                    row = db.execute(
+                        "SELECT event_id FROM memory_events WHERE dedupe_key = ?",
+                        (dedupe_key,),
+                    ).fetchone()
+                    if row:
+                        event_id = str(row["event_id"])
+                        if queue_job:
+                            self._enqueue_memory_job_locked(db, event_id, job_type, now_iso)
+                        db.commit()
+                        return event_id, False
+
+                event_id = str(uuid.uuid4())
+                db.execute(
+                    "INSERT INTO memory_events (event_id, created_at, event_type, dedupe_key, payload_json) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (event_id, now_iso, event_type, dedupe_key, payload_json),
+                )
+                if queue_job:
+                    self._enqueue_memory_job_locked(db, event_id, job_type, now_iso)
+                db.commit()
+                return event_id, True
+        except Exception as e:
+            logger.warning("Failed to append memory event (%s): %s", event_type, e)
+            return None, False
+
+    async def append_memory_event_async(
+        self,
+        event_type: str,
+        payload: dict[str, Any],
+        dedupe_key: str | None = None,
+        queue_job: bool = True,
+        job_type: str = "materialize_observation",
+    ) -> tuple[str | None, bool]:
+        return await asyncio.to_thread(
+            self.append_memory_event,
+            event_type,
+            payload,
+            dedupe_key,
+            queue_job,
+            job_type,
+        )
+
+    def claim_pending_jobs(self, limit: int = 10) -> list[dict[str, Any]]:
+        """Claim pending memory jobs and mark them as running."""
+        now_iso = self._now_iso()
+        claimed: list[dict[str, Any]] = []
+        with self._db_lock:
+            db = self._ensure_connected()
+            rows = db.execute(
+                "SELECT j.job_id, j.event_id, j.job_type, j.attempts, "
+                "e.event_type, e.payload_json "
+                "FROM memory_jobs j JOIN memory_events e ON e.event_id = j.event_id "
+                "WHERE j.status = 'pending' AND j.available_at <= ? "
+                "ORDER BY j.created_at ASC LIMIT ?",
+                (now_iso, limit),
+            ).fetchall()
+            for row in rows:
+                updated = db.execute(
+                    "UPDATE memory_jobs SET status = 'running', attempts = attempts + 1, updated_at = ? "
+                    "WHERE job_id = ? AND status = 'pending'",
+                    (now_iso, row["job_id"]),
+                )
+                if updated.rowcount != 1:
+                    continue
+                payload: dict[str, Any]
+                try:
+                    payload = json.loads(row["payload_json"])
+                except Exception:
+                    payload = {"raw_payload": row["payload_json"]}
+                claimed.append(
+                    {
+                        "job_id": row["job_id"],
+                        "event_id": row["event_id"],
+                        "job_type": row["job_type"],
+                        "attempts": int(row["attempts"]) + 1,
+                        "event_type": row["event_type"],
+                        "payload": payload,
+                    }
+                )
+            db.commit()
+        return claimed
+
+    def mark_job_done(self, job_id: str) -> bool:
+        """Mark a running job as done."""
+        now_iso = self._now_iso()
+        with self._db_lock:
+            db = self._ensure_connected()
+            updated = db.execute(
+                "UPDATE memory_jobs SET status = 'done', updated_at = ?, last_error = NULL "
+                "WHERE job_id = ?",
+                (now_iso, job_id),
+            )
+            db.commit()
+            return updated.rowcount == 1
+
+    def mark_job_failed(
+        self,
+        job_id: str,
+        error: str,
+        retry_delay_sec: float = 10.0,
+        max_attempts: int = 3,
+    ) -> str:
+        """Mark a running job as pending retry or dead_letter.
+
+        Returns the resulting status: 'pending', 'dead_letter', or 'missing'.
+        """
+        now = datetime.now()
+        now_iso = now.isoformat()
+        with self._db_lock:
+            db = self._ensure_connected()
+            row = db.execute(
+                "SELECT attempts FROM memory_jobs WHERE job_id = ?",
+                (job_id,),
+            ).fetchone()
+            if row is None:
+                return "missing"
+
+            attempts = int(row["attempts"])
+            if attempts >= max_attempts:
+                status = "dead_letter"
+                available_at = now_iso
+            else:
+                status = "pending"
+                available_at = (now + timedelta(seconds=max(retry_delay_sec, 0.0))).isoformat()
+
+            db.execute(
+                "UPDATE memory_jobs SET status = ?, available_at = ?, last_error = ?, updated_at = ? "
+                "WHERE job_id = ?",
+                (status, available_at, error[:500], now_iso, job_id),
+            )
+            db.commit()
+            return status
+
+    def _materialize_memory_save_event(self, event_id: str, payload: dict[str, Any]) -> bool:
+        """Materialize a memory.save payload into observations + embeddings."""
+        content = str(payload.get("content", "")).strip()
+        if not content:
+            logger.warning("memory.save event missing content (event_id=%s)", event_id)
+            return False
+
+        direction = str(payload.get("direction", "unknown"))
+        kind = str(payload.get("kind", "observation"))
+        emotion = str(payload.get("emotion", "neutral"))
+        image_path = payload.get("image_path")
+        override_date = payload.get("override_date")
+
+        # Compute embedding and thumbnail outside lock (CPU/IO)
+        image_data = _encode_image(image_path) if image_path else None
+        vec = self._embedder.encode_document([content])[0]
+        blob = _encode_vector(vec)
+        now = datetime.now()
+        if override_date:
+            save_date = str(override_date)
+            save_time = "23:59"
+            save_timestamp = f"{save_date}T23:59:59"
+        else:
+            save_date = now.strftime("%Y-%m-%d")
+            save_time = now.strftime("%H:%M")
+            save_timestamp = now.isoformat()
+
+        with self._db_lock:
+            db = self._ensure_connected()
+            exists = db.execute(
+                "SELECT 1 FROM observations WHERE id = ?",
+                (event_id,),
+            ).fetchone()
+            if exists:
+                return True
+            db.execute(
+                "INSERT INTO observations "
+                "(id, content, timestamp, date, time, direction, kind, emotion, image_path, image_data) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    event_id,
+                    content,
+                    save_timestamp,
+                    save_date,
+                    save_time,
+                    direction,
+                    kind,
+                    emotion,
+                    image_path,
+                    image_data,
+                ),
+            )
+            db.execute(
+                "INSERT INTO obs_embeddings (obs_id, vector) VALUES (?, ?)",
+                (event_id, blob),
+            )
+            db.commit()
+        return True
+
+    def materialize_event(self, event_id: str) -> bool:
+        """Materialize an event into queryable memory rows."""
+        try:
+            with self._db_lock:
+                db = self._ensure_connected()
+                row = db.execute(
+                    "SELECT event_type, payload_json FROM memory_events WHERE event_id = ?",
+                    (event_id,),
+                ).fetchone()
+            if row is None:
+                logger.warning("No memory event found for event_id=%s", event_id)
+                return False
+
+            payload = json.loads(row["payload_json"])
+            event_type = row["event_type"]
+            if event_type == "memory.save":
+                return self._materialize_memory_save_event(event_id, payload)
+
+            logger.warning("Unsupported memory event type: %s", event_type)
+            return False
+        except Exception as e:
+            logger.warning("Failed to materialize event %s: %s", event_id, e)
+            return False
 
     def save(
         self,
@@ -215,6 +442,8 @@ class ObservationMemory:
         emotion: str = "neutral",
         image_path: str | None = None,
         override_date: str | None = None,
+        dedupe_key: str | None = None,
+        materialize_now: bool = True,
     ) -> bool:
         """Save memory with embedding synchronously.
 
@@ -226,48 +455,42 @@ class ObservationMemory:
             image_path: Optional path to image file (thumbnail stored as base64).
             override_date: If set, use this date (YYYY-MM-DD) instead of now.
                            Useful for backfilling day summaries for past dates.
+            dedupe_key: Optional idempotency key. When an event with the same key
+                        already exists, this write is treated as already processed.
+            materialize_now: If False, enqueue a durable job and return immediately.
+                             If event append fails, falls back to immediate save.
         """
         try:
-            # Compute embedding and image outside lock (CPU/IO, no DB access)
-            image_data = _encode_image(image_path) if image_path else None
-            vec = self._embedder.encode_document([content])[0]
-            blob = _encode_vector(vec)
-            now = datetime.now()
-            obs_id = str(uuid.uuid4())
-
-            if override_date:
-                save_date = override_date
-                save_time = "23:59"
-                save_timestamp = f"{override_date}T23:59:59"
-            else:
-                save_date = now.strftime("%Y-%m-%d")
-                save_time = now.strftime("%H:%M")
-                save_timestamp = now.isoformat()
-
-            with self._db_lock:
-                db = self._ensure_connected()
-                db.execute(
-                    "INSERT INTO observations "
-                    "(id, content, timestamp, date, time, direction, kind, emotion, image_path, image_data) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (
-                        obs_id,
-                        content,
-                        save_timestamp,
-                        save_date,
-                        save_time,
-                        direction,
-                        kind,
-                        emotion,
-                        image_path,
-                        image_data,
-                    ),
+            event_payload = {
+                "content": content,
+                "direction": direction,
+                "kind": kind,
+                "emotion": emotion,
+                "image_path": image_path,
+                "override_date": override_date,
+            }
+            try:
+                event_id, created_new = self.append_memory_event(
+                    "memory.save",
+                    event_payload,
+                    dedupe_key=dedupe_key,
+                    queue_job=True,
+                    job_type="materialize_observation",
                 )
-                db.execute(
-                    "INSERT INTO obs_embeddings (obs_id, vector) VALUES (?, ?)",
-                    (obs_id, blob),
-                )
-                db.commit()
+            except Exception as e:
+                logger.warning("Failed to record memory event (continuing): %s", e)
+                event_id, created_new = None, False
+            if dedupe_key and event_id and not created_new:
+                logger.info("Deduped memory.save event for key=%s", dedupe_key)
+                return True
+
+            if not materialize_now and event_id:
+                logger.debug("Queued memory.save event %s for async materialization", event_id)
+                return True
+
+            obs_id = event_id or str(uuid.uuid4())
+            if not self._materialize_memory_save_event(obs_id, event_payload):
+                return False
             logger.info("Saved %s (%s): %s...", kind, emotion, content[:60])
             return True
         except Exception as e:
@@ -477,9 +700,19 @@ class ObservationMemory:
         emotion: str = "neutral",
         image_path: str | None = None,
         override_date: str | None = None,
+        dedupe_key: str | None = None,
+        materialize_now: bool = True,
     ) -> bool:
         return await asyncio.to_thread(
-            self.save, content, direction, kind, emotion, image_path, override_date
+            self.save,
+            content,
+            direction,
+            kind,
+            emotion,
+            image_path,
+            override_date,
+            dedupe_key,
+            materialize_now,
         )
 
     async def recall_async(self, query: str, n: int = 3, kind: str | None = None) -> list[dict]:

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -30,6 +30,7 @@ def _make_agent():
     agent.backend = MagicMock()
     agent.backend.complete = AsyncMock(return_value="summary text")
     agent.backend.make_user_message = lambda t: _make_msg("user", t)
+    agent._utility_backend = agent.backend
 
     agent._memory = MagicMock()
     agent._memory.recall_async = AsyncMock(return_value=[])

--- a/tests/test_companion_mood.py
+++ b/tests/test_companion_mood.py
@@ -112,6 +112,7 @@ class TestInferCompanionMood:
         from familiar_agent.tools.coding import CodingTool
 
         agent._memory = MagicMock(spec=ObservationMemory)
+        agent._memory.recall_day_summaries_async = AsyncMock(return_value=[])
         agent._memory_tool = MagicMock(spec=MemoryTool)
         agent._tom_tool = MagicMock(spec=ToMTool)
         agent._coding = MagicMock(spec=CodingTool)
@@ -123,6 +124,7 @@ class TestInferCompanionMood:
         mock_backend = MagicMock()
         mock_backend.complete = AsyncMock(return_value=complete_return)
         agent.backend = mock_backend
+        agent._utility_backend = mock_backend
 
         return agent
 
@@ -212,6 +214,7 @@ class TestFrustratedBoostsDesire:
         agent._memory.recent_feelings_async = AsyncMock(return_value=[])
         agent._memory.recall_self_model_async = AsyncMock(return_value=[])
         agent._memory.recall_curiosities_async = AsyncMock(return_value=[])
+        agent._memory.recall_day_summaries_async = AsyncMock(return_value=[])
         agent._memory.save_async = AsyncMock(return_value=True)
         agent._memory.format_for_context = MagicMock(return_value="")
         agent._memory.format_feelings_for_context = MagicMock(return_value="")
@@ -235,6 +238,7 @@ class TestFrustratedBoostsDesire:
         )
 
         agent.backend = mock_backend
+        agent._utility_backend = mock_backend
         agent.config = MagicMock()
         agent.config.max_tokens = 512
         agent.config.companion_name = "Kouta"

--- a/tests/test_memory_event_log.py
+++ b/tests/test_memory_event_log.py
@@ -1,0 +1,108 @@
+"""Tests for append-only memory event log and pending job queue."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from unittest.mock import patch
+
+from familiar_agent.tools.memory import ObservationMemory, _EmbeddingModel
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_save_appends_event_and_pending_job(tmp_path) -> None:
+    db_path = str(tmp_path / "memory_events.db")
+    with (
+        patch.object(_EmbeddingModel, "pre_warm"),
+        patch.object(_EmbeddingModel, "encode_document", return_value=[[0.1, 0.2, 0.3]]),
+    ):
+        mem = ObservationMemory(db_path=db_path)
+        assert mem.save("hello world", kind="conversation", emotion="curious")
+        mem.close()
+
+    with _connect(db_path) as conn:
+        event = conn.execute(
+            "SELECT event_id, event_type, payload_json FROM memory_events"
+        ).fetchone()
+        assert event is not None
+        assert event["event_type"] == "memory.save"
+
+        payload = json.loads(event["payload_json"])
+        assert payload["content"] == "hello world"
+        assert payload["kind"] == "conversation"
+        assert payload["emotion"] == "curious"
+
+        job = conn.execute(
+            "SELECT job_type, status, attempts FROM memory_jobs WHERE event_id = ?",
+            (event["event_id"],),
+        ).fetchone()
+        assert job is not None
+        assert job["job_type"] == "materialize_observation"
+        assert job["status"] == "pending"
+        assert job["attempts"] == 0
+
+
+def test_save_with_dedupe_key_is_idempotent(tmp_path) -> None:
+    db_path = str(tmp_path / "memory_dedupe.db")
+    with (
+        patch.object(_EmbeddingModel, "pre_warm"),
+        patch.object(_EmbeddingModel, "encode_document", return_value=[[0.1, 0.2, 0.3]]),
+    ):
+        mem = ObservationMemory(db_path=db_path)
+        assert mem.save("same payload", kind="conversation", dedupe_key="turn-1-conversation")
+        assert mem.save("same payload", kind="conversation", dedupe_key="turn-1-conversation")
+        mem.close()
+
+    with _connect(db_path) as conn:
+        event_count = conn.execute("SELECT COUNT(*) FROM memory_events").fetchone()[0]
+        job_count = conn.execute("SELECT COUNT(*) FROM memory_jobs").fetchone()[0]
+        observation_count = conn.execute("SELECT COUNT(*) FROM observations").fetchone()[0]
+
+    assert event_count == 1
+    assert job_count == 1
+    assert observation_count == 1
+
+
+def test_save_can_enqueue_without_immediate_materialization(tmp_path) -> None:
+    db_path = str(tmp_path / "memory_async_queue.db")
+    with (
+        patch.object(_EmbeddingModel, "pre_warm"),
+        patch.object(_EmbeddingModel, "encode_document", return_value=[[0.1, 0.2, 0.3]]),
+    ):
+        mem = ObservationMemory(db_path=db_path)
+        assert mem.save("queued only", kind="conversation", materialize_now=False)
+        mem.close()
+
+    with _connect(db_path) as conn:
+        event_count = conn.execute("SELECT COUNT(*) FROM memory_events").fetchone()[0]
+        job_row = conn.execute("SELECT status FROM memory_jobs").fetchone()
+        observation_count = conn.execute("SELECT COUNT(*) FROM observations").fetchone()[0]
+
+    assert event_count == 1
+    assert job_row is not None
+    assert job_row["status"] == "pending"
+    assert observation_count == 0
+
+
+def test_save_continues_when_event_append_fails(tmp_path) -> None:
+    db_path = str(tmp_path / "memory_fail_open.db")
+    with (
+        patch.object(_EmbeddingModel, "pre_warm"),
+        patch.object(_EmbeddingModel, "encode_document", return_value=[[0.1, 0.2, 0.3]]),
+    ):
+        mem = ObservationMemory(db_path=db_path)
+        with patch.object(mem, "append_memory_event", side_effect=RuntimeError("boom")):
+            assert mem.save("still stored despite event failure")
+        mem.close()
+
+    with _connect(db_path) as conn:
+        event_count = conn.execute("SELECT COUNT(*) FROM memory_events").fetchone()[0]
+        observation_count = conn.execute("SELECT COUNT(*) FROM observations").fetchone()[0]
+
+    assert event_count == 0
+    assert observation_count == 1

--- a/tests/test_memory_migrations.py
+++ b/tests/test_memory_migrations.py
@@ -1,0 +1,95 @@
+"""Tests for automatic SQLite schema migrations on startup."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+from familiar_agent.tools.memory import ObservationMemory, _EmbeddingModel
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return {str(r["name"]) for r in rows}
+
+
+def test_auto_applies_migrations_on_first_connect(tmp_path) -> None:
+    db_path = str(tmp_path / "auto_migrate.db")
+    expected_ids = {p.stem for p in (Path.cwd() / "migration").glob("*.py")}
+
+    with patch.object(_EmbeddingModel, "pre_warm"):
+        mem = ObservationMemory(db_path=db_path)
+        mem.append_memory_event("memory.save", {"content": "x"}, queue_job=False)
+        mem.close()
+
+    with _connect(db_path) as conn:
+        applied = {
+            str(r["id"]) for r in conn.execute("SELECT id FROM schema_migrations").fetchall()
+        }
+        tables = {
+            str(r["name"])
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        }
+
+    assert expected_ids.issubset(applied)
+    assert {"observations", "obs_embeddings", "memory_events", "memory_jobs"}.issubset(tables)
+
+
+def test_migrates_legacy_observations_schema(tmp_path) -> None:
+    db_path = str(tmp_path / "legacy_schema.db")
+    with _connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE observations (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                date TEXT NOT NULL,
+                time TEXT NOT NULL,
+                direction TEXT NOT NULL DEFAULT 'unknown'
+            )
+            """
+        )
+        conn.commit()
+
+    with patch.object(_EmbeddingModel, "pre_warm"):
+        mem = ObservationMemory(db_path=db_path)
+        mem.append_memory_event("memory.save", {"content": "x"}, queue_job=False)
+        mem.close()
+
+    with _connect(db_path) as conn:
+        cols = _columns(conn, "observations")
+        applied = {
+            str(r["id"]) for r in conn.execute("SELECT id FROM schema_migrations").fetchall()
+        }
+
+    for name in ("kind", "emotion", "image_path", "image_data"):
+        assert name in cols
+    assert "2026-03-03-001_observations_baseline" in applied
+
+
+def test_migrations_are_idempotent_across_restarts(tmp_path) -> None:
+    db_path = str(tmp_path / "idempotent.db")
+    with patch.object(_EmbeddingModel, "pre_warm"):
+        mem = ObservationMemory(db_path=db_path)
+        mem.append_memory_event("memory.save", {"content": "first"}, queue_job=False)
+        mem.close()
+
+        with _connect(db_path) as conn:
+            count_first = conn.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0]
+
+        mem2 = ObservationMemory(db_path=db_path)
+        mem2.append_memory_event("memory.save", {"content": "second"}, queue_job=False)
+        mem2.close()
+
+    with _connect(db_path) as conn:
+        count_second = conn.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0]
+
+    assert count_second == count_first

--- a/tests/test_memory_worker.py
+++ b/tests/test_memory_worker.py
@@ -1,0 +1,85 @@
+"""Tests for background memory job worker."""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+from familiar_agent.memory_worker import MemoryJobWorker, MemoryWorkerConfig
+from familiar_agent.tools.memory import ObservationMemory, _EmbeddingModel
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_worker_materializes_memory_save_jobs(tmp_path) -> None:
+    db_path = str(tmp_path / "worker_ok.db")
+    with (
+        patch.object(_EmbeddingModel, "pre_warm"),
+        patch.object(_EmbeddingModel, "encode_document", return_value=[[0.1, 0.2, 0.3]]),
+    ):
+        mem = ObservationMemory(db_path=db_path)
+        payload = {
+            "content": "queued memory",
+            "direction": "unknown",
+            "kind": "conversation",
+            "emotion": "neutral",
+            "image_path": None,
+            "override_date": None,
+        }
+        event_id, created = mem.append_memory_event("memory.save", payload, queue_job=True)
+        assert created is True
+        assert event_id is not None
+
+        worker = MemoryJobWorker(mem, MemoryWorkerConfig(batch_size=4, retry_delay_sec=0.0))
+        processed = await worker.run_once()
+        assert processed == 1
+        mem.close()
+
+    with _connect(db_path) as conn:
+        obs = conn.execute("SELECT content FROM observations WHERE id = ?", (event_id,)).fetchone()
+        job = conn.execute("SELECT status, attempts FROM memory_jobs").fetchone()
+    assert obs is not None
+    assert obs["content"] == "queued memory"
+    assert job["status"] == "done"
+    assert job["attempts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_retries_then_dead_letters_failed_jobs(tmp_path) -> None:
+    db_path = str(tmp_path / "worker_retry.db")
+    with (
+        patch.object(_EmbeddingModel, "pre_warm"),
+        patch.object(_EmbeddingModel, "encode_document", return_value=[[0.1, 0.2, 0.3]]),
+    ):
+        mem = ObservationMemory(db_path=db_path)
+        event_id, created = mem.append_memory_event(
+            "memory.unknown",
+            {"content": "bad event"},
+            queue_job=True,
+        )
+        assert created is True
+        assert event_id is not None
+
+        worker = MemoryJobWorker(
+            mem,
+            MemoryWorkerConfig(batch_size=2, retry_delay_sec=0.0, max_attempts=2),
+        )
+        first = await worker.run_once()
+        second = await worker.run_once()
+        assert first == 1
+        assert second == 1
+        mem.close()
+
+    with _connect(db_path) as conn:
+        row = conn.execute("SELECT status, attempts, last_error FROM memory_jobs").fetchone()
+    assert row is not None
+    assert row["status"] == "dead_letter"
+    assert row["attempts"] == 2
+    assert row["last_error"]

--- a/tests/test_new_migration_script.py
+++ b/tests/test_new_migration_script.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _run_script(tmp_path: Path, *args: str) -> Path:
+    script = Path.cwd() / "scripts" / "new_migration.sh"
+    result = subprocess.run(
+        ["bash", str(script), *args, "--dir", str(tmp_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def test_new_migration_script_creates_file_with_slug_and_template(tmp_path) -> None:
+    created = _run_script(tmp_path, "Add memory jobs table", "--date", "2026-03-03")
+    assert created.name == "2026-03-03-001_add_memory_jobs_table.py"
+    content = created.read_text(encoding="utf-8")
+    assert "def upgrade(conn: sqlite3.Connection) -> None:" in content
+    assert '"""TODO: describe migration."""' in content
+
+
+def test_new_migration_script_increments_sequence(tmp_path) -> None:
+    first = _run_script(tmp_path, "first", "--date", "2026-03-03")
+    second = _run_script(tmp_path, "second", "--date", "2026-03-03")
+    assert first.name.startswith("2026-03-03-001_")
+    assert second.name.startswith("2026-03-03-002_")


### PR DESCRIPTION
## Summary
- add a Rails-style SQLite migration runner with startup auto-apply and `schema_migrations` tracking
- add timestamped migrations under `migration/` for baseline observations schema and durable memory event/job tables
- add `MemoryJobWorker` and queue-based memory materialization path, plus idempotent event append APIs
- add `scripts/new_migration.sh` to scaffold new `migration/YYYY-MM-DD-XXX_name.py` files
- update docs/tests for migration flow, legacy schema upgrade, and worker retry/dead-letter behavior

## Validation
- `uv run ruff check src/familiar_agent/sqlite_migrations.py src/familiar_agent/tools/memory.py src/familiar_agent/memory_worker.py src/familiar_agent/agent.py tests/test_new_migration_script.py tests/test_memory_migrations.py tests/test_memory_event_log.py tests/test_memory_worker.py tests/test_compaction.py tests/test_companion_mood.py`
- `uv run --group dev mypy src/familiar_agent/sqlite_migrations.py src/familiar_agent/tools/memory.py src/familiar_agent/memory_worker.py src/familiar_agent/agent.py`
- `uv run pytest -q tests/test_new_migration_script.py tests/test_memory_migrations.py tests/test_memory_event_log.py tests/test_memory_worker.py tests/test_memory_prewarm.py tests/test_compaction.py tests/test_companion_mood.py tests/test_gui_async_stability.py tests/test_gui_callbacks.py tests/test_tui_interrupt_stress.py tests/test_tui_stt_interrupt_stress.py tests/test_tui_*.py tests/test_ui_helpers.py`
