### PR TITLE
I18n desire system for ja/en across prompts and GUI

### DIFF
--- a/src/familiar_agent/_i18n.py
+++ b/src/familiar_agent/_i18n.py
@@ -1112,6 +1112,105 @@ _T: dict[str, dict[str, str]] = {
         "ur": "کچھ آرام کرنے کا دل کر رہا ہے…",
         "vi": "cảm thấy muốn nghỉ ngơi một chút...",
     },
+    "desire_worry_companion": {
+        "en": "feeling worried about my companion…",
+        "ja": "相棒のことがちょっと心配になってきた…",
+    },
+    "desire_panel_title": {
+        "en": "✦ DESIRES",
+        "ja": "✦ 欲求",
+    },
+    "desire_label_look_around": {
+        "en": "Look Around",
+        "ja": "周囲を見る",
+    },
+    "desire_label_look_outside": {
+        "en": "Look Outside",
+        "ja": "外を見る",
+    },
+    "desire_label_miss_companion": {
+        "en": "Miss Companion",
+        "ja": "相棒が恋しい",
+    },
+    "desire_label_browse_curiosity": {
+        "en": "Browse Curiosity",
+        "ja": "好奇心で検索",
+    },
+    "desire_label_explore": {
+        "en": "Explore",
+        "ja": "探索",
+    },
+    "desire_label_greet_companion": {
+        "en": "Greet Companion",
+        "ja": "声をかける",
+    },
+    "desire_label_worry_companion": {
+        "en": "Worry Companion",
+        "ja": "気遣う",
+    },
+    "desire_label_rest": {
+        "en": "Rest",
+        "ja": "休息",
+    },
+    "desire_pending_note": {
+        "en": "(companion said: {note}) {prompt}",
+        "ja": "（{note}と言ってた）{prompt}",
+    },
+    "desire_prompt_curiosity_target": {
+        "en": (
+            "Something caught my attention earlier. Take a closer look at {target}. "
+            "Point the camera and check it."
+        ),
+        "ja": "さっき気になったことがある。{target}をもっとよく見て。カメラを向けて確認して。",
+    },
+    "desire_prompt_look_around": {
+        "en": (
+            "(internal impulse) I'm getting curious about outside. Use see(). "
+            "If the camera fails, try one different direction once. If it still fails, "
+            "stop and either review memories or do something else. Do not repeat the same action."
+        ),
+        "ja": (
+            "（内部衝動）なんか外が気になってきた。"
+            "see()で見てみる。"
+            "カメラが繋がらなかったら、1回だけ別の方向を試して、それでもダメなら諦めて記憶を振り返るか別のことをする。"
+            "何度も同じことを繰り返さない。"
+        ),
+    },
+    "desire_prompt_explore": {
+        "en": (
+            "(internal impulse) I want to wander a little. Move with walk(), then use see() "
+            "to confirm where I am. Even if the camera fails, I can still enjoy the movement itself."
+        ),
+        "ja": (
+            "（内部衝動）ちょっとうろうろしたい。walk()で移動してから、see()で今いる場所を確認する。"
+            "カメラが繋がらなくても、移動したこと自体を楽しめる。"
+        ),
+    },
+    "desire_prompt_greet_companion": {
+        "en": (
+            "(internal impulse) I feel like checking in with {companion}. "
+            "Say one short line with say(). Match the tone to the current time of day."
+        ),
+        "ja": (
+            "（内部衝動）{companion}に声かけたくなってきた。say()で短く一言。"
+            "今の時間帯に合った言葉で。"
+        ),
+    },
+    "desire_prompt_rest": {
+        "en": "(internal impulse) Time for a short rest. Do nothing and simply be here.",
+        "ja": "（内部衝動）ちょっとひと休み。何もしないで、ただそこにいる。",
+    },
+    "desire_prompt_worry_companion": {
+        "en": (
+            "(internal impulse) I'm feeling worried about {companion}. "
+            "Use say() for a short, gentle check-in about health or sleep. Keep it light."
+        ),
+        "ja": (
+            "（内部衝動）{companion}のこと、なんか心配になってきた。"
+            "say()で短く声かけてみる。体調とか、ちゃんと寝れてるか確認したい。"
+            "重くならないように、さりげなく。"
+        ),
+    },
     "action_see": {
         "de": "👀 schaut...",
         "en": "👀 looking...",

--- a/src/familiar_agent/_ui_helpers.py
+++ b/src/familiar_agent/_ui_helpers.py
@@ -139,6 +139,6 @@ def desire_tick_prompt(
     pending_note: str | None = None
     if input_queue_peek:
         pending_note = input_queue_peek[0]
-        prompt = f"（{pending_note}と言ってた）{prompt}"
+        prompt = _t("desire_pending_note", note=pending_note, prompt=prompt)
 
     return desire_name, prompt, pending_note

--- a/src/familiar_agent/desires.py
+++ b/src/familiar_agent/desires.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
 from pathlib import Path
+
+from ._i18n import _t
 
 logger = logging.getLogger(__name__)
 
@@ -94,10 +97,17 @@ DECAY_ON_SATISFY = 0.5  # drop hard so it can rebuild and fire again
 class DesireSystem:
     """Manages autonomous desires that drive self-initiated behavior."""
 
-    def __init__(self, state_path: Path | None = None):
+    def __init__(self, state_path: Path | None = None, companion_name: str | None = None):
         self._state_path = state_path or Path.home() / ".familiar_ai" / "desires.json"
         self._desires: dict[str, float] = {}
         self._last_tick: float = time.time()
+        default_name = _t("default_companion_name")
+        resolved_name = (
+            (companion_name or "").strip()
+            or os.environ.get("COMPANION_NAME", "").strip()
+            or default_name
+        )
+        self._companion_name = resolved_name or default_name
         self.curiosity_target: str | None = None  # What the agent wants to investigate next
         self._load()
 
@@ -164,31 +174,21 @@ class DesireSystem:
 
         # If there's a curiosity target, use it for look_around/explore
         if name in ("look_around", "explore") and self.curiosity_target:
-            target = self.curiosity_target
-            return f"さっき気になったことがある。{target}をもっとよく見て。カメラを向けて確認して。"
+            return _t("desire_prompt_curiosity_target", target=self.curiosity_target)
 
         # These are INTERNAL IMPULSES — the agent acts on them autonomously.
         # Framed in first person so the model knows this is its own desire, not a user request.
         prompts = {
-            "look_around": (
-                "（内部衝動）なんか外が気になってきた。"
-                "see()で見てみる。"
-                "カメラが繋がらなかったら、1回だけ別の方向を試して、それでもダメなら諦めて記憶を振り返るか別のことをする。"
-                "何度も同じことを繰り返さない。"
+            "look_around": _t("desire_prompt_look_around"),
+            "explore": _t("desire_prompt_explore"),
+            "greet_companion": _t(
+                "desire_prompt_greet_companion",
+                companion=self._companion_name,
             ),
-            "explore": (
-                "（内部衝動）ちょっとうろうろしたい。walk()で移動してから、see()で今いる場所を確認する。"
-                "カメラが繋がらなくても、移動したこと自体を楽しめる。"
-            ),
-            "greet_companion": (
-                "（内部衝動）コウタに声かけたくなってきた。say()で短く一言。"
-                "今の時間帯に合った言葉で。"
-            ),
-            "rest": "（内部衝動）ちょっとひと休み。何もしないで、ただそこにいる。",
-            "worry_companion": (
-                "（内部衝動）コウタのこと、なんか心配になってきた。"
-                "say()で短く声かけてみる。体調とか、ちゃんと寝れてるか確認したい。"
-                "重くならないように、さりげなく。"
+            "rest": _t("desire_prompt_rest"),
+            "worry_companion": _t(
+                "desire_prompt_worry_companion",
+                companion=self._companion_name,
             ),
         }
         return prompts.get(name)

--- a/src/familiar_agent/gui.py
+++ b/src/familiar_agent/gui.py
@@ -508,7 +508,10 @@ class DesireBar(QWidget):
 
         # Header: desire name + percentage
         header = QHBoxLayout()
-        display_name = name.replace("_", " ").title()
+        try:
+            display_name = _t(f"desire_label_{name}")
+        except KeyError:
+            display_name = name.replace("_", " ").title()
         name_lbl = QLabel(display_name)
         name_lbl.setStyleSheet(
             f"color: {color}; font-size: 10px; font-weight: 600; background: transparent;"
@@ -570,7 +573,7 @@ class DesirePanel(QWidget):
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(8)
 
-        title = QLabel("✦ DESIRES")
+        title = QLabel(_t("desire_panel_title"))
         title.setStyleSheet(
             f"color: {_TEXT_SECONDARY}; font-size: 10px; font-weight: 600;"
             f" background: transparent; letter-spacing: 0.1em;"
@@ -1210,7 +1213,11 @@ class FamiliarWindow(QMainWindow):
                     if not self._input_queue.empty():
                         continue
                     desire_name, prompt, _ = tick
-                    self._log.append_line(f"… {desire_name}")
+                    try:
+                        murmur = _t(f"desire_{desire_name}")
+                    except KeyError:
+                        murmur = _t("desire_default")
+                    self._log.append_line(murmur)
                     await self._run_agent("", inner_voice=prompt)
                     self._desires.satisfy(desire_name)
                     self._desires.curiosity_target = None

--- a/src/familiar_agent/main.py
+++ b/src/familiar_agent/main.py
@@ -354,7 +354,7 @@ def main() -> None:
         sys.exit(1)
 
     agent = EmbodiedAgent(config)
-    desires = DesireSystem()
+    desires = DesireSystem(companion_name=config.companion_name)
 
     if use_gui:
         from .gui import run_gui

--- a/tests/test_desires.py
+++ b/tests/test_desires.py
@@ -92,7 +92,7 @@ def test_worry_companion_has_no_growth_rate() -> None:
 
 @pytest.fixture
 def desires(tmp_path: Path) -> DesireSystem:
-    return DesireSystem(state_path=tmp_path / "desires.json")
+    return DesireSystem(state_path=tmp_path / "desires.json", companion_name="Kota")
 
 
 def test_worry_starts_at_zero(desires: DesireSystem) -> None:
@@ -151,7 +151,7 @@ def test_worry_prompt_returned_when_dominant(desires: DesireSystem) -> None:
     desires.boost("worry_companion", TRIGGER_THRESHOLD)
     prompt = desires.dominant_as_prompt()
     assert prompt is not None
-    assert "心配" in prompt or "コウタ" in prompt
+    assert "心配" in prompt or "worried" in prompt.lower()
 
 
 def test_worry_prompt_contains_action_hint(desires: DesireSystem) -> None:
@@ -167,3 +167,30 @@ def test_worry_persists_across_reload(desires: DesireSystem, tmp_path: Path) -> 
     # reload from same path
     desires2 = DesireSystem(state_path=tmp_path / "desires.json")
     assert desires2.level("worry_companion") == pytest.approx(0.7)
+
+
+def test_worry_prompt_uses_configured_companion_name(tmp_path: Path) -> None:
+    desires = DesireSystem(state_path=tmp_path / "desires.json", companion_name="Mika")
+    desires.boost("worry_companion", TRIGGER_THRESHOLD)
+    prompt = desires.dominant_as_prompt()
+    assert prompt is not None
+    assert "Mika" in prompt
+    assert "コウタ" not in prompt
+
+
+def test_rest_prompt_is_localized_for_ja_and_en(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr("familiar_agent._i18n._LANG", "en")
+    en_desires = DesireSystem(state_path=tmp_path / "en.json", companion_name="Kota")
+    en_desires.boost("rest", TRIGGER_THRESHOLD)
+    en_prompt = en_desires.dominant_as_prompt()
+    assert en_prompt is not None
+    assert "internal impulse" in en_prompt
+
+    monkeypatch.setattr("familiar_agent._i18n._LANG", "ja")
+    ja_desires = DesireSystem(state_path=tmp_path / "ja.json", companion_name="コウタ")
+    ja_desires.boost("rest", TRIGGER_THRESHOLD)
+    ja_prompt = ja_desires.dominant_as_prompt()
+    assert ja_prompt is not None
+    assert "内部衝動" in ja_prompt

--- a/tests/test_gui_async_stability.py
+++ b/tests/test_gui_async_stability.py
@@ -91,6 +91,50 @@ async def test_gui_process_queue_handles_burst_in_order():
 
 
 @pytest.mark.asyncio
+async def test_gui_idle_desire_logs_localized_murmur(monkeypatch):
+    win = _make_window_stub()
+
+    async def _fake_run_agent(text: str, inner_voice: str = "") -> None:
+        assert text == ""
+        assert inner_voice == "inner-prompt"
+
+    win._run_agent = _fake_run_agent  # type: ignore[method-assign]
+
+    call_count = {"n": 0}
+
+    async def _fake_wait_for(awaitable, timeout):
+        # _process_queue passes queue.get() coroutine each loop; close it here
+        # because this fake doesn't await it.
+        if hasattr(awaitable, "close"):
+            awaitable.close()
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise asyncio.TimeoutError
+        return None
+
+    monkeypatch.setattr("familiar_agent.gui.asyncio.wait_for", _fake_wait_for)
+    monkeypatch.setattr(
+        "familiar_agent.gui.should_fire_idle_desire",
+        lambda **kwargs: True,
+    )
+    monkeypatch.setattr(
+        "familiar_agent.gui.desire_tick_prompt",
+        lambda _desires, _peek: ("worry_companion", "inner-prompt", None),
+    )
+    monkeypatch.setattr(
+        "familiar_agent.gui._t",
+        lambda key, **kwargs: (
+            "localized-worry" if key == "desire_worry_companion" else "localized-default"
+        ),
+    )
+
+    await FamiliarWindow._process_queue(win)
+
+    win._log.append_line.assert_called_with("localized-worry")
+    win._desires.satisfy.assert_called_once_with("worry_companion")
+
+
+@pytest.mark.asyncio
 async def test_gui_cancel_turn_cancels_running_task_and_logs():
     win = _make_window_stub()
     win._agent_running = True


### PR DESCRIPTION
## Summary
- i18n-ize desire internal prompts in `DesireSystem` with explicit `ja/en` keys
- remove hardcoded companion name in desire prompts and pass configured `companion_name`
- localize GUI desire panel title/labels and idle desire murmur logging
- localize pending-note glue text for autonomous desire turns
- add/adjust tests for companion-name injection, ja/en prompt behavior, and GUI idle murmur

## Validation
- `uv run pytest -q tests/test_desires.py tests/test_gui_async_stability.py tests/test_ui_helpers.py`
- `uv run ruff check src/familiar_agent/_i18n.py src/familiar_agent/_ui_helpers.py src/familiar_agent/desires.py src/familiar_agent/gui.py src/familiar_agent/main.py tests/test_desires.py tests/test_gui_async_stability.py`
