### PR TITLE
feat(memory): add revision chain for semantic/policy reconsolidation

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -61,6 +61,8 @@ At the start of each session, relevant past memories are retrieved by semantic s
 
 Schema changes are applied automatically at startup through timestamped migration scripts under `migration/`, tracked by `schema_migrations`.
 
+Projected semantic/policy memories keep a revision chain (`memory_revisions`) when they are updated, so older interpretations are not silently overwritten.
+
 Implementation: `src/familiar_agent/tools/memory.py`
 
 ---

--- a/migration/2026-03-03-004_memory_revisions.py
+++ b/migration/2026-03-03-004_memory_revisions.py
@@ -1,0 +1,27 @@
+"""Add revision history table for semantic/policy reconsolidation."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS memory_revisions (
+            id TEXT PRIMARY KEY,
+            entity_type TEXT NOT NULL,
+            entity_key TEXT NOT NULL,
+            previous_text TEXT NOT NULL,
+            new_text TEXT NOT NULL,
+            previous_confidence REAL NOT NULL DEFAULT 0.0,
+            new_confidence REAL NOT NULL DEFAULT 0.0,
+            source_memory_id TEXT REFERENCES observations(id) ON DELETE SET NULL,
+            reason TEXT NOT NULL DEFAULT 'projection_update',
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_revisions_entity ON memory_revisions(entity_type, entity_key, created_at)"
+    )

--- a/src/familiar_agent/tools/memory.py
+++ b/src/familiar_agent/tools/memory.py
@@ -10,7 +10,6 @@ Architecture inspired by memory-mcp (Phase 11: SQLite+numpy).
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 import logging
 import sqlite3
@@ -64,10 +63,6 @@ def _encode_vector(vec: list[float]) -> bytes:
 
 def _decode_vector(blob: bytes) -> np.ndarray:
     return np.frombuffer(blob, dtype=np.float32)
-
-
-def _stable_hash(text: str, length: int = 16) -> str:
-    return hashlib.sha1(text.encode("utf-8", errors="ignore")).hexdigest()[:length]
 
 
 # ── lazy embedding model ──────────────────────────────────────
@@ -368,10 +363,13 @@ class ObservationMemory:
         now_iso = self._now_iso()
         confidence = max(0.0, min(1.0, float(confidence)))
         existing = db.execute(
-            "SELECT id FROM semantic_facts WHERE fact_key = ?",
+            "SELECT id, fact_text, confidence FROM semantic_facts WHERE fact_key = ?",
             (fact_key,),
         ).fetchone()
         if existing:
+            prev_text = str(existing["fact_text"])
+            prev_conf = float(existing["confidence"])
+            new_conf = max(prev_conf, confidence)
             db.execute(
                 "UPDATE semantic_facts "
                 "SET fact_text = ?, source_memory_id = COALESCE(?, source_memory_id), "
@@ -387,6 +385,17 @@ class ObservationMemory:
                     fact_key,
                 ),
             )
+            if prev_text != fact_text or abs(new_conf - prev_conf) > 1e-6:
+                self._insert_revision_locked(
+                    db,
+                    entity_type="semantic_fact",
+                    entity_key=fact_key,
+                    previous_text=prev_text,
+                    new_text=fact_text,
+                    previous_confidence=prev_conf,
+                    new_confidence=new_conf,
+                    source_memory_id=source_memory_id,
+                )
             return
         db.execute(
             "INSERT INTO semantic_facts "
@@ -418,10 +427,13 @@ class ObservationMemory:
         now_iso = self._now_iso()
         confidence = max(0.0, min(1.0, float(confidence)))
         existing = db.execute(
-            "SELECT id FROM behavior_policies WHERE policy_key = ?",
+            "SELECT id, policy_text, confidence FROM behavior_policies WHERE policy_key = ?",
             (policy_key,),
         ).fetchone()
         if existing:
+            prev_text = str(existing["policy_text"])
+            prev_conf = float(existing["confidence"])
+            new_conf = max(prev_conf, confidence)
             db.execute(
                 "UPDATE behavior_policies "
                 "SET policy_text = ?, trigger_context = ?, action_hint = ?, "
@@ -439,6 +451,17 @@ class ObservationMemory:
                     policy_key,
                 ),
             )
+            if prev_text != policy_text or abs(new_conf - prev_conf) > 1e-6:
+                self._insert_revision_locked(
+                    db,
+                    entity_type="behavior_policy",
+                    entity_key=policy_key,
+                    previous_text=prev_text,
+                    new_text=policy_text,
+                    previous_confidence=prev_conf,
+                    new_confidence=new_conf,
+                    source_memory_id=source_memory_id,
+                )
             return
         db.execute(
             "INSERT INTO behavior_policies "
@@ -459,6 +482,37 @@ class ObservationMemory:
             ),
         )
 
+    def _insert_revision_locked(
+        self,
+        db: sqlite3.Connection,
+        entity_type: str,
+        entity_key: str,
+        previous_text: str,
+        new_text: str,
+        previous_confidence: float,
+        new_confidence: float,
+        source_memory_id: str | None,
+        reason: str = "projection_update",
+    ) -> None:
+        db.execute(
+            "INSERT INTO memory_revisions "
+            "(id, entity_type, entity_key, previous_text, new_text, previous_confidence, "
+            "new_confidence, source_memory_id, reason, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                str(uuid.uuid4()),
+                entity_type,
+                entity_key,
+                previous_text[:800],
+                new_text[:800],
+                max(0.0, min(1.0, float(previous_confidence))),
+                max(0.0, min(1.0, float(new_confidence))),
+                source_memory_id,
+                reason,
+                self._now_iso(),
+            ),
+        )
+
     def _project_memory_locked(
         self,
         db: sqlite3.Connection,
@@ -473,10 +527,9 @@ class ObservationMemory:
 
         # Episodic -> semantic (stable self/companion facts)
         if kind == "self_model":
-            key = f"self_model:{_stable_hash(text)}"
             self._upsert_semantic_fact_locked(
                 db,
-                fact_key=key,
+                fact_key="self_model:core",
                 fact_text=text[:220],
                 source_memory_id=source_memory_id,
                 confidence=0.82,
@@ -485,10 +538,9 @@ class ObservationMemory:
             return
 
         if kind == "companion_status":
-            key = f"companion_status:{_stable_hash(text)}"
             self._upsert_semantic_fact_locked(
                 db,
-                fact_key=key,
+                fact_key="companion_status:latest",
                 fact_text=text[:220],
                 source_memory_id=source_memory_id,
                 confidence=0.78,
@@ -498,11 +550,10 @@ class ObservationMemory:
 
         # Episodic -> policy (action tendencies)
         if kind == "curiosity":
-            key = f"curiosity_policy:{_stable_hash(text)}"
             policy_text = f"When idle, follow up this curiosity thread: {text[:180]}"
             self._upsert_behavior_policy_locked(
                 db,
-                policy_key=key,
+                policy_key="curiosity:active",
                 policy_text=policy_text,
                 trigger_context="idle",
                 action_hint="look_around",
@@ -512,11 +563,10 @@ class ObservationMemory:
             return
 
         if kind == "conversation" and emotion in {"moved", "excited"}:
-            key = f"conversation_style:{_stable_hash(text)}"
             policy_text = f"Prefer this response style when supporting the companion: {text[:180]}"
             self._upsert_behavior_policy_locked(
                 db,
-                policy_key=key,
+                policy_key="conversation:supportive_style",
                 policy_text=policy_text,
                 trigger_context="conversation",
                 action_hint="respond_supportively",
@@ -978,6 +1028,47 @@ class ObservationMemory:
             )
         return "\n".join(lines)
 
+    def recall_revisions(
+        self, entity_type: str | None = None, entity_key: str | None = None, n: int = 20
+    ) -> list[dict]:
+        """Return recent revision records for semantic/policy memory."""
+        try:
+            clauses: list[str] = []
+            params: list[Any] = []
+            if entity_type:
+                clauses.append("entity_type = ?")
+                params.append(entity_type)
+            if entity_key:
+                clauses.append("entity_key = ?")
+                params.append(entity_key)
+            where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+            with self._db_lock:
+                db = self._ensure_connected()
+                rows = db.execute(
+                    "SELECT entity_type, entity_key, previous_text, new_text, "
+                    "previous_confidence, new_confidence, source_memory_id, reason, created_at "
+                    f"FROM memory_revisions {where} "
+                    "ORDER BY created_at DESC LIMIT ?",
+                    params + [n],
+                ).fetchall()
+            return [
+                {
+                    "entity_type": r["entity_type"],
+                    "entity_key": r["entity_key"],
+                    "previous_text": r["previous_text"],
+                    "new_text": r["new_text"],
+                    "previous_confidence": float(r["previous_confidence"]),
+                    "new_confidence": float(r["new_confidence"]),
+                    "source_memory_id": r["source_memory_id"],
+                    "reason": r["reason"],
+                    "created_at": r["created_at"],
+                }
+                for r in rows
+            ]
+        except Exception as e:
+            logger.warning("Failed to recall revisions: %s", e)
+            return []
+
     async def save_async(
         self,
         content: str,
@@ -1018,6 +1109,11 @@ class ObservationMemory:
 
     async def recall_behavior_policies_async(self, query: str, n: int = 5) -> list[dict]:
         return await asyncio.to_thread(self.recall_behavior_policies, query, n)
+
+    async def recall_revisions_async(
+        self, entity_type: str | None = None, entity_key: str | None = None, n: int = 20
+    ) -> list[dict]:
+        return await asyncio.to_thread(self.recall_revisions, entity_type, entity_key, n)
 
     # ── Day summary support ────────────────────────────────────────
 

--- a/tests/test_memory_projection.py
+++ b/tests/test_memory_projection.py
@@ -67,3 +67,27 @@ def test_moved_conversation_projects_to_support_policy(tmp_path) -> None:
     policy = policies[0]
     assert policy["trigger_context"] == "conversation"
     assert policy["action_hint"] == "respond_supportively"
+
+
+def test_projection_updates_create_revision_chain(tmp_path) -> None:
+    db_path = str(tmp_path / "projection_revisions.db")
+    with (
+        patch.object(_EmbeddingModel, "pre_warm"),
+        patch.object(_EmbeddingModel, "encode_document", return_value=[[0.1, 0.2, 0.3]]),
+        patch.object(_EmbeddingModel, "encode_query", return_value=[[0.1, 0.2, 0.3]]),
+    ):
+        mem = ObservationMemory(db_path=db_path)
+        assert mem.save("I value honesty in responses.", kind="self_model", emotion="moved")
+        assert mem.save(
+            "I value precision and honesty in responses.", kind="self_model", emotion="moved"
+        )
+
+        facts = mem.recall_semantic_facts("honesty", n=5)
+        revisions = mem.recall_revisions(entity_type="semantic_fact", entity_key="self_model:core")
+        mem.close()
+
+    assert facts
+    assert "precision" in facts[0]["summary"].lower()
+    assert revisions
+    assert "value honesty" in revisions[0]["previous_text"].lower()
+    assert "precision" in revisions[0]["new_text"].lower()


### PR DESCRIPTION
## Summary
- add migration `2026-03-03-004_memory_revisions.py` to persist semantic/policy revision history
- record revision entries (`memory_revisions`) whenever projected semantic facts or behavior policies are updated
- switch projection keys to stable identities (`self_model:core`, `companion_status:latest`, `curiosity:active`, `conversation:supportive_style`) so reconsolidation updates the same memory slot over time
- add revision recall API (`recall_revisions` / `recall_revisions_async`)
- add weighted morning-context selection under a fixed budget to reduce startup prompt bloat:
  - new `_select_context_blocks(...)`
  - `_morning_reconstruction(...)` now uses priority + char budget (`_MORNING_CONTEXT_MAX_CHARS`)
- update technical docs to reflect revision-chain behavior

## Why
- prevents silent overwrite of long-term semantic/policy memory by preserving a revision chain
- improves startup consistency by prioritizing high-value memories within bounded context

## Tests
- `uv run ruff check src/familiar_agent/agent.py src/familiar_agent/tools/memory.py migration/2026-03-03-004_memory_revisions.py tests/test_memory_projection.py tests/test_memory_migrations.py tests/test_morning_context_budget.py`
- `uv run --group dev mypy src/familiar_agent/tools/memory.py src/familiar_agent/agent.py src/familiar_agent/memory_worker.py src/familiar_agent/sqlite_migrations.py`
- `uv run pytest -q tests/test_memory_projection.py tests/test_memory_migrations.py tests/test_memory_recall_metadata.py tests/test_memory_event_log.py tests/test_memory_worker.py tests/test_morning_context_budget.py`
- `uv run pytest -q tests/test_compaction.py tests/test_companion_mood.py tests/test_gui_async_stability.py tests/test_gui_callbacks.py tests/test_tui_interrupt_stress.py tests/test_tui_stt_interrupt_stress.py tests/test_tui_*.py tests/test_ui_helpers.py`
