### PR TITLE
feat(agent): prioritize morning memory context within budget

### DIFF
--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -27,6 +27,7 @@ from ._i18n import _t
 logger = logging.getLogger(__name__)
 
 MAX_ITERATIONS = 50
+_MORNING_CONTEXT_MAX_CHARS = 2600
 _DEFAULT_TOOL_TIMEOUT = 20.0
 _TOOL_TIMEOUTS: dict[str, float] = {
     "see": 12.0,
@@ -574,6 +575,33 @@ class EmbodiedAgent:
         """Return exploration history for ICL-based direction steering."""
         return self._exploration.context_for_prompt(n=5)
 
+    @staticmethod
+    def _select_context_blocks(
+        blocks: list[tuple[str, float]],
+        max_chars: int = _MORNING_CONTEXT_MAX_CHARS,
+    ) -> list[str]:
+        """Select high-priority context blocks within a character budget."""
+        if max_chars <= 0:
+            return [text for text, _ in blocks]
+
+        ranked = [
+            (idx, text, score) for idx, (text, score) in enumerate(blocks) if text and text.strip()
+        ]
+        ranked.sort(key=lambda item: item[2], reverse=True)
+
+        selected: list[tuple[int, str]] = []
+        used = 0
+        for idx, text, _score in ranked:
+            block_len = len(text)
+            sep = 2 if selected else 0
+            if used + sep + block_len > max_chars:
+                continue
+            selected.append((idx, text))
+            used += sep + block_len
+
+        selected.sort(key=lambda item: item[0])
+        return [text for _, text in selected]
+
     async def _infer_emotion(self, text: str) -> str:
         """Ask the LLM to label the emotion of a response. Returns label string."""
         label = await self._utility_backend.complete(
@@ -651,19 +679,37 @@ class EmbodiedAgent:
         if desires is not None and curiosities and desires.curiosity_target is None:
             desires.curiosity_target = curiosities[0]["summary"]
 
-        parts = []
+        blocks: list[tuple[str, float]] = []
         if day_summaries:
-            parts.append(self._memory.format_day_summaries_for_context(day_summaries))
+            blocks.append((self._memory.format_day_summaries_for_context(day_summaries), 0.78))
         if semantic_facts:
-            parts.append(self._memory.format_semantic_facts_for_context(semantic_facts))
+            avg_conf = sum(float(x.get("confidence", 0.5)) for x in semantic_facts) / len(
+                semantic_facts
+            )
+            blocks.append(
+                (
+                    self._memory.format_semantic_facts_for_context(semantic_facts),
+                    0.86 + avg_conf * 0.1,
+                )
+            )
         if behavior_policies:
-            parts.append(self._memory.format_behavior_policies_for_context(behavior_policies))
+            avg_conf = sum(float(x.get("confidence", 0.5)) for x in behavior_policies) / len(
+                behavior_policies
+            )
+            blocks.append(
+                (
+                    self._memory.format_behavior_policies_for_context(behavior_policies),
+                    0.84 + avg_conf * 0.1,
+                )
+            )
         if self_model:
-            parts.append(self._memory.format_self_model_for_context(self_model))
+            blocks.append((self._memory.format_self_model_for_context(self_model), 0.83))
         if curiosities:
-            parts.append(self._memory.format_curiosities_for_context(curiosities))
+            blocks.append((self._memory.format_curiosities_for_context(curiosities), 0.74))
         if feelings:
-            parts.append(self._memory.format_feelings_for_context(feelings))
+            blocks.append((self._memory.format_feelings_for_context(feelings), 0.71))
+
+        parts = self._select_context_blocks(blocks, _MORNING_CONTEXT_MAX_CHARS)
 
         if not parts:
             # No history yet — make it explicit so the agent doesn't fabricate a past

--- a/tests/test_morning_context_budget.py
+++ b/tests/test_morning_context_budget.py
@@ -1,0 +1,33 @@
+"""Tests for morning reconstruction context selection under budget."""
+
+from __future__ import annotations
+
+from familiar_agent.agent import EmbodiedAgent
+
+
+def test_select_context_blocks_prefers_higher_priority_within_budget() -> None:
+    blocks = [
+        ("low-a", 0.2),
+        ("high-a", 0.9),
+        ("mid-a", 0.5),
+    ]
+    selected = EmbodiedAgent._select_context_blocks(blocks, max_chars=len("high-a\n\nmid-a"))
+    assert "high-a" in selected
+    assert "mid-a" in selected
+    assert "low-a" not in selected
+
+
+def test_select_context_blocks_restores_original_order_after_selection() -> None:
+    blocks = [
+        ("first", 0.4),
+        ("second", 0.9),
+        ("third", 0.8),
+    ]
+    selected = EmbodiedAgent._select_context_blocks(blocks, max_chars=100)
+    assert selected == ["first", "second", "third"]
+
+
+def test_select_context_blocks_returns_all_when_budget_disabled() -> None:
+    blocks = [("a", 0.1), ("b", 0.2)]
+    selected = EmbodiedAgent._select_context_blocks(blocks, max_chars=0)
+    assert selected == ["a", "b"]


### PR DESCRIPTION
## Summary
- prioritize morning-context blocks with a weighted selector when composing reconstruction context
- add `_MORNING_CONTEXT_MAX_CHARS` and `_select_context_blocks(...)` to control and score included snippets
- apply selector in `_morning_reconstruction(...)` before prompt assembly
- add focused tests for budgeting/selection behavior in `tests/test_morning_context_budget.py`

## Testing
- `uv run pytest -q tests/test_morning_context_budget.py tests/test_compaction.py tests/test_companion_mood.py`
