### PR TITLE
fix(voice): block realtime stt self-echo loops

### DIFF
--- a/src/familiar_agent/realtime_stt_session.py
+++ b/src/familiar_agent/realtime_stt_session.py
@@ -24,6 +24,8 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from .voice_guard import VoiceLoopGuard, get_shared_voice_guard
+
 if TYPE_CHECKING:
     from .tools.realtime_stt import RealtimeSttClient
     from .tools.mic import MicCapture
@@ -88,14 +90,22 @@ class RealtimeSttSession:
                       (called *before* the text is placed on the queue).
     """
 
-    def __init__(self, api_key: str, language_code: str = "ja") -> None:
+    def __init__(
+        self,
+        api_key: str,
+        language_code: str = "ja",
+        *,
+        voice_guard: VoiceLoopGuard | None = None,
+    ) -> None:
         self._api_key = api_key
         self._language_code = language_code.strip()
+        self._voice_guard = voice_guard or get_shared_voice_guard()
         self._stt_client: RealtimeSttClient | None = None
         self._mic_capture: MicCapture | None = None
         self._relay_task: asyncio.Task | None = None
         self._partial_task: asyncio.Task | None = None
         self._monitor_task: asyncio.Task | None = None
+        self._restart_task: asyncio.Task[bool] | None = None
         self._committed_queue: asyncio.Queue[str | None] | None = None
         self._incoming_committed: asyncio.Queue[str] = asyncio.Queue()
         self._incoming_partial: asyncio.Queue[str] = asyncio.Queue()
@@ -111,7 +121,7 @@ class RealtimeSttSession:
         # Display callbacks (set by caller before start())
         self.on_partial: Callable[[str], None] | None = None
         self.on_committed: Callable[[str], None] | None = None
-        self.on_restart: Callable[[str], None] | None = None
+        self.on_watchdog_restart: Callable[[str], None] | None = None
 
     @property
     def active(self) -> bool:
@@ -122,6 +132,11 @@ class RealtimeSttSession:
     def connected(self) -> bool:
         """True while the websocket transport is currently live."""
         return bool(self._stt_client and self._stt_client.connected)
+
+    @property
+    def gated(self) -> bool:
+        """True while TTS is currently gating STT commit/partial handling."""
+        return self._voice_guard.gated
 
     async def start(
         self,
@@ -159,7 +174,10 @@ class RealtimeSttSession:
         if self._mic_capture:
             self._mic_capture.stop()
             self._mic_capture = None
+        current_task = asyncio.current_task()
         for task in (self._relay_task, self._partial_task, self._monitor_task):
+            if task is current_task:
+                continue
             if task:
                 task.cancel()
                 try:
@@ -172,10 +190,19 @@ class RealtimeSttSession:
         if self._stt_client:
             await self._stt_client.close()
             self._stt_client = None
+        restart_task = self._restart_task
+        if restart_task and restart_task is not current_task and not restart_task.done():
+            restart_task.cancel()
+            try:
+                await restart_task
+            except asyncio.CancelledError:
+                pass
+        if restart_task is not current_task:
+            self._restart_task = None
         logger.info("Realtime STT session stopped")
 
     async def restart(self, reason: str = "manual") -> bool:
-        """Reconnect the realtime STT session using the stored loop/queue."""
+        """Reconnect the realtime STT transport and microphone pipeline."""
         if self._loop is None or self._committed_queue is None:
             logger.debug("Realtime STT restart skipped before initial start (%s)", reason)
             return False
@@ -235,6 +262,18 @@ class RealtimeSttSession:
             return
         await client.send_audio(pcm16le)
 
+    def _schedule_restart(self, reason: str) -> None:
+        if self._stopping:
+            return
+        if self._restart_task and not self._restart_task.done():
+            return
+        if self.on_watchdog_restart:
+            try:
+                self.on_watchdog_restart(reason)
+            except Exception:
+                logger.exception("Realtime STT watchdog callback failed")
+        self._restart_task = asyncio.create_task(self.restart(reason))
+
     async def _committed_relay(self) -> None:
         assert self._committed_queue is not None
         while True:
@@ -253,6 +292,12 @@ class RealtimeSttSession:
             ):
                 logger.debug("Dropped duplicate realtime STT transcript: %s", text)
                 continue
+            decision = self._voice_guard.check_transcript(text)
+            if decision.blocked:
+                logger.info("Realtime STT gated transcript (%s): %r", decision.reason, text)
+                if decision.should_restart:
+                    self._schedule_restart("watchdog_loop")
+                continue
             self._last_normalized_text = normalized
             self._last_time = now
             if self.on_committed:
@@ -265,11 +310,64 @@ class RealtimeSttSession:
             if _looks_like_audio_event(text):
                 logger.debug("Realtime STT dropped audio-event partial: %r", text)
                 continue
+            if self._voice_guard.should_gate_partial(text):
+                logger.debug("Realtime STT gated partial transcript: %r", text)
+                continue
             if self.on_partial:
                 self.on_partial(text)
 
 
-def create_realtime_stt_session() -> RealtimeSttSession | None:
+class RealtimeSttController:
+    """UI-facing controller that wraps realtime STT session start/stop/restart."""
+
+    def __init__(self, session: RealtimeSttSession) -> None:
+        self._session = session
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._committed_queue: asyncio.Queue[str | None] | None = None
+        self.on_partial: Callable[[str], None] | None = None
+        self.on_committed: Callable[[str], None] | None = None
+        self.on_restart: Callable[[str], None] | None = None
+
+    @property
+    def active(self) -> bool:
+        return self._session.active
+
+    @property
+    def connected(self) -> bool:
+        return self._session.connected
+
+    @property
+    def gated(self) -> bool:
+        return self._session.gated
+
+    async def start(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        committed_queue: asyncio.Queue[str | None],
+    ) -> None:
+        self._loop = loop
+        self._committed_queue = committed_queue
+        self._session.on_partial = self.on_partial
+        self._session.on_committed = self.on_committed
+        self._session.on_watchdog_restart = self.on_restart
+        await self._session.start(loop, committed_queue)
+
+    async def stop(self) -> None:
+        await self._session.stop()
+
+    async def restart(self, reason: str = "manual") -> bool:
+        if self._loop is None or self._committed_queue is None:
+            logger.debug("Realtime STT controller restart skipped before start (%s)", reason)
+            return False
+        self._session.on_partial = self.on_partial
+        self._session.on_committed = self.on_committed
+        self._session.on_watchdog_restart = self.on_restart
+        return await self._session.restart(reason)
+
+
+def create_realtime_stt_session(
+    voice_guard: VoiceLoopGuard | None = None,
+) -> RealtimeSttSession | None:
     """Create a session if ``REALTIME_STT=true`` and the API key is available.
 
     Returns ``None`` when realtime STT is not configured.
@@ -284,16 +382,12 @@ def create_realtime_stt_session() -> RealtimeSttSession | None:
         logger.warning("REALTIME_STT=true but ELEVENLABS_API_KEY is not set")
         return None
 
-    return RealtimeSttSession(api_key, language_code=language_code)
-
-
-RealtimeSttController = RealtimeSttSession
+    return RealtimeSttSession(api_key, language_code=language_code, voice_guard=voice_guard)
 
 
 def create_realtime_stt_controller() -> RealtimeSttController | None:
-    """Compatibility shim for the GUI bootstrap path.
-
-    PR2 only needs a restart-capable controller surface for GUI startup and
-    diagnostics. The richer voice-guard behavior lands in PR3.
-    """
-    return create_realtime_stt_session()
+    """Create a guard-aware controller if realtime STT is configured."""
+    session = create_realtime_stt_session()
+    if session is None:
+        return None
+    return RealtimeSttController(session)

--- a/src/familiar_agent/tools/tts.py
+++ b/src/familiar_agent/tools/tts.py
@@ -15,6 +15,8 @@ import urllib.request
 from pathlib import Path
 from urllib.parse import quote
 
+from ..voice_guard import VoiceLoopGuard, get_shared_voice_guard
+
 logger = logging.getLogger(__name__)
 
 
@@ -116,6 +118,7 @@ class TTSTool:
         go2rtc_url: str = "http://localhost:1984",
         go2rtc_stream: str = "tapo_cam",
         output: str = "local",
+        voice_guard: VoiceLoopGuard | None = None,
     ) -> None:
         self.api_key = api_key
         self.voice_id = voice_id
@@ -123,6 +126,7 @@ class TTSTool:
         self.go2rtc_stream = go2rtc_stream
         # "local" = PC speaker only, "remote" = camera speaker only, "both" = both simultaneously
         self.output = output
+        self._voice_guard = voice_guard or get_shared_voice_guard()
         # Serialize concurrent say() calls so audio never overlaps
         self._lock = asyncio.Lock()
         # Ensure go2rtc is running at startup
@@ -152,24 +156,33 @@ class TTSTool:
         }
 
         async with self._lock:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(url, json=payload, headers=headers) as resp:
-                    if resp.status != 200:
-                        err = await resp.text()
-                        return f"TTS API failed ({resp.status}): {err[:80]}"
-                    content_type = resp.headers.get("Content-Type", "")
-                    audio_data = await resp.read()
-
-            # ElevenLabs may return MP3 even when PCM was requested (model-dependent).
-            # Detect by content-type and save to the correct format.
-            is_mp3 = "mpeg" in content_type or audio_data[:3] in (b"ID3", b"\xff\xfb", b"\xff\xf3")
-            if is_mp3:
-                tmp_path = _write_tmp_audio(audio_data, suffix=".mp3")
-            else:
-                tmp_path = _write_pcm_as_wav(audio_data, sample_rate=16000)
-
+            voice_guard = getattr(self, "_voice_guard", None)
+            if voice_guard is None:
+                voice_guard = get_shared_voice_guard()
+                self._voice_guard = voice_guard
+            played_via: list[str] = []
+            tmp_path: str | None = None
+            voice_guard.on_tts_start(text)
             try:
-                played_via: list[str] = []
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(url, json=payload, headers=headers) as resp:
+                        if resp.status != 200:
+                            err = await resp.text()
+                            return f"TTS API failed ({resp.status}): {err[:80]}"
+                        content_type = resp.headers.get("Content-Type", "")
+                        audio_data = await resp.read()
+
+                # ElevenLabs may return MP3 even when PCM was requested (model-dependent).
+                # Detect by content-type and save to the correct format.
+                is_mp3 = "mpeg" in content_type or audio_data[:3] in (
+                    b"ID3",
+                    b"\xff\xfb",
+                    b"\xff\xf3",
+                )
+                if is_mp3:
+                    tmp_path = _write_tmp_audio(audio_data, suffix=".mp3")
+                else:
+                    tmp_path = _write_pcm_as_wav(audio_data, sample_rate=16000)
 
                 if output in ("remote", "both"):
                     ok, msg = await asyncio.to_thread(
@@ -191,10 +204,12 @@ class TTSTool:
                     return "TTS playback failed (no working audio player found)"
                 return f"Said: {text[:50]}... (via {', '.join(played_via)})"
             finally:
-                try:
-                    os.unlink(tmp_path)
-                except OSError:
-                    pass
+                voice_guard.on_tts_end(text, played=bool(played_via))
+                if tmp_path is not None:
+                    try:
+                        os.unlink(tmp_path)
+                    except OSError:
+                        pass
 
     def get_tool_definitions(self) -> list[dict]:
         return [

--- a/src/familiar_agent/tui.py
+++ b/src/familiar_agent/tui.py
@@ -29,7 +29,7 @@ from ._ui_helpers import (
     format_tool_result as _format_tool_result,
     should_fire_idle_desire,
 )
-from .realtime_stt_session import create_realtime_stt_session, RealtimeSttSession
+from .realtime_stt_session import create_realtime_stt_controller, RealtimeSttController
 
 if TYPE_CHECKING:
     from .agent import EmbodiedAgent
@@ -165,6 +165,7 @@ class FamiliarApp(App):
         Binding("ctrl+c", "quit", _t("quit_label"), show=True, priority=True),
         Binding("ctrl+l", "clear_history", _t("clear_label"), show=True),
         Binding("ctrl+t", "toggle_listen", "🎙 Voice", show=True),
+        Binding("ctrl+r", "restart_realtime_stt", "↻ STT", show=True),
         Binding("escape", "cancel_turn", "🛑 Cancel", show=False),
         Binding("space", "start_ptt", "🎙 PTT", show=False),
     ]
@@ -190,7 +191,7 @@ class FamiliarApp(App):
         # Push-to-Talk state
         self._ptt_active: bool = False
         # Realtime STT (hands-free, always-on)
-        self._realtime_stt: RealtimeSttSession | None = create_realtime_stt_session()
+        self._realtime_stt: RealtimeSttController | None = create_realtime_stt_controller()
 
     def _open_log_file(self) -> Path:
         log_dir = Path.home() / ".cache" / "familiar-ai"
@@ -576,12 +577,31 @@ class FamiliarApp(App):
 
             self._realtime_stt.on_partial = _on_partial
             self._realtime_stt.on_committed = _on_committed
+            self._realtime_stt.on_restart = lambda reason: self._log_system(
+                f"🎤 Realtime STT restarting ({reason})"
+            )
             await self._realtime_stt.start(loop, self._input_queue)
             self._log_system("\U0001f3a4 Realtime STT ON (ElevenLabs)")
         except Exception as e:
             logger.warning("Realtime STT init failed: %s", e)
             self._log_system(f"\u26a0 Realtime STT init failed: {e}")
             self._realtime_stt = None
+
+    async def action_restart_realtime_stt(self) -> None:
+        """Reconnect realtime STT after a loop or transient transport issue."""
+        if not self._realtime_stt:
+            self._log_system("Realtime STT not configured")
+            return
+        try:
+            restarted = await self._realtime_stt.restart(reason="manual")
+        except Exception as exc:
+            logger.warning("Realtime STT restart failed: %s", exc)
+            self._log_system(f"⚠ Realtime STT restart failed: {exc}")
+            return
+        if restarted:
+            self._log_system("🎤 Realtime STT restarted")
+        else:
+            self._log_system("Realtime STT restart unavailable before startup")
 
     async def action_toggle_listen(self) -> None:
         """Toggle microphone recording for voice input."""

--- a/src/familiar_agent/voice_guard.py
+++ b/src/familiar_agent/voice_guard.py
@@ -1,0 +1,200 @@
+"""Voice-loop guard for TTS -> realtime STT echo suppression."""
+
+from __future__ import annotations
+
+import re
+import time
+from collections import deque
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+
+_SUPPRESSION_WINDOW_SECS = 1.2
+_FINGERPRINT_TTL_SECS = 15.0
+_LOOP_WINDOW_SECS = 8.0
+_LOOP_TRIGGER_COUNT = 3
+_SIMILARITY_THRESHOLD = 0.88
+_TAG_RE = re.compile(r"\[[^\[\]]+\]")
+
+
+def _guard_now() -> float:
+    """Return the monotonic clock used by the voice guard."""
+    return time.monotonic()
+
+
+def _normalize_voice_text(text: str) -> str:
+    """Normalize spoken text for fuzzy self-echo detection."""
+    normalized = _TAG_RE.sub(" ", text or "")
+    normalized = normalized.strip().lower()
+    normalized = re.sub(r"\s+", " ", normalized)
+    normalized = normalized.strip(" 　。、！？…・「」『』（）()!?,.\"'")
+    return normalized
+
+
+@dataclass(frozen=True)
+class VoiceGuardDecision:
+    """Result of checking whether a transcript should be suppressed."""
+
+    blocked: bool
+    reason: str | None = None
+    should_restart: bool = False
+
+
+class VoiceLoopGuard:
+    """Small state machine for preventing TTS from looping back into realtime STT."""
+
+    def __init__(
+        self,
+        *,
+        suppression_window_secs: float = _SUPPRESSION_WINDOW_SECS,
+        fingerprint_ttl_secs: float = _FINGERPRINT_TTL_SECS,
+        loop_window_secs: float = _LOOP_WINDOW_SECS,
+        loop_trigger_count: int = _LOOP_TRIGGER_COUNT,
+    ) -> None:
+        self._suppression_window_secs = suppression_window_secs
+        self._fingerprint_ttl_secs = fingerprint_ttl_secs
+        self._loop_window_secs = loop_window_secs
+        self._loop_trigger_count = loop_trigger_count
+        self._speaking_count = 0
+        self._suppressed_until = 0.0
+        self._recent_tts_fingerprints: deque[tuple[str, float]] = deque()
+        self._loop_fingerprint = ""
+        self._loop_counter = 0
+        self._loop_last_time = 0.0
+
+    @property
+    def speaking(self) -> bool:
+        """True while TTS playback is active."""
+        return self._speaking_count > 0
+
+    @property
+    def suppressed_until(self) -> float:
+        """Monotonic timestamp until which self-echo suppression remains active."""
+        return self._suppressed_until
+
+    @property
+    def gated(self) -> bool:
+        """True while STT should be treated as gated by active or recent TTS."""
+        return self.speaking or _guard_now() < self._suppressed_until
+
+    @property
+    def loop_counter(self) -> int:
+        """Current watchdog counter for repeated self-echo candidates."""
+        return self._loop_counter
+
+    @property
+    def recent_tts_fingerprints(self) -> tuple[str, ...]:
+        """Recent normalized TTS fingerprints, newest last."""
+        self._expire(_guard_now())
+        return tuple(text for text, _ts in self._recent_tts_fingerprints)
+
+    def on_tts_start(self, text: str) -> None:
+        """Enter speaking mode before playback begins."""
+        self._speaking_count += 1
+        normalized = _normalize_voice_text(text)
+        if normalized:
+            self._remember_fingerprint(normalized, _guard_now())
+
+    def on_tts_end(self, text: str, *, played: bool) -> None:
+        """Exit speaking mode after playback, optionally arming the suppression window."""
+        if self._speaking_count > 0:
+            self._speaking_count -= 1
+        now = _guard_now()
+        normalized = _normalize_voice_text(text)
+        if played and normalized:
+            self._remember_fingerprint(normalized, now)
+            self._suppressed_until = max(
+                self._suppressed_until, now + self._suppression_window_secs
+            )
+        elif not self.speaking:
+            self._suppressed_until = min(self._suppressed_until, now)
+
+    def should_gate_partial(self, text: str) -> bool:
+        """Return True when a partial transcript should be hidden while TTS is gated."""
+        decision = self.check_transcript(text, count_for_watchdog=False)
+        return decision.blocked
+
+    def check_transcript(self, text: str, *, count_for_watchdog: bool = True) -> VoiceGuardDecision:
+        """Decide whether a committed transcript should be suppressed."""
+        normalized = _normalize_voice_text(text)
+        if not normalized:
+            self._reset_loop()
+            return VoiceGuardDecision(blocked=False)
+
+        now = _guard_now()
+        self._expire(now)
+        matches_recent = self._matches_recent_fingerprint(normalized)
+
+        if self.speaking:
+            should_restart = (
+                self._register_loop_echo(normalized, now)
+                if count_for_watchdog and matches_recent
+                else False
+            )
+            return VoiceGuardDecision(
+                blocked=True, reason="tts_active", should_restart=should_restart
+            )
+
+        if now < self._suppressed_until and matches_recent:
+            should_restart = (
+                self._register_loop_echo(normalized, now) if count_for_watchdog else False
+            )
+            return VoiceGuardDecision(
+                blocked=True, reason="tts_suppression", should_restart=should_restart
+            )
+
+        self._reset_loop()
+        return VoiceGuardDecision(blocked=False)
+
+    def _expire(self, now: float) -> None:
+        while self._recent_tts_fingerprints:
+            _text, ts = self._recent_tts_fingerprints[0]
+            if now - ts <= self._fingerprint_ttl_secs:
+                break
+            self._recent_tts_fingerprints.popleft()
+        if now - self._loop_last_time > self._loop_window_secs:
+            self._reset_loop()
+
+    def _remember_fingerprint(self, normalized: str, now: float) -> None:
+        self._recent_tts_fingerprints.append((normalized, now))
+        self._expire(now)
+
+    def _matches_recent_fingerprint(self, normalized: str) -> bool:
+        for fingerprint, _ts in reversed(self._recent_tts_fingerprints):
+            if normalized == fingerprint:
+                return True
+            if len(normalized) >= 8 and (normalized in fingerprint or fingerprint in normalized):
+                return True
+            if min(len(normalized), len(fingerprint)) < 4:
+                continue
+            ratio = SequenceMatcher(None, normalized, fingerprint).ratio()
+            if ratio >= _SIMILARITY_THRESHOLD:
+                return True
+        return False
+
+    def _register_loop_echo(self, normalized: str, now: float) -> bool:
+        if (
+            normalized == self._loop_fingerprint
+            and now - self._loop_last_time <= self._loop_window_secs
+        ):
+            self._loop_counter += 1
+        else:
+            self._loop_fingerprint = normalized
+            self._loop_counter = 1
+        self._loop_last_time = now
+        return self._loop_counter >= self._loop_trigger_count
+
+    def _reset_loop(self) -> None:
+        self._loop_fingerprint = ""
+        self._loop_counter = 0
+        self._loop_last_time = 0.0
+
+
+_SHARED_VOICE_GUARD: VoiceLoopGuard | None = None
+
+
+def get_shared_voice_guard() -> VoiceLoopGuard:
+    """Return the process-wide voice guard shared by TTS and realtime STT."""
+    global _SHARED_VOICE_GUARD
+    if _SHARED_VOICE_GUARD is None:
+        _SHARED_VOICE_GUARD = VoiceLoopGuard()
+    return _SHARED_VOICE_GUARD

--- a/tests/test_gui_async_stability.py
+++ b/tests/test_gui_async_stability.py
@@ -32,6 +32,7 @@ class _ManualRealtimeStt:
     def __init__(self) -> None:
         self.on_partial: Callable[[str], None] | None = None
         self.on_committed: Callable[[str], None] | None = None
+        self.on_restart: Callable[[str], None] | None = None
         self._queue: asyncio.Queue[str | None] | None = None
         self.started = False
 
@@ -43,6 +44,12 @@ class _ManualRealtimeStt:
 
     async def stop(self) -> None:
         self.started = False
+
+    async def restart(self, reason: str = "manual") -> bool:
+        if self.on_restart:
+            self.on_restart(reason)
+        self.started = True
+        return True
 
     async def emit_committed(self, text: str) -> None:
         assert self._queue is not None
@@ -77,6 +84,7 @@ def _make_window_stub() -> FamiliarWindow:
     win._send_btn = MagicMock()
     win._stop_btn = MagicMock()
     win._lag_timer = MagicMock()
+    win._status_timer = MagicMock()
     win._last_lag_tick = time.perf_counter()
     win.setEnabled = MagicMock()  # type: ignore[method-assign]
     win.setWindowTitle = MagicMock()  # type: ignore[method-assign]

--- a/tests/test_realtime_stt_session.py
+++ b/tests/test_realtime_stt_session.py
@@ -9,11 +9,14 @@ from types import SimpleNamespace
 import pytest
 
 from familiar_agent.realtime_stt_session import (
+    RealtimeSttController,
     RealtimeSttSession,
     _normalize_for_dedupe,
+    create_realtime_stt_controller,
     create_realtime_stt_session,
     should_skip_stt,
 )
+from familiar_agent.voice_guard import VoiceLoopGuard
 
 
 def test_normalize_for_dedupe_collapses_spacing_and_trailing_punctuation() -> None:
@@ -198,6 +201,64 @@ async def test_partial_relay_drops_audio_event_tags() -> None:
     assert shown == ["こんにちは"]
 
 
+@pytest.mark.asyncio
+async def test_committed_relay_drops_recent_tts_echo(monkeypatch) -> None:
+    ts = iter([300.0, 300.1, 300.2, 300.3])
+    monkeypatch.setattr("familiar_agent.realtime_stt_session._dedupe_now", lambda: next(ts))
+    monkeypatch.setattr("familiar_agent.voice_guard._guard_now", lambda: next(ts))
+
+    guard = VoiceLoopGuard(suppression_window_secs=1.0)
+    guard.on_tts_start("こんにちは")
+    guard.on_tts_end("こんにちは", played=True)
+
+    session = RealtimeSttSession("dummy", voice_guard=guard)
+    committed_q: asyncio.Queue[str] = asyncio.Queue()
+    input_q: asyncio.Queue[str | None] = asyncio.Queue()
+    session._incoming_committed = committed_q
+    session._committed_queue = input_q
+
+    task = asyncio.create_task(session._committed_relay())
+    await committed_q.put("こんにちは。")
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    assert input_q.empty()
+
+
+@pytest.mark.asyncio
+async def test_committed_relay_schedules_restart_after_loop_watchdog(monkeypatch) -> None:
+    stt_ts = iter([400.0, 401.0, 402.0, 403.0])
+    guard_ts = iter([410.0, 410.1, 410.2, 410.3, 410.4])
+    monkeypatch.setattr("familiar_agent.realtime_stt_session._dedupe_now", lambda: next(stt_ts))
+    monkeypatch.setattr("familiar_agent.voice_guard._guard_now", lambda: next(guard_ts))
+
+    guard = VoiceLoopGuard(suppression_window_secs=2.0, loop_trigger_count=3)
+    guard.on_tts_start("おはよう")
+    guard.on_tts_end("おはよう", played=True)
+
+    session = RealtimeSttSession("dummy", voice_guard=guard)
+    committed_q: asyncio.Queue[str] = asyncio.Queue()
+    input_q: asyncio.Queue[str | None] = asyncio.Queue()
+    session._incoming_committed = committed_q
+    session._committed_queue = input_q
+
+    scheduled: list[str] = []
+    monkeypatch.setattr(session, "_schedule_restart", lambda reason: scheduled.append(reason))
+
+    task = asyncio.create_task(session._committed_relay())
+    await committed_q.put("おはよう")
+    await committed_q.put("おはよう")
+    await committed_q.put("おはよう")
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    assert scheduled == ["watchdog_loop"]
+
+
 def test_create_realtime_stt_session_uses_stt_language(monkeypatch) -> None:
     monkeypatch.setenv("REALTIME_STT", "true")
     monkeypatch.setenv("ELEVENLABS_API_KEY", "key")
@@ -207,3 +268,13 @@ def test_create_realtime_stt_session_uses_stt_language(monkeypatch) -> None:
 
     assert session is not None
     assert session._language_code == "ja"
+
+
+def test_create_realtime_stt_controller_wraps_configured_session(monkeypatch) -> None:
+    monkeypatch.setenv("REALTIME_STT", "true")
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "key")
+
+    controller = create_realtime_stt_controller()
+
+    assert controller is not None
+    assert isinstance(controller, RealtimeSttController)

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -176,6 +176,40 @@ async def test_say_returns_error_on_api_failure():
 
 
 @pytest.mark.asyncio
+async def test_say_notifies_voice_guard_on_success():
+    tool = _make_tts()
+    tool._voice_guard = MagicMock()
+
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.read = AsyncMock(return_value=b"fake_mp3_data")
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.post = MagicMock(return_value=mock_response)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("aiohttp.ClientSession", return_value=mock_session),
+        patch("familiar_agent.tools.tts._play_local", new=AsyncMock(return_value=True)),
+        patch("os.unlink"),
+        patch("tempfile.NamedTemporaryFile") as mock_tmp,
+    ):
+        tmp_file = MagicMock()
+        tmp_file.__enter__ = MagicMock(return_value=tmp_file)
+        tmp_file.__exit__ = MagicMock(return_value=False)
+        tmp_file.name = "/tmp/fake.mp3"
+        mock_tmp.return_value = tmp_file
+
+        await tool.say("hello world")
+
+    tool._voice_guard.on_tts_start.assert_called_once_with("hello world")
+    tool._voice_guard.on_tts_end.assert_called_once_with("hello world", played=True)
+
+
+@pytest.mark.asyncio
 async def test_say_serializes_concurrent_calls():
     """Concurrent say() calls must be serialized (lock prevents overlap)."""
     tool = _make_tts()

--- a/tests/test_tui_stt_interrupt_stress.py
+++ b/tests/test_tui_stt_interrupt_stress.py
@@ -14,6 +14,7 @@ class _ManualRealtimeStt:
     def __init__(self) -> None:
         self.on_partial = None
         self.on_committed = None
+        self.on_restart = None
         self._queue: asyncio.Queue[str | None] | None = None
         self.started = False
 
@@ -23,6 +24,12 @@ class _ManualRealtimeStt:
 
     async def stop(self) -> None:
         self.started = False
+
+    async def restart(self, reason: str = "manual") -> bool:
+        if self.on_restart:
+            self.on_restart(reason)
+        self.started = True
+        return True
 
     async def emit_committed(self, text: str) -> None:
         assert self._queue is not None

--- a/tests/test_voice_guard.py
+++ b/tests/test_voice_guard.py
@@ -1,0 +1,53 @@
+"""Tests for TTS/STT self-loop guard logic."""
+
+from __future__ import annotations
+
+from familiar_agent.voice_guard import VoiceLoopGuard
+
+
+def test_voice_guard_blocks_self_echo_during_speaking(monkeypatch) -> None:
+    ts = iter([10.0, 10.1])
+    monkeypatch.setattr("familiar_agent.voice_guard._guard_now", lambda: next(ts))
+
+    guard = VoiceLoopGuard()
+    guard.on_tts_start("[cheerful] こんにちは")
+
+    decision = guard.check_transcript("こんにちは")
+
+    assert decision.blocked is True
+    assert decision.reason == "tts_active"
+    assert decision.should_restart is False
+
+
+def test_voice_guard_blocks_recent_self_echo_after_tts(monkeypatch) -> None:
+    ts = iter([20.0, 20.2, 20.4, 22.0])
+    monkeypatch.setattr("familiar_agent.voice_guard._guard_now", lambda: next(ts))
+
+    guard = VoiceLoopGuard(suppression_window_secs=1.0)
+    guard.on_tts_start("今日はいい天気だね")
+    guard.on_tts_end("今日はいい天気だね", played=True)
+
+    blocked = guard.check_transcript("今日はいい天気だね。")
+    allowed = guard.check_transcript("窓を開ける？")
+
+    assert blocked.blocked is True
+    assert blocked.reason == "tts_suppression"
+    assert allowed.blocked is False
+
+
+def test_voice_guard_requests_watchdog_restart_after_repeated_echo(monkeypatch) -> None:
+    ts = iter([30.0, 30.1, 30.3, 30.6, 30.9])
+    monkeypatch.setattr("familiar_agent.voice_guard._guard_now", lambda: next(ts))
+
+    guard = VoiceLoopGuard(suppression_window_secs=2.0, loop_trigger_count=3)
+    guard.on_tts_start("おはよう")
+    guard.on_tts_end("おはよう", played=True)
+
+    first = guard.check_transcript("おはよう")
+    second = guard.check_transcript("おはよう")
+    third = guard.check_transcript("おはよう")
+
+    assert first.should_restart is False
+    assert second.should_restart is False
+    assert third.should_restart is True
+    assert guard.loop_counter == 3


### PR DESCRIPTION
## Summary
- add a shared voice guard to gate realtime STT during and immediately after TTS playback
- drop likely self-echo transcripts and reconnect STT when repeated loop signatures are detected
- expose manual STT restart through the GUI and TUI controllers

## Testing
- uv run pytest -q tests/test_realtime_stt_session.py tests/test_voice_guard.py tests/test_tts.py tests/test_tui_stt_interrupt_stress.py
- uv run ruff check .
- uv run --group dev mypy src/familiar_agent