### PR TITLE
fix(gui): create tasks safely before event loop is running

### DIFF
--- a/src/familiar_agent/gui.py
+++ b/src/familiar_agent/gui.py
@@ -22,7 +22,7 @@ import html as _html
 import logging
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import qasync
 from PySide6.QtCore import QEasingCurve, QPropertyAnimation, QSize, Qt, QTimer
@@ -747,9 +747,21 @@ class FamiliarWindow(QMainWindow):
         self.setStyleSheet(f"background: {_BG_BASE};")
         self._build_ui()
 
-        self._queue_task = asyncio.create_task(self._process_queue())
+        self._queue_task = self._create_task(self._process_queue())
         if not self._agent.is_embedding_ready:
-            self._init_task = asyncio.create_task(self._show_init_status())
+            self._init_task = self._create_task(self._show_init_status())
+
+    def _create_task(self, coro) -> asyncio.Task[Any]:
+        """Create an asyncio task from GUI sync callbacks safely.
+
+        `asyncio.create_task()` requires a running loop and fails during
+        early window construction on some platforms (notably Windows).
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.get_event_loop()
+        return loop.create_task(coro)
 
     # ------------------------------------------------------------------
     # UI construction
@@ -1024,7 +1036,7 @@ class FamiliarWindow(QMainWindow):
             self._camera.update_image(b64)
 
         try:
-            self._agent_task = asyncio.create_task(
+            self._agent_task = self._create_task(
                 self._agent.run(
                     user_input,
                     on_action=on_action,
@@ -1093,7 +1105,7 @@ class FamiliarWindow(QMainWindow):
     def _ensure_shutdown_task(self) -> asyncio.Task[None]:
         if self._shutdown_task and not self._shutdown_task.done():
             return self._shutdown_task
-        self._shutdown_task = asyncio.create_task(self._shutdown())
+        self._shutdown_task = self._create_task(self._shutdown())
         self._shutdown_task.add_done_callback(lambda _task: self._finalize_close())
         return self._shutdown_task
 

--- a/tests/test_gui_async_stability.py
+++ b/tests/test_gui_async_stability.py
@@ -122,3 +122,34 @@ def test_gui_event_loop_lag_warning_emits_log(caplog: pytest.LogCaptureFixture):
         FamiliarWindow._report_event_loop_lag(win)
 
     assert "event-loop lag detected" in caplog.text
+
+
+def test_gui_create_task_falls_back_when_no_running_loop(monkeypatch):
+    win = _make_window_stub()
+
+    class _DummyTask:
+        pass
+
+    class _DummyLoop:
+        def __init__(self) -> None:
+            self.created = False
+
+        def create_task(self, coro):
+            self.created = True
+            coro.close()
+            return _DummyTask()
+
+    dummy_loop = _DummyLoop()
+
+    def _raise_no_running_loop():
+        raise RuntimeError("no running event loop")
+
+    monkeypatch.setattr(asyncio, "get_running_loop", _raise_no_running_loop)
+    monkeypatch.setattr(asyncio, "get_event_loop", lambda: dummy_loop)
+
+    async def _noop() -> None:
+        return None
+
+    task = FamiliarWindow._create_task(win, _noop())
+    assert isinstance(task, _DummyTask)
+    assert dummy_loop.created is True


### PR DESCRIPTION
## What
- add `FamiliarWindow._create_task(...)` to create asyncio tasks from sync GUI callbacks even when no loop is currently running
- replace direct `asyncio.create_task(...)` calls in window init / run / shutdown paths with the safe helper
- add regression test covering the no-running-loop fallback path

## Why
- Windows GUI startup could crash with `RuntimeError: no running event loop` during `FamiliarWindow.__init__`

## Tests
- `uv run pytest -q tests/test_gui_async_stability.py`
- `uv run pytest -q tests/test_gui_async_stability.py tests/test_tui_stt_interrupt_stress.py tests/test_tui_interrupt_stress.py`
