### PR TITLE
[codex] Automate the develop-to-main release flow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,45 @@
+name: Prepare Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version to prepare (X.Y.Z)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-release-pr:
+    runs-on: ubuntu-latest
+    if: github.ref_name == 'develop'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Prepare release files
+        run: python scripts/release_flow.py prepare "${{ inputs.version }}"
+
+      - name: Create release PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: release/v${{ inputs.version }}
+          base: main
+          commit-message: chore(release): prepare v${{ inputs.version }}
+          title: chore(release): prepare v${{ inputs.version }}
+          body: |
+            ## Summary
+            - bump `pyproject.toml` to `${{ inputs.version }}`
+            - roll `CHANGELOG.md` `Unreleased` into the `${{ inputs.version }}` release section
+            - prepare the release branch for merge into `main`
+          draft: true
+          delete-branch: true

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,55 @@
+name: Tag Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Read release version
+        id: version
+        run: |
+          version="$(python scripts/release_flow.py version)"
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Skip when tag already exists
+        id: tag-check
+        run: |
+          if git rev-parse "refs/tags/v${{ steps.version.outputs.value }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate release notes
+        if: steps.tag-check.outputs.exists == 'false'
+        run: python scripts/release_flow.py notes "${{ steps.version.outputs.value }}" > release-notes.md
+
+      - name: Create annotated git tag
+        if: steps.tag-check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ steps.version.outputs.value }}" -m "Release v${{ steps.version.outputs.value }}"
+          git push origin "v${{ steps.version.outputs.value }}"
+
+      - name: Create GitHub release
+        if: steps.tag-check.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.value }}
+          name: v${{ steps.version.outputs.value }}
+          body_path: release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- GitHub Actions-based release automation for the new `develop -> main -> tag` flow, including a manual release PR workflow and an automatic tag/release workflow on `main`
 - Realtime STT via ElevenLabs Scribe v2 Realtime WebSocket API
   - Always-on, hands-free voice input with VAD auto-commit
   - Works in both REPL (`--no-tui`) and TUI modes
@@ -23,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Lightweight layered self continuity with inertial proto-self updates, recent intention-result traces, and persistent active concerns
 
 ### Changed
+- Lint and test workflows now run for both `develop` and `main`, matching the new default-branch strategy
 - GUI settings dialog now keeps JP labels fully visible (including short labels like `名`), refreshed the app to a bright, soft, rounded light theme, split first-turn startup status from "thinking", and increased GUI font sizing for readability.
 - Local TTS playback now prefers `afplay` on macOS, documents the actual platform-specific fallback chain, and CI now runs the test suite on Ubuntu, macOS, and Windows runners
 - Interoception now reflects internal self-state signals in addition to time, uptime, social context, and mood

--- a/README.md
+++ b/README.md
@@ -438,6 +438,14 @@ Curious about how it works? See [docs/technical.md](./docs/technical.md) for the
 
 familiar-ai is an open experiment. If any of this resonates with you — technically or philosophically — contributions are very welcome.
 
+### Release Flow
+
+- `develop` is the default integration branch.
+- Run the **Prepare Release PR** workflow from `develop` with a target version like `0.6.0`.
+- The workflow creates or updates `release/v0.6.0`, bumps `pyproject.toml`, and rolls `CHANGELOG.md` `Unreleased` into `## [0.6.0] - YYYY-MM-DD`.
+- Merge that release PR into `main` when it is stable enough to ship.
+- Pushing to `main` triggers **Tag Release**, which creates `v0.6.0` and a GitHub Release from the matching changelog section.
+
 **Good places to start:**
 
 | Area | What's needed |

--- a/scripts/release_flow.py
+++ b/scripts/release_flow.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Helpers for the develop -> main release flow.
+
+Commands:
+  version                  Print the current project version from pyproject.toml.
+  prepare VERSION          Update pyproject.toml and roll CHANGELOG.md Unreleased into VERSION.
+  notes VERSION            Print the CHANGELOG section for VERSION.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+CHANGELOG = ROOT / "CHANGELOG.md"
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+VERSION_LINE_RE = re.compile(r'^(version\s*=\s*")([^"]+)(")$', re.MULTILINE)
+UNRELEASED_RE = re.compile(r"(?ms)^## \[Unreleased\]\n(?P<body>.*?)(?=^## \[|\Z)")
+RELEASE_SECTION_RE = re.compile(
+    r"(?ms)^## \[(?P<version>[^\]]+)\] - (?P<date>\d{4}-\d{2}-\d{2})\n(?P<body>.*?)(?=^## \[|\Z)"
+)
+
+EMPTY_UNRELEASED_TEMPLATE = "### Added\n\n### Changed\n\n### Fixed\n"
+
+
+@dataclass(frozen=True)
+class PreparedRelease:
+    version: str
+    release_date: str
+
+
+def read_version(pyproject_path: Path = PYPROJECT) -> str:
+    content = pyproject_path.read_text(encoding="utf-8")
+    match = VERSION_LINE_RE.search(content)
+    if not match:
+        raise ValueError(f"Could not find version in {pyproject_path}")
+    return match.group(2)
+
+
+def write_version(version: str, pyproject_path: Path = PYPROJECT) -> None:
+    content = pyproject_path.read_text(encoding="utf-8")
+    updated, count = VERSION_LINE_RE.subn(rf"\g<1>{version}\g<3>", content, count=1)
+    if count != 1:
+        raise ValueError(f"Could not update version in {pyproject_path}")
+    pyproject_path.write_text(updated, encoding="utf-8")
+
+
+def _normalize_body(body: str) -> str:
+    trimmed = body.strip()
+    return (trimmed + "\n") if trimmed else ""
+
+
+def _validate_version(version: str) -> None:
+    if not SEMVER_RE.fullmatch(version):
+        raise ValueError(f"Version must match X.Y.Z: {version}")
+
+
+def _is_placeholder_only_unreleased(body: str) -> bool:
+    normalize = lambda s: re.sub(r"\s+", "", s)  # noqa: E731
+    return normalize(body) == normalize(EMPTY_UNRELEASED_TEMPLATE)
+
+
+def prepare_release(
+    version: str,
+    *,
+    release_date: str | None = None,
+    pyproject_path: Path = PYPROJECT,
+    changelog_path: Path = CHANGELOG,
+) -> PreparedRelease:
+    _validate_version(version)
+    current_version = read_version(pyproject_path)
+    if version == current_version:
+        raise ValueError(f"Version {version} already matches pyproject.toml")
+
+    changelog = changelog_path.read_text(encoding="utf-8")
+    unreleased_match = UNRELEASED_RE.search(changelog)
+    if not unreleased_match:
+        raise ValueError("Could not find [Unreleased] section in CHANGELOG.md")
+    if re.search(rf"(?m)^## \[{re.escape(version)}\] - ", changelog):
+        raise ValueError(f"CHANGELOG.md already contains a section for {version}")
+
+    chosen_date = release_date or date.today().isoformat()
+    unreleased_body = _normalize_body(unreleased_match.group("body"))
+    if not unreleased_body:
+        raise ValueError("CHANGELOG.md [Unreleased] section is empty")
+    if _is_placeholder_only_unreleased(unreleased_body):
+        raise ValueError("CHANGELOG.md [Unreleased] section only contains empty placeholders")
+
+    new_unreleased = f"## [Unreleased]\n\n{EMPTY_UNRELEASED_TEMPLATE}\n"
+    new_release = f"## [{version}] - {chosen_date}\n\n{unreleased_body}"
+    updated_changelog = (
+        changelog[: unreleased_match.start()]
+        + new_unreleased
+        + new_release
+        + changelog[unreleased_match.end() :]
+    )
+    # Normalize any triple-newline seams created by replacement.
+    updated_changelog = re.sub(r"\n{4,}", "\n\n\n", updated_changelog)
+
+    write_version(version, pyproject_path)
+    changelog_path.write_text(updated_changelog, encoding="utf-8")
+    return PreparedRelease(version=version, release_date=chosen_date)
+
+
+def extract_release_notes(version: str, changelog_path: Path = CHANGELOG) -> str:
+    changelog = changelog_path.read_text(encoding="utf-8")
+    for match in RELEASE_SECTION_RE.finditer(changelog):
+        if match.group("version") == version:
+            body = _normalize_body(match.group("body"))
+            if not body:
+                raise ValueError(f"Release {version} has no notes in CHANGELOG.md")
+            return f"## [{version}] - {match.group('date')}\n\n{body}"
+    raise ValueError(f"Could not find CHANGELOG section for {version}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Release helpers for familiar-ai")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("version", help="Print the current project version")
+
+    prepare_cmd = sub.add_parser(
+        "prepare", help="Prepare a release by updating version + changelog"
+    )
+    prepare_cmd.add_argument("version", help="Release version (X.Y.Z)")
+    prepare_cmd.add_argument(
+        "--date",
+        dest="release_date",
+        default="",
+        help="Release date in YYYY-MM-DD format (default: today)",
+    )
+
+    notes_cmd = sub.add_parser("notes", help="Print release notes for a version")
+    notes_cmd.add_argument("version", help="Release version (X.Y.Z)")
+
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.command == "version":
+        print(read_version())
+        return 0
+
+    if args.command == "prepare":
+        prepared = prepare_release(args.version, release_date=args.release_date or None)
+        print(f"Prepared release {prepared.version} ({prepared.release_date})")
+        return 0
+
+    if args.command == "notes":
+        print(extract_release_notes(args.version), end="")
+        return 0
+
+    parser.error(f"Unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_flow.py
+++ b/tests/test_release_flow.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.release_flow import extract_release_notes, prepare_release, read_version
+
+
+def test_prepare_release_updates_version_and_changelog(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "familiar-ai"\nversion = "0.5.0"\n',
+        encoding="utf-8",
+    )
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "### Added\n"
+        "- New thing\n\n"
+        "### Changed\n"
+        "- Tweaked thing\n\n"
+        "## [0.5.0] - 2026-04-01\n\n"
+        "### Added\n"
+        "- Old thing\n",
+        encoding="utf-8",
+    )
+
+    prepared = prepare_release(
+        "0.6.0",
+        release_date="2026-04-05",
+        pyproject_path=pyproject,
+        changelog_path=changelog,
+    )
+
+    assert prepared.version == "0.6.0"
+    assert read_version(pyproject) == "0.6.0"
+
+    updated = changelog.read_text(encoding="utf-8")
+    assert "## [Unreleased]\n\n### Added\n\n### Changed\n\n### Fixed\n" in updated
+    assert "## [0.6.0] - 2026-04-05" in updated
+    assert "- New thing" in updated
+    assert "- Tweaked thing" in updated
+
+
+def test_prepare_release_rejects_empty_unreleased(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "familiar-ai"\nversion = "0.5.0"\n',
+        encoding="utf-8",
+    )
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n\n## [Unreleased]\n\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="empty"):
+        prepare_release("0.6.0", pyproject_path=pyproject, changelog_path=changelog)
+
+
+def test_prepare_release_rejects_placeholder_only_unreleased(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "familiar-ai"\nversion = "0.5.0"\n',
+        encoding="utf-8",
+    )
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n## [Unreleased]\n\n### Added\n\n### Changed\n\n### Fixed\n\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="placeholders"):
+        prepare_release("0.6.0", pyproject_path=pyproject, changelog_path=changelog)
+
+
+def test_extract_release_notes_returns_matching_section(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "### Added\n\n"
+        "## [0.6.0] - 2026-04-05\n\n"
+        "### Added\n"
+        "- New thing\n\n"
+        "### Fixed\n"
+        "- Bug fix\n\n"
+        "## [0.5.0] - 2026-04-01\n\n"
+        "### Added\n"
+        "- Old thing\n",
+        encoding="utf-8",
+    )
+
+    notes = extract_release_notes("0.6.0", changelog_path=changelog)
+
+    assert notes.startswith("## [0.6.0] - 2026-04-05")
+    assert "- New thing" in notes
+    assert "- Bug fix" in notes


### PR DESCRIPTION
## Summary
- add release automation workflows for the new `develop -> main -> tag` strategy
- introduce a small helper script plus tests to prepare release versions and extract changelog notes
- update CI triggers and README guidance so day-to-day development now follows `develop`

## What changed
- added `scripts/release_flow.py` to:
  - read the current version from `pyproject.toml`
  - prepare a release by bumping the version and rolling `CHANGELOG.md` `Unreleased` into a dated release section
  - extract release notes for a tagged version
- added `tests/test_release_flow.py` for the release helper behavior
- added **Prepare Release PR** workflow:
  - manually dispatched from `develop`
  - creates or updates `release/vX.Y.Z`
  - opens a draft PR into `main`
- added **Tag Release** workflow:
  - runs on push to `main`
  - creates `vX.Y.Z` and a GitHub Release from the matching changelog section
- updated `lint.yml` and `test.yml` to run on both `develop` and `main`
- documented the release flow in `README.md`

## Why
We changed the repository strategy so `develop` is the integration branch and `main` becomes the release line. Without explicit automation, version bumps, changelog cuts, release PR creation, and tagging would stay manual and easy to drift.

## Validation
- `uv run pytest -q tests/test_release_flow.py`
- `uv run pytest -q tests/test_tts.py tests/test_tts_no_ffmpeg.py`
- `uv run ruff check scripts/release_flow.py tests/test_release_flow.py`
- `uv run --group dev mypy scripts/release_flow.py`
- `git diff --check`

## Notes
- `uv.lock` had unrelated local noise from environment-specific resolution and was intentionally left out of this PR.
