### PR TITLE
fix(stt): suppress duplicate committed transcripts

### DIFF
--- a/src/familiar_agent/realtime_stt_session.py
+++ b/src/familiar_agent/realtime_stt_session.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -31,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 # ── Filler / short-utterance filter ──────────────────────────────────
 _FILLER_WORDS = frozenset("えー ええと えっと あの その うーん んー ま はい うん ん".split())
+_DEDUPE_WINDOW_SECS = 3.0
 
 
 def _is_only_punct_or_symbol(s: str) -> bool:
@@ -47,6 +49,13 @@ def should_skip_stt(text: str) -> bool:
     if text in _FILLER_WORDS:
         return True
     return False
+
+
+def _normalize_for_dedupe(text: str) -> str:
+    """Normalize STT text for stable duplicate detection."""
+    normalized = text.strip().lower()
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized.strip(" 　。、！？…・「」『』（）()!?,.\"'")
 
 
 class RealtimeSttSession:
@@ -67,7 +76,7 @@ class RealtimeSttSession:
         self._committed_queue: asyncio.Queue[str | None] | None = None
 
         # Deduplication state
-        self._last_text = ""
+        self._last_normalized_text = ""
         self._last_time = 0.0
 
         # Display callbacks (set by caller before start())
@@ -131,10 +140,17 @@ class RealtimeSttSession:
             text = await self._stt_client.on_committed.get()
             if should_skip_stt(text):
                 continue
-            now = time.time()
-            if text == self._last_text and now - self._last_time < 1.2:
+            normalized = _normalize_for_dedupe(text)
+            if not normalized:
                 continue
-            self._last_text = text
+            now = time.time()
+            if (
+                normalized == self._last_normalized_text
+                and now - self._last_time < _DEDUPE_WINDOW_SECS
+            ):
+                logger.debug("Dropped duplicate realtime STT transcript: %s", text)
+                continue
+            self._last_normalized_text = normalized
             self._last_time = now
             if self.on_committed:
                 self.on_committed(text)

--- a/tests/test_realtime_stt_session.py
+++ b/tests/test_realtime_stt_session.py
@@ -1,0 +1,78 @@
+"""Tests for realtime STT session filtering and deduplication."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from types import SimpleNamespace
+
+import pytest
+
+from familiar_agent.realtime_stt_session import RealtimeSttSession, _normalize_for_dedupe
+
+
+def test_normalize_for_dedupe_collapses_spacing_and_trailing_punctuation() -> None:
+    assert _normalize_for_dedupe("  こんにちは。 ") == "こんにちは"
+    assert _normalize_for_dedupe("Hello   world!!") == "hello world"
+    assert _normalize_for_dedupe("「テスト」") == "テスト"
+
+
+@pytest.mark.asyncio
+async def test_committed_relay_drops_same_text_within_dedupe_window(monkeypatch) -> None:
+    session = RealtimeSttSession("dummy")
+    committed_q: asyncio.Queue[str] = asyncio.Queue()
+    input_q: asyncio.Queue[str | None] = asyncio.Queue()
+    session._stt_client = SimpleNamespace(on_committed=committed_q)
+    session._committed_queue = input_q
+
+    forwarded: list[str] = []
+    session.on_committed = forwarded.append
+
+    ts = iter([100.0, 101.0, 104.5])
+    monkeypatch.setattr("familiar_agent.realtime_stt_session.time.time", lambda: next(ts))
+
+    task = asyncio.create_task(session._committed_relay())
+    await committed_q.put("こんにちは")
+    await committed_q.put(" こんにちは。 ")
+    await committed_q.put("こんにちは")
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    queued: list[str] = []
+    while not input_q.empty():
+        item = input_q.get_nowait()
+        assert isinstance(item, str)
+        queued.append(item)
+
+    assert forwarded == ["こんにちは", "こんにちは"]
+    assert queued == ["こんにちは", "こんにちは"]
+
+
+@pytest.mark.asyncio
+async def test_committed_relay_keeps_different_texts(monkeypatch) -> None:
+    session = RealtimeSttSession("dummy")
+    committed_q: asyncio.Queue[str] = asyncio.Queue()
+    input_q: asyncio.Queue[str | None] = asyncio.Queue()
+    session._stt_client = SimpleNamespace(on_committed=committed_q)
+    session._committed_queue = input_q
+
+    ts = iter([200.0, 200.5])
+    monkeypatch.setattr("familiar_agent.realtime_stt_session.time.time", lambda: next(ts))
+
+    task = asyncio.create_task(session._committed_relay())
+    await committed_q.put("こんにちは")
+    await committed_q.put("こんばんは")
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    queued: list[str] = []
+    while not input_q.empty():
+        item = input_q.get_nowait()
+        assert isinstance(item, str)
+        queued.append(item)
+
+    assert queued == ["こんにちは", "こんばんは"]


### PR DESCRIPTION
## What
- harden realtime STT dedupe in `RealtimeSttSession`
- normalize transcripts before duplicate checks (whitespace/punctuation differences no longer bypass dedupe)
- extend duplicate suppression window to reduce double-queued turns in TUI/REPL

## Why
- duplicate committed STT lines could enqueue multiple identical turns
- this looked like sudden context loss/forgetting, but root cause was double-send

## Tests
- `uv run pytest -q tests/test_realtime_stt_session.py tests/test_tui_stt_interrupt_stress.py tests/test_tui_interrupt_stress.py tests/test_tui_escape_cancel.py`
