### PR TITLE
Fix GUI realtime STT wiring and queue integration

### DIFF
--- a/src/familiar_agent/gui.py
+++ b/src/familiar_agent/gui.py
@@ -58,11 +58,13 @@ from ._ui_helpers import (
     format_action,
     should_fire_idle_desire,
 )
+from .realtime_stt_session import create_realtime_stt_session
 
 if TYPE_CHECKING:
     from familiar_agent.agent import EmbodiedAgent
     from familiar_agent.config import AgentConfig
     from familiar_agent.desires import DesireSystem
+    from familiar_agent.realtime_stt_session import RealtimeSttSession
 
 logger = logging.getLogger(__name__)
 
@@ -800,6 +802,8 @@ class FamiliarWindow(QMainWindow):
         self._look_preview_task: asyncio.Task[None] | None = None
         self._look_preview_until: float = 0.0
         self._look_preview_disabled = False
+        self._realtime_stt: RealtimeSttSession | None = create_realtime_stt_session()
+        self._realtime_stt_task: asyncio.Task[None] | None = None
         self._last_lag_tick = time.perf_counter()
         self._lag_timer = QTimer(self)
         self._lag_timer.setInterval(int(_GUI_LOOP_LAG_CHECK_SEC * 1000))
@@ -814,6 +818,8 @@ class FamiliarWindow(QMainWindow):
         self._queue_task = self._create_task(self._process_queue())
         if not self._agent.is_embedding_ready:
             self._init_task = self._create_task(self._show_init_status())
+        if self._realtime_stt:
+            self._realtime_stt_task = self._create_task(self._start_realtime_stt())
 
     def _create_task(self, coro) -> asyncio.Task[Any]:
         """Create an asyncio task from GUI sync callbacks safely.
@@ -1141,6 +1147,7 @@ class FamiliarWindow(QMainWindow):
         if not text:
             return
         self._input.clear()
+        self._stream.clear_status()
         self._log.append_line(f"[{self._companion_display_name}] {text}")
         self._input_queue.put_nowait(text)
         qsize = self._input_queue.qsize()
@@ -1148,6 +1155,41 @@ class FamiliarWindow(QMainWindow):
             logger.warning("GUI input queue backlog: %d", qsize)
         else:
             logger.debug("GUI input queued (size=%d)", qsize)
+
+    def _on_realtime_stt_partial(self, text: str) -> None:
+        """Display partial STT transcript while idle."""
+        if self._closing:
+            return
+        partial = text.strip()
+        if not partial:
+            return
+        if self._agent_running or self._stream.has_content():
+            return
+        self._stream.set_status(f"🎤 {partial}")
+
+    def _on_realtime_stt_committed(self, text: str) -> None:
+        """Display committed STT transcript as a user message bubble."""
+        if self._closing:
+            return
+        spoken = text.strip()
+        if not spoken:
+            return
+        self._stream.clear_status()
+        self._log.append_line(f"[{self._companion_display_name}] {spoken}")
+
+    async def _start_realtime_stt(self) -> None:
+        """Initialize realtime STT and feed transcripts into the GUI input queue."""
+        assert self._realtime_stt is not None
+        try:
+            loop = asyncio.get_event_loop()
+            self._realtime_stt.on_partial = self._on_realtime_stt_partial
+            self._realtime_stt.on_committed = self._on_realtime_stt_committed
+            await self._realtime_stt.start(loop, self._input_queue)
+            self._log.append_line("🎤 Realtime STT ON (ElevenLabs)")
+        except Exception as exc:
+            logger.warning("Realtime STT init failed: %s", exc)
+            self._log.append_line(f"[error] Realtime STT init failed: {exc}")
+            self._realtime_stt = None
 
     def _on_cancel_clicked(self) -> None:
         self._cancel_turn(reason="user")
@@ -1372,6 +1414,15 @@ class FamiliarWindow(QMainWindow):
         """Best-effort async cleanup on window close."""
         self._lag_timer.stop()
         self._cancel_turn(reason="shutdown")
+        if self._realtime_stt_task and not self._realtime_stt_task.done():
+            self._realtime_stt_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._realtime_stt_task
+        self._realtime_stt_task = None
+        if self._realtime_stt:
+            with contextlib.suppress(asyncio.TimeoutError, Exception):
+                await asyncio.wait_for(self._realtime_stt.stop(), timeout=2.0)
+            self._realtime_stt = None
         if self._look_preview_task and not self._look_preview_task.done():
             self._look_preview_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/tests/test_gui_async_stability.py
+++ b/tests/test_gui_async_stability.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import logging
 import time
+from collections.abc import Callable
 from unittest.mock import MagicMock
 
 import pytest
@@ -25,6 +26,31 @@ class _FakeCloseEvent:
         self.ignored = True
 
 
+class _ManualRealtimeStt:
+    """Minimal controllable realtime STT session stub for GUI tests."""
+
+    def __init__(self) -> None:
+        self.on_partial: Callable[[str], None] | None = None
+        self.on_committed: Callable[[str], None] | None = None
+        self._queue: asyncio.Queue[str | None] | None = None
+        self.started = False
+
+    async def start(
+        self, _loop: asyncio.AbstractEventLoop, committed_queue: asyncio.Queue[str | None]
+    ) -> None:
+        self._queue = committed_queue
+        self.started = True
+
+    async def stop(self) -> None:
+        self.started = False
+
+    async def emit_committed(self, text: str) -> None:
+        assert self._queue is not None
+        if self.on_committed:
+            self.on_committed(text)
+        await self._queue.put(text)
+
+
 def _make_window_stub() -> FamiliarWindow:
     win = FamiliarWindow.__new__(FamiliarWindow)
     win._agent_display_name = "Yukine"
@@ -42,8 +68,12 @@ def _make_window_stub() -> FamiliarWindow:
     win._look_preview_task = None
     win._look_preview_until = 0.0
     win._look_preview_disabled = False
+    win._realtime_stt = None
+    win._realtime_stt_task = None
     win._desires = MagicMock()
     win._log = MagicMock()
+    win._stream = MagicMock()
+    win._stream.has_content.return_value = False
     win._send_btn = MagicMock()
     win._stop_btn = MagicMock()
     win._lag_timer = MagicMock()
@@ -88,6 +118,47 @@ async def test_gui_process_queue_handles_burst_in_order():
 
     await asyncio.wait_for(FamiliarWindow._process_queue(win), timeout=1.0)
     assert processed == burst
+
+
+@pytest.mark.asyncio
+async def test_gui_realtime_stt_callbacks_log_and_enqueue_text():
+    win = _make_window_stub()
+    fake_stt = _ManualRealtimeStt()
+    win._realtime_stt = fake_stt  # type: ignore[assignment]
+
+    await FamiliarWindow._start_realtime_stt(win)
+
+    assert fake_stt.started is True
+    assert fake_stt.on_partial is not None
+    assert fake_stt.on_committed is not None
+    win._log.append_line.assert_any_call("🎤 Realtime STT ON (ElevenLabs)")
+
+    fake_stt.on_partial("testing partial")
+    win._stream.set_status.assert_called_with("🎤 testing partial")
+
+    await fake_stt.emit_committed("voice hello")
+    win._stream.clear_status.assert_called()
+    win._log.append_line.assert_any_call("[Kota] voice hello")
+    assert await asyncio.wait_for(win._input_queue.get(), timeout=0.5) == "voice hello"
+
+
+@pytest.mark.asyncio
+async def test_gui_realtime_stt_init_failure_sets_session_none():
+    win = _make_window_stub()
+
+    class _FailRealtimeStt:
+        on_partial = None
+        on_committed = None
+
+        async def start(self, _loop: asyncio.AbstractEventLoop, _queue) -> None:
+            raise RuntimeError("boom")
+
+    win._realtime_stt = _FailRealtimeStt()  # type: ignore[assignment]
+
+    await FamiliarWindow._start_realtime_stt(win)
+
+    assert win._realtime_stt is None
+    win._log.append_line.assert_any_call("[error] Realtime STT init failed: boom")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- wire `RealtimeSttSession` into GUI startup so realtime STT actually runs in GUI mode
- route partial transcripts to GUI status line and committed transcripts to chat log + existing input queue
- clear status text when typed messages are sent to avoid stale partial overlays
- stop realtime STT cleanly during GUI shutdown
- add GUI regression tests for successful STT wiring and init-failure fallback

## Validation
- `uv run pytest -q tests/test_gui_async_stability.py tests/test_ui_helpers.py tests/test_desires.py`
- `uv run ruff check src/familiar_agent/gui.py tests/test_gui_async_stability.py`
