### PR TITLE
feat(gui): show thinking elapsed time in stream panel

### DIFF
--- a/src/familiar_agent/_i18n.py
+++ b/src/familiar_agent/_i18n.py
@@ -2960,6 +2960,10 @@ _T: dict[str, dict[str, str]] = {
         "ur": "تیار ہوں",
         "vi": "Sẵn sàng",
     },
+    "thinking_status": {
+        "en": "{name} is thinking... {seconds}s",
+        "ja": "{name}が思考中... {seconds}s",
+    },
 }
 
 

--- a/src/familiar_agent/gui.py
+++ b/src/familiar_agent/gui.py
@@ -1019,10 +1019,13 @@ class FamiliarWindow(QMainWindow):
     def _set_turn_ui_state(self, running: bool) -> None:
         self._stop_btn.setEnabled(running)
 
-    @staticmethod
-    def _thinking_status_text(elapsed_sec: int) -> str:
+    def _thinking_status_text(self, elapsed_sec: int) -> str:
         """Status line shown while waiting for the first response chunk."""
-        return f"AIが思考中... {elapsed_sec}s"
+        return _t(
+            "thinking_status",
+            name=self._agent_display_name,
+            seconds=str(elapsed_sec),
+        )
 
     # ------------------------------------------------------------------
     # Agent loop

--- a/tests/test_gui_async_stability.py
+++ b/tests/test_gui_async_stability.py
@@ -45,9 +45,9 @@ def _make_window_stub() -> FamiliarWindow:
     win._stop_btn = MagicMock()
     win._lag_timer = MagicMock()
     win._last_lag_tick = time.perf_counter()
-    win.setEnabled = MagicMock()
-    win.setWindowTitle = MagicMock()
-    win.close = MagicMock()
+    win.setEnabled = MagicMock()  # type: ignore[method-assign]
+    win.setWindowTitle = MagicMock()  # type: ignore[method-assign]
+    win.close = MagicMock()  # type: ignore[method-assign]
     return win
 
 
@@ -62,7 +62,7 @@ def _make_chat_log_stub(
     def _capture(text: str, **kwargs) -> None:
         captured.append((text, kwargs))
 
-    log._add_bubble = _capture  # type: ignore[method-assign]
+    log._add_bubble = _capture  # type: ignore[assignment]
     return log, captured
 
 
@@ -204,9 +204,20 @@ def test_gui_on_send_uses_companion_display_name() -> None:
 
     FamiliarWindow._on_send(win)
 
+    assert isinstance(win._log, MagicMock)
     win._log.append_line.assert_called_once_with("[Kota] hello")
 
 
-def test_gui_thinking_status_text_includes_elapsed_seconds() -> None:
-    assert FamiliarWindow._thinking_status_text(0) == "AIが思考中... 0s"
-    assert FamiliarWindow._thinking_status_text(7) == "AIが思考中... 7s"
+def test_gui_thinking_status_text_uses_i18n_and_agent_display_name(monkeypatch) -> None:
+    win = _make_window_stub()
+    win._agent_display_name = "Yukine"
+
+    def _fake_t(key: str, **kwargs: str) -> str:
+        assert key == "thinking_status"
+        assert kwargs["name"] == "Yukine"
+        return f"{kwargs['name']}:::{kwargs['seconds']}"
+
+    monkeypatch.setattr("familiar_agent.gui._t", _fake_t)
+
+    assert FamiliarWindow._thinking_status_text(win, 0) == "Yukine:::0"
+    assert FamiliarWindow._thinking_status_text(win, 7) == "Yukine:::7"


### PR DESCRIPTION
## What
- show a live thinking status in the stream area while waiting for response chunks
- status format: `AIが思考中... {n}s` updated every 200ms
- keep status separate from streamed assistant text so commit/clear behavior stays unchanged

## Tests
- `uv run pytest -q tests/test_gui_async_stability.py`
