### PR TITLE
[codex] Add GUI launchers and macOS audio fallback

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Agent replies no longer wait on post-response memory/self-model updates, and TAPE planning is skipped when no separate utility backend is configured
 - System prompts now surface at most one active concern and one recent misaligned intention trace, while post-response updates carry those states forward without adding hot-path LLM calls
 
+### Fixed
+- `scripts/new_migration.sh` now accepts Windows-style `--dir` paths in Git Bash so cross-platform CI migration tests pass on `windows-latest`
+
 ## [0.1.0] - 2026-02-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   - Filler word filtering and deduplication
   - Opt-in via `REALTIME_STT=true` in `.env`
   - Coexists with existing batch STT (Ctrl+T / Space PTT)
+- Dedicated `run-gui.sh` / `run-gui.bat` launchers for opening the desktop GUI without changing the existing TUI defaults
 - Support for full RTSP URLs in `CAMERA_HOST` (enables ATOMCam and other non-standard RTSP paths)
 - Persistent latent self state driven by workspace broadcasts, with prompt-visible interoception updates and dedicated test coverage
 - Action-conditioned prediction with agency-error tracking for `see` / `look` / `walk`, including scene integration and focused tests
@@ -23,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - GUI settings dialog now keeps JP labels fully visible (including short labels like `名`), refreshed the app to a bright, soft, rounded light theme, split first-turn startup status from "thinking", and increased GUI font sizing for readability.
+- Local TTS playback now prefers `afplay` on macOS, documents the actual platform-specific fallback chain, and CI now runs the test suite on Ubuntu, macOS, and Windows runners
 - Interoception now reflects internal self-state signals in addition to time, uptime, social context, and mood
 - Prediction signals now distinguish external surprise from mismatches in the agent's own embodied actions
 - Self-narrative entries now record their trigger and suppress duplicate same-day rewrites

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ Or: `winget install astral-sh.uv`
 
 ### 2. Install ffmpeg
 
-ffmpeg is **required** for camera image capture and audio playback.
+ffmpeg is **required** for camera image capture and camera-speaker playback via go2rtc.
+Local PC audio playback can also use built-in OS players (`afplay` on macOS) or the
+pure-Python fallback.
 
 | OS | Command |
 |----|---------|
@@ -153,13 +155,17 @@ cp persona-template/en.md ME.md
 
 **macOS / Linux / WSL2:**
 ```bash
-./run.sh             # Textual TUI (recommended)
+./run.sh             # Textual TUI (backward-compatible default)
+./run-gui.sh         # Desktop GUI launcher
+./run.sh --gui       # Desktop GUI (same as run-gui.sh)
 ./run.sh --no-tui    # Plain REPL
 ```
 
 **Windows:**
 ```bat
-run.bat              # Textual TUI (recommended)
+run.bat              # Textual TUI (backward-compatible default)
+run-gui.bat          # Desktop GUI launcher
+run.bat --gui        # Desktop GUI (same as run-gui.bat)
 run.bat --no-tui     # Plain REPL
 ```
 
@@ -277,6 +283,7 @@ API_KEY=sk-...
 ```
 
 Run `./run.sh` (macOS/Linux/WSL2) or `run.bat` (Windows) and start chatting. Add hardware as you go.
+If you want the desktop GUI directly, use `./run-gui.sh` or `run-gui.bat`.
 
 ### Wi-Fi PTZ camera (Tapo C220)
 
@@ -355,14 +362,17 @@ Set `TTS_OUTPUT=remote` (or `both`). Requires [go2rtc](https://github.com/AlexxI
 
 #### B) Local PC speaker
 
-The default (`TTS_OUTPUT=local`). Tries players in order: **paplay** → **mpv** → **ffplay**. Also used as a fallback when `TTS_OUTPUT=remote` and go2rtc is unavailable.
+The default (`TTS_OUTPUT=local`). Tries players in order:
+**afplay (macOS)** → **paplay** → **mpv** → **sounddevice**.
+On Windows, MP3 playback can also fall back to built-in **MCI** if no external player is available.
+Local playback is also used as a fallback when `TTS_OUTPUT=remote` and go2rtc is unavailable.
 
 | OS | Install |
 |----|---------|
-| macOS | `brew install mpv` |
+| macOS | No extra player required (`afplay` is built in). Optional: `brew install mpv` |
 | Ubuntu / Debian | `sudo apt install mpv` (or `paplay` via `pulseaudio-utils`) |
 | WSL2 / WSLg | `sudo apt install pulseaudio-utils` — set `PULSE_SERVER=unix:/mnt/wslg/PulseServer` in `.env` |
-| Windows | [mpv.io/installation](https://mpv.io/installation/) — download and add to PATH, **or** `winget install ffmpeg` |
+| Windows | [mpv.io/installation](https://mpv.io/installation/) — download and add to PATH. Without it, familiar-ai still tries built-in/Python fallbacks |
 
 > If no audio player is available, speech is still generated — it just won't play.
 

--- a/run-gui.bat
+++ b/run-gui.bat
@@ -1,0 +1,3 @@
+@echo off
+cd /d "%~dp0"
+uv run familiar --gui %*

--- a/run-gui.sh
+++ b/run-gui.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")"
+exec uv run familiar --gui "$@"

--- a/scripts/new_migration.sh
+++ b/scripts/new_migration.sh
@@ -68,10 +68,19 @@ if [[ ! "$migration_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
   exit 1
 fi
 
-# GitHub Windows runners pass temp dirs as C:\...; normalize separators for bash file ops.
+display_dir="$migration_dir"
+used_windows_dir=0
+
+# GitHub Windows runners pass temp dirs as C:\...; use cygpath for bash file ops.
 case "$migration_dir" in
   [A-Za-z]:\\*|[A-Za-z]:/*)
-    migration_dir="${migration_dir//\\//}"
+    used_windows_dir=1
+    display_dir="${migration_dir//\\//}"
+    if command -v cygpath >/dev/null 2>&1; then
+      migration_dir="$(cygpath -u "$migration_dir")"
+    else
+      migration_dir="$display_dir"
+    fi
     ;;
 esac
 
@@ -104,7 +113,7 @@ if [[ -e "$target" ]]; then
   exit 1
 fi
 
-cat > "$target" <<'PY'
+cat > "$target" <<'PY2'
 """TODO: describe migration."""
 
 from __future__ import annotations
@@ -117,6 +126,11 @@ def upgrade(conn: sqlite3.Connection) -> None:
     # Example:
     # conn.execute("CREATE TABLE example (id INTEGER PRIMARY KEY)")
     pass
-PY
+PY2
 
-echo "$target"
+display_target="$target"
+if ((used_windows_dir)); then
+  display_target="$display_dir/${migration_date}-${next_seq}_${slug}.py"
+fi
+
+echo "$display_target"

--- a/scripts/new_migration.sh
+++ b/scripts/new_migration.sh
@@ -68,6 +68,13 @@ if [[ ! "$migration_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
   exit 1
 fi
 
+# GitHub Windows runners pass temp dirs as C:\...; normalize separators for bash file ops.
+case "$migration_dir" in
+  [A-Za-z]:\\*|[A-Za-z]:/*)
+    migration_dir="${migration_dir//\\//}"
+    ;;
+esac
+
 slug="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
 if [[ -z "$slug" ]]; then
   slug="migration"

--- a/src/familiar_agent/gui.py
+++ b/src/familiar_agent/gui.py
@@ -11,7 +11,7 @@ Provides a native desktop window with:
 Launch via:
     uv run familiar --gui
 
-or via run.bat --gui / run.sh --gui
+or via run-gui.bat / run-gui.sh
 """
 
 from __future__ import annotations

--- a/src/familiar_agent/tools/tts.py
+++ b/src/familiar_agent/tools/tts.py
@@ -344,13 +344,36 @@ async def _play_local(tmp_path: str) -> bool:
     """Play audio file on the local PC speaker. Returns True on success.
 
     Try order:
-    1. paplay (PulseAudio native — most reliable on WSL2/WSLg when PULSE_SERVER is set)
-    2. mpv (auto audio backend selection)
-    3. sounddevice (pure Python fallback, no system tools required)
+    1. afplay (macOS built-in)
+    2. paplay (PulseAudio native — most reliable on WSL2/WSLg when PULSE_SERVER is set)
+    3. mpv (auto audio backend selection)
+    4. sounddevice (pure Python fallback, no system tools required)
 
     Note: file is always WAV (pcm_16000) so paplay needs no ffmpeg conversion.
     """
     pulse_env = _pulse_env()
+
+    # --- afplay (macOS built-in) ---
+    if sys.platform == "darwin":
+        afplay = shutil.which("afplay")
+        if afplay:
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    afplay,
+                    tmp_path,
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                _, stderr = await proc.communicate()
+                if proc.returncode == 0:
+                    return True
+                logger.warning(
+                    "afplay failed (exit %d): %s",
+                    proc.returncode,
+                    stderr.decode(errors="replace")[:120],
+                )
+            except (FileNotFoundError, OSError) as e:
+                logger.warning("Could not launch afplay: %s", e)
 
     # --- paplay (PulseAudio native, WAV only) ---
     paplay = shutil.which("paplay")

--- a/tests/test_new_migration_script.py
+++ b/tests/test_new_migration_script.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -8,6 +9,12 @@ from pathlib import Path
 def _bash_executable() -> str:
     if os.name != "nt":
         return "bash"
+
+    git_exe = shutil.which("git.exe") or shutil.which("git")
+    if git_exe:
+        git_bash = Path(git_exe).with_name("bash.exe")
+        if git_bash.exists():
+            return str(git_bash)
 
     candidates = [
         Path(os.environ.get("ProgramW6432", r"C:\Program Files")) / "Git" / "bin" / "bash.exe",

--- a/tests/test_new_migration_script.py
+++ b/tests/test_new_migration_script.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -28,3 +29,74 @@ def test_new_migration_script_increments_sequence(tmp_path) -> None:
     second = _run_script(tmp_path, "second", "--date", "2026-03-03")
     assert first.name.startswith("2026-03-03-001_")
     assert second.name.startswith("2026-03-03-002_")
+
+
+def test_new_migration_script_accepts_windows_style_dir_with_cygpath(tmp_path) -> None:
+    script = Path.cwd() / "scripts" / "new_migration.sh"
+    fake_cygdrive = tmp_path / "cygdrive" / "c"
+    fake_cygdrive.mkdir(parents=True)
+    fake_root_name = f"fake-root-{tmp_path.name}"
+    fake_root = fake_cygdrive / fake_root_name
+    fake_root.mkdir()
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_cygpath = fake_bin / "cygpath"
+    fake_cygpath.write_text(
+        r"""#!/usr/bin/env bash
+set -euo pipefail
+
+mode="$1"
+path="$2"
+fake_cygdrive="${FAKE_CYGDRIVE:?}"
+path="${path//\\//}"
+
+case "$mode" in
+  -u)
+    case "$path" in
+      C:/*)
+        root_name="${path#C:/}"
+        root_name="${root_name%%/*}"
+        suffix="${path#C:/$root_name/}"
+        printf '%s/%s/%s\n' "$fake_cygdrive" "$root_name" "$suffix"
+        ;;
+      *)
+        printf '%s\n' "$path"
+        ;;
+    esac
+    ;;
+  *)
+    echo "unsupported cygpath mode: $mode" >&2
+    exit 1
+    ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    fake_cygpath.chmod(0o755)
+
+    env = os.environ.copy()
+    env["FAKE_CYGDRIVE"] = str(fake_cygdrive)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    windows_dir = rf"C:\{fake_root_name}\migrations"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(script),
+            "Add memory jobs table",
+            "--date",
+            "2026-03-03",
+            "--dir",
+            windows_dir,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.stdout.strip() == (
+        f"C:/{fake_root_name}/migrations/2026-03-03-001_add_memory_jobs_table.py"
+    )
+    actual = fake_root / "migrations" / "2026-03-03-001_add_memory_jobs_table.py"
+    assert actual.exists()

--- a/tests/test_new_migration_script.py
+++ b/tests/test_new_migration_script.py
@@ -5,10 +5,28 @@ import subprocess
 from pathlib import Path
 
 
+def _bash_executable() -> str:
+    if os.name != "nt":
+        return "bash"
+
+    candidates = [
+        Path(os.environ.get("ProgramW6432", r"C:\Program Files")) / "Git" / "bin" / "bash.exe",
+        Path(os.environ.get("ProgramFiles", r"C:\Program Files")) / "Git" / "bin" / "bash.exe",
+        Path(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"))
+        / "Git"
+        / "bin"
+        / "bash.exe",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+    return "bash"
+
+
 def _run_script(tmp_path: Path, *args: str) -> Path:
     script = Path.cwd() / "scripts" / "new_migration.sh"
     result = subprocess.run(
-        ["bash", str(script), *args, "--dir", str(tmp_path)],
+        [_bash_executable(), str(script), *args, "--dir", str(tmp_path)],
         check=True,
         capture_output=True,
         text=True,
@@ -81,7 +99,7 @@ esac
 
     result = subprocess.run(
         [
-            "bash",
+            _bash_executable(),
             str(script),
             "Add memory jobs table",
             "--date",

--- a/tests/test_new_migration_script.py
+++ b/tests/test_new_migration_script.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+
+import pytest
 from pathlib import Path
 
 
@@ -56,6 +58,7 @@ def test_new_migration_script_increments_sequence(tmp_path) -> None:
     assert second.name.startswith("2026-03-03-002_")
 
 
+@pytest.mark.skipif(os.name == "nt", reason="fake cygpath shim is only needed off Windows")
 def test_new_migration_script_accepts_windows_style_dir_with_cygpath(tmp_path) -> None:
     script = Path.cwd() / "scripts" / "new_migration.sh"
     fake_cygdrive = tmp_path / "cygdrive" / "c"

--- a/tests/test_tts_no_ffmpeg.py
+++ b/tests/test_tts_no_ffmpeg.py
@@ -92,6 +92,7 @@ async def test_tts_payload_requests_pcm_format() -> None:
     tool._lock = __import__("asyncio").Lock()
 
     captured_payload: dict = {}
+    captured_url = ""
 
     class FakeResp:
         status = 200
@@ -111,6 +112,9 @@ async def test_tts_payload_requests_pcm_format() -> None:
 
     class FakePost:
         def __init__(self, *a, **kw):
+            nonlocal captured_url
+            if a:
+                captured_url = a[0]
             captured_payload.update(kw.get("json", {}))
 
         async def __aenter__(self):
@@ -133,9 +137,10 @@ async def test_tts_payload_requests_pcm_format() -> None:
         with patch("aiohttp.ClientSession", return_value=FakeSession()):
             await tool.say("テスト")
 
-    assert captured_payload.get("output_format") == "pcm_16000", (
-        f"Expected output_format=pcm_16000, got: {captured_payload.get('output_format')}"
+    assert "output_format=pcm_16000" in captured_url, (
+        f"Expected output_format=pcm_16000 in URL, got: {captured_url}"
     )
+    assert captured_payload.get("model_id") == "eleven_v3"
 
 
 # ---------------------------------------------------------------------------
@@ -176,3 +181,36 @@ async def test_play_via_sounddevice_called_as_fallback(tmp_path) -> None:
 
     assert result is True
     mock_sd.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_play_local_prefers_afplay_on_macos(tmp_path) -> None:
+    """macOS should try built-in afplay before other local playback fallbacks."""
+    from familiar_agent.tools import tts
+
+    pcm = _make_pcm(1600)
+    wav_path = _write_pcm_as_wav(pcm, sample_rate=16000, tmp_dir=str(tmp_path))
+
+    proc = AsyncMock()
+    proc.communicate.return_value = (b"", b"")
+    proc.returncode = 0
+
+    def _which(name: str) -> str | None:
+        if name == "afplay":
+            return "/usr/bin/afplay"
+        return None
+
+    with (
+        patch.object(tts.sys, "platform", "darwin"),
+        patch("shutil.which", side_effect=_which),
+        patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)) as mock_exec,
+        patch(
+            "familiar_agent.tools.tts._play_via_sounddevice", new=AsyncMock(return_value=True)
+        ) as mock_sd,
+    ):
+        result = await tts._play_local(wav_path)
+
+    assert result is True
+    mock_exec.assert_awaited_once()
+    assert mock_exec.await_args.args[:2] == ("/usr/bin/afplay", wav_path)
+    mock_sd.assert_not_called()


### PR DESCRIPTION
## Summary
- add dedicated `run-gui.sh` and `run-gui.bat` launchers without changing the existing TUI defaults
- prefer `afplay` for local TTS playback on macOS before falling back to the existing cross-platform chain
- update docs, changelog, and GitHub Actions test workflow to reflect the actual platform support story and run tests on Ubuntu/macOS/Windows

## Why
The project already had working TUI paths and partial local-audio fallbacks, but the GUI entry path was implicit and the platform story was inconsistent:
- macOS did not use its built-in local audio player
- README described a different audio fallback chain than the implementation
- CI only exercised Ubuntu, so Windows/macOS regressions could slip through unnoticed

## User Impact
- existing `run.sh` / `run.bat` behavior stays unchanged for current TUI users
- users who want the desktop GUI now have explicit launchers on both shell and batch environments
- macOS users get a better out-of-the-box local speech playback path
- platform regressions should be caught earlier once the new CI matrix runs

## Validation
- `uv run pytest -q tests/test_tts.py tests/test_tts_no_ffmpeg.py`
- `uv run --group dev mypy src/familiar_agent`
- `uv run ruff check src/familiar_agent/tools/tts.py src/familiar_agent/gui.py tests/test_tts_no_ffmpeg.py`
- `bash -n run-gui.sh`
- `git diff --check`

## Notes
- `uv.lock` had unrelated local noise from environment-specific resolution and was intentionally left out of this PR.
