### PR TITLE
fix(gui): use configured agent/companion display names

### DIFF
--- a/src/familiar_agent/gui.py
+++ b/src/familiar_agent/gui.py
@@ -191,8 +191,16 @@ class ChatLog(QScrollArea):
         append_action(name: str, tool_input: dict) -> None
     """
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        agent_label: str = "Agent",
+        companion_label: str = "You",
+    ) -> None:
         super().__init__(parent)
+        self._agent_label = (agent_label or "Agent").strip() or "Agent"
+        self._companion_label = (companion_label or "You").strip() or "You"
         self.setWidgetResizable(True)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.setStyleSheet(f"QScrollArea {{ background: {_BG_BASE}; border: none; }}")
@@ -211,32 +219,49 @@ class ChatLog(QScrollArea):
             20, lambda: self.verticalScrollBar().setValue(self.verticalScrollBar().maximum())
         )
 
+    @staticmethod
+    def _extract_prefixed_text(text: str, label: str) -> str | None:
+        marker = f"[{label}]"
+        if text.startswith(marker):
+            return text[len(marker) :].strip()
+        return None
+
     def append_line(self, text: str) -> None:
         """Add a styled bubble. Prefix determines bubble style."""
         text = text.strip()
         if not text:
             return
 
-        if text.startswith("[You]"):
+        user_text = self._extract_prefixed_text(text, self._companion_label)
+        if user_text is None and self._companion_label != "You":
+            user_text = self._extract_prefixed_text(text, "You")
+        if user_text is not None:
             self._add_bubble(
-                text[5:].strip(),
-                prefix="You",
+                user_text,
+                prefix=self._companion_label,
                 prefix_color=_TEXT_SECONDARY,
                 bg=_BUBBLE_USER_BG,
                 ml=60,
                 mr=4,
             )
-        elif text.startswith("[Agent]"):
+            return
+
+        agent_text = self._extract_prefixed_text(text, self._agent_label)
+        if agent_text is None and self._agent_label != "Agent":
+            agent_text = self._extract_prefixed_text(text, "Agent")
+        if agent_text is not None:
             self._add_bubble(
-                text[7:].strip(),
-                prefix="Agent",
+                agent_text,
+                prefix=self._agent_label,
                 prefix_color=_ACCENT,
                 bg=_BUBBLE_AGENT_BG,
                 ml=4,
                 mr=60,
                 accent_left=True,
             )
-        elif text.startswith("[error]"):
+            return
+
+        if text.startswith("[error]"):
             self._add_bubble(
                 f"⚠ {text[7:].strip()}",
                 bg="#2a1520",
@@ -726,6 +751,8 @@ class FamiliarWindow(QMainWindow):
         super().__init__()
         self._agent = agent
         self._desires = desires
+        self._agent_display_name = (self._agent.config.agent_name or "Agent").strip() or "Agent"
+        self._companion_display_name = (self._agent.config.companion_name or "You").strip() or "You"
         self._input_queue: asyncio.Queue[str | None] = asyncio.Queue()
         self._agent_running = False
         self._closing = False
@@ -812,7 +839,10 @@ class FamiliarWindow(QMainWindow):
         left_layout.addWidget(header)
 
         # Chat log
-        self._log = ChatLog()
+        self._log = ChatLog(
+            agent_label=self._agent_display_name,
+            companion_label=self._companion_display_name,
+        )
         left_layout.addWidget(self._log, stretch=5)
 
         # Stream label
@@ -930,7 +960,7 @@ class FamiliarWindow(QMainWindow):
         if not text:
             return
         self._input.clear()
-        self._log.append_line(f"[You] {text}")
+        self._log.append_line(f"[{self._companion_display_name}] {text}")
         self._input_queue.put_nowait(text)
         qsize = self._input_queue.qsize()
         if qsize >= _GUI_QUEUE_WARN_SIZE:
@@ -1029,7 +1059,7 @@ class FamiliarWindow(QMainWindow):
         def on_action(name: str, tool_input: dict) -> None:
             committed = self._stream.commit_and_clear()
             if committed.strip():
-                self._log.append_line(f"[Agent] {committed.strip()}")
+                self._log.append_line(f"[{self._agent_display_name}] {committed.strip()}")
             self._log.append_action(name, tool_input)
 
         def on_image(b64: str) -> None:
@@ -1051,7 +1081,7 @@ class FamiliarWindow(QMainWindow):
             committed = self._stream.commit_and_clear()
             display = committed.strip() or final_text.strip()
             if display:
-                self._log.append_line(f"[Agent] {display}")
+                self._log.append_line(f"[{self._agent_display_name}] {display}")
         except asyncio.CancelledError:
             self._stream.commit_and_clear()
             if not self._cancel_requested:

--- a/tests/test_gui_async_stability.py
+++ b/tests/test_gui_async_stability.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from familiar_agent.gui import FamiliarWindow
+from familiar_agent.gui import ChatLog, FamiliarWindow
 
 
 class _FakeCloseEvent:
@@ -27,6 +27,8 @@ class _FakeCloseEvent:
 
 def _make_window_stub() -> FamiliarWindow:
     win = FamiliarWindow.__new__(FamiliarWindow)
+    win._agent_display_name = "Yukine"
+    win._companion_display_name = "Kota"
     win._input_queue = asyncio.Queue()
     win._agent_running = False
     win._closing = False
@@ -47,6 +49,21 @@ def _make_window_stub() -> FamiliarWindow:
     win.setWindowTitle = MagicMock()
     win.close = MagicMock()
     return win
+
+
+def _make_chat_log_stub(
+    *, agent_label: str = "Yukine", companion_label: str = "Kota"
+) -> tuple[ChatLog, list[tuple[str, dict]]]:
+    log = ChatLog.__new__(ChatLog)
+    log._agent_label = agent_label
+    log._companion_label = companion_label
+    captured: list[tuple[str, dict]] = []
+
+    def _capture(text: str, **kwargs) -> None:
+        captured.append((text, kwargs))
+
+    log._add_bubble = _capture  # type: ignore[method-assign]
+    return log, captured
 
 
 @pytest.mark.asyncio
@@ -153,3 +170,38 @@ def test_gui_create_task_falls_back_when_no_running_loop(monkeypatch):
     task = FamiliarWindow._create_task(win, _noop())
     assert isinstance(task, _DummyTask)
     assert dummy_loop.created is True
+
+
+def test_chatlog_uses_configured_labels_for_user_and_agent_prefixes() -> None:
+    log, captured = _make_chat_log_stub(agent_label="ゆきね", companion_label="コウタ")
+
+    ChatLog.append_line(log, "[コウタ] こんにちは")
+    ChatLog.append_line(log, "[ゆきね] おはよう")
+
+    assert captured[0][0] == "こんにちは"
+    assert captured[0][1]["prefix"] == "コウタ"
+    assert captured[1][0] == "おはよう"
+    assert captured[1][1]["prefix"] == "ゆきね"
+
+
+def test_chatlog_accepts_legacy_you_agent_markers_with_custom_labels() -> None:
+    log, captured = _make_chat_log_stub(agent_label="ゆきね", companion_label="コウタ")
+
+    ChatLog.append_line(log, "[You] legacy user")
+    ChatLog.append_line(log, "[Agent] legacy agent")
+
+    assert captured[0][0] == "legacy user"
+    assert captured[0][1]["prefix"] == "コウタ"
+    assert captured[1][0] == "legacy agent"
+    assert captured[1][1]["prefix"] == "ゆきね"
+
+
+def test_gui_on_send_uses_companion_display_name() -> None:
+    win = _make_window_stub()
+    win._input = MagicMock()
+    win._input.text.return_value = "hello"
+    win._input.clear = MagicMock()
+
+    FamiliarWindow._on_send(win)
+
+    win._log.append_line.assert_called_once_with("[Kota] hello")


### PR DESCRIPTION
## What
- remove hardcoded GUI chat labels (`You` / `Agent`) and use configured display names from agent config
- wire `ChatLog` to render user/agent bubbles with those labels
- keep backward compatibility for legacy `[You]` / `[Agent]` markers
- add regression tests for custom labels and send-path behavior

## Why
- GUI regressed to fixed English labels and stopped reflecting `COMPANION_NAME` / `AGENT_NAME`

## Tests
- `uv run pytest -q tests/test_gui_async_stability.py`
- `uv run pytest -q tests/test_gui_async_stability.py tests/test_tui_stt_interrupt_stress.py tests/test_tui_interrupt_stress.py`
