### PR TITLE
fix(stt): add WSL2 microphone diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,19 @@ STT_LANGUAGE=ja            # recommended for Japanese; used by both batch and re
 
 familiar-ai streams microphone audio to ElevenLabs Scribe v2 and auto-commits transcripts when you pause speaking. No button press required. Coexists with the push-to-talk mode (Ctrl+T).
 
+On WSL2/WSLg, realtime STT also depends on `sounddevice` / PortAudio being able to
+see your microphone input, not just PulseAudio playback. Install
+`pulseaudio-utils` and `libasound2-plugins`, set
+`PULSE_SERVER=unix:/mnt/wslg/PulseServer`, then verify:
+
+```bash
+uv run python -m sounddevice
+```
+
+If that command shows no input devices or reports `Error querying device -1`,
+familiar-ai will not be able to capture microphone audio until PortAudio can
+see the WSLg input bridge.
+
 ---
 
 ## TUI

--- a/README_ja.md
+++ b/README_ja.md
@@ -296,6 +296,18 @@ ELEVENLABS_API_KEY=sk_...   # TTSと同じキー
 STT_LANGUAGE=ja            # 日本語なら推奨。バッチSTT / Realtime STT の両方で使います
 ```
 
+WSL2/WSLg では、Realtime STT は PulseAudio の再生設定だけでなく、
+`sounddevice` / PortAudio からマイク入力が見えている必要があります。
+`pulseaudio-utils` と `libasound2-plugins` を入れて
+`PULSE_SERVER=unix:/mnt/wslg/PulseServer` を設定したうえで、次を確認してください:
+
+```bash
+uv run python -m sounddevice
+```
+
+ここで入力デバイスが出ない、または `Error querying device -1` になる場合は、
+familiar-ai からもマイク入力を利用できません。
+
 ---
 
 ## FAQ

--- a/docs/handson-guide.md
+++ b/docs/handson-guide.md
@@ -376,12 +376,19 @@ PC のスピーカーから AI の声が聞こえたら成功です！
 >
 > WSL2 の場合は追加で:
 > ```bash
-> sudo apt install -y pulseaudio-utils
+> sudo apt install -y pulseaudio-utils libasound2-plugins
 > ```
 > `.env` に以下を追加:
 > ```env
 > PULSE_SERVER=unix:/mnt/wslg/PulseServer
 > ```
+> Realtime STT も使う場合は、さらに
+> ```bash
+> uv run python -m sounddevice
+> ```
+> で入力デバイスが見えていることを確認してください。ここで
+> `Error querying device -1` や入力デバイスなしになる場合、
+> familiar-ai からはマイクを使えません。
 
 ---
 
@@ -626,6 +633,12 @@ USB カメラは自動では WSL2 に見えません。[Step 3-1 の手順](#31-
    ```env
    PULSE_SERVER=unix:/mnt/wslg/PulseServer
    ```
+   Realtime STT を使う場合は、追加で
+   ```bash
+   sudo apt install -y pulseaudio-utils libasound2-plugins
+   uv run python -m sounddevice
+   ```
+   を実行し、`sounddevice` から入力デバイスが見えていることを確認してください。
 
 ### Q. `./run.sh: Permission denied` と出る
 

--- a/src/familiar_agent/diagnostics.py
+++ b/src/familiar_agent/diagnostics.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from .realtime_stt_session import RealtimeSttSession
 from .setup import validate_camera_connection
+from .tools.mic import probe_sounddevice_input
 
 if TYPE_CHECKING:
     from .config import AgentConfig
@@ -182,6 +183,9 @@ async def test_realtime_stt_connection_from_config(config: "AgentConfig") -> tup
         return False, "REALTIME_STT is disabled."
     if not config.tts.elevenlabs_api_key:
         return False, "ELEVENLABS_API_KEY is not set."
+    mic_ok, mic_detail = probe_sounddevice_input()
+    if not mic_ok:
+        return False, mic_detail
 
     session = RealtimeSttSession(
         config.tts.elevenlabs_api_key,
@@ -193,4 +197,9 @@ async def test_realtime_stt_connection_from_config(config: "AgentConfig") -> tup
         return False, str(exc)
     finally:
         await session.stop()
-    return True, "Realtime STT websocket connected."
+    return True, f"Realtime STT websocket connected. Mic: {mic_detail}"
+
+
+setattr(test_backend_connection, "__test__", False)
+setattr(test_camera_connection_from_config, "__test__", False)
+setattr(test_realtime_stt_connection_from_config, "__test__", False)

--- a/src/familiar_agent/tools/mic.py
+++ b/src/familiar_agent/tools/mic.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import platform
 from typing import Any
 
 import numpy as np
@@ -13,6 +15,62 @@ logger = logging.getLogger(__name__)
 TARGET_RATE = 16000  # ElevenLabs Realtime STT expects 16 kHz PCM
 CHANNELS = 1
 _BLOCK_MS = 100  # capture block size in milliseconds
+
+
+def _is_wsl2() -> bool:
+    release = platform.release().lower()
+    return bool(os.environ.get("WSL_INTEROP") or os.environ.get("WSL_DISTRO_NAME")) or (
+        "microsoft" in release or "wsl" in release
+    )
+
+
+def describe_sounddevice_input_failure(exc: Exception | None = None) -> str:
+    """Return a user-facing microphone diagnosis for sounddevice failures."""
+    detail = str(exc).strip() if exc else ""
+    parts: list[str] = []
+    if detail:
+        parts.append(detail)
+
+    if _is_wsl2():
+        parts.append(
+            "WSL2/WSLg hint: set PULSE_SERVER=unix:/mnt/wslg/PulseServer and install "
+            "pulseaudio-utils plus libasound2-plugins. If `python -m sounddevice` shows no "
+            "input devices, PortAudio cannot see the WSLg microphone bridge yet."
+        )
+    else:
+        parts.append(
+            "No default microphone input device is available to sounddevice. Try "
+            "`python -m sounddevice` and check your OS microphone permissions."
+        )
+
+    return " ".join(part for part in parts if part)
+
+
+def probe_sounddevice_input() -> tuple[bool, str]:
+    """Best-effort check that sounddevice can see a default input device."""
+    try:
+        import sounddevice as sd
+    except ImportError:
+        return False, "sounddevice is not installed."
+
+    try:
+        devices = sd.query_devices()
+    except Exception as exc:  # pragma: no cover - covered via query(kind="input") too
+        return False, describe_sounddevice_input_failure(exc)
+
+    if not devices:
+        return False, describe_sounddevice_input_failure(
+            RuntimeError("sounddevice did not enumerate any audio devices.")
+        )
+
+    try:
+        info = sd.query_devices(kind="input")
+    except Exception as exc:
+        return False, describe_sounddevice_input_failure(exc)
+
+    name = str(info.get("name", "default")).strip() or "default"
+    sample_rate = int(info.get("default_samplerate", TARGET_RATE) or TARGET_RATE)
+    return True, f"{name} @ {sample_rate} Hz"
 
 
 def _resample(pcm_bytes: bytes, from_rate: int) -> bytes:
@@ -48,37 +106,44 @@ class MicCapture:
         """Start capturing from the default input device."""
         import sounddevice as sd
 
+        ok, detail = probe_sounddevice_input()
+        if not ok:
+            raise RuntimeError(detail)
+
         self._loop = loop
 
-        # Use the device's native sample rate to avoid paInvalidSampleRate
-        device_info = sd.query_devices(kind="input")
-        self._native_rate = int(device_info["default_samplerate"])
-        block_size = int(self._native_rate * _BLOCK_MS / 1000)
+        try:
+            # Use the device's native sample rate to avoid paInvalidSampleRate
+            device_info = sd.query_devices(kind="input")
+            self._native_rate = int(device_info["default_samplerate"])
+            block_size = int(self._native_rate * _BLOCK_MS / 1000)
 
-        logger.info(
-            "Microphone capture: device=%s native_rate=%d target_rate=%d",
-            device_info.get("name", "default"),
-            self._native_rate,
-            TARGET_RATE,
-        )
+            logger.info(
+                "Microphone capture: device=%s native_rate=%d target_rate=%d",
+                device_info.get("name", "default"),
+                self._native_rate,
+                TARGET_RATE,
+            )
 
-        def _callback(indata, frames, time_info, status):  # noqa: ANN001, ARG001
-            if status:
-                logger.debug("Mic status: %s", status)
-            pcm = _resample(bytes(indata), self._native_rate)
-            if self._loop and not self._loop.is_closed():
-                self._loop.call_soon_threadsafe(
-                    lambda b=pcm: self._loop.create_task(self._on_audio(b))
-                )
+            def _callback(indata, frames, time_info, status):  # noqa: ANN001, ARG001
+                if status:
+                    logger.debug("Mic status: %s", status)
+                pcm = _resample(bytes(indata), self._native_rate)
+                if self._loop and not self._loop.is_closed():
+                    self._loop.call_soon_threadsafe(
+                        lambda b=pcm: self._loop.create_task(self._on_audio(b))
+                    )
 
-        self._stream = sd.RawInputStream(
-            samplerate=self._native_rate,
-            blocksize=block_size,
-            channels=CHANNELS,
-            dtype="int16",
-            callback=_callback,
-        )
-        self._stream.start()
+            self._stream = sd.RawInputStream(
+                samplerate=self._native_rate,
+                blocksize=block_size,
+                channels=CHANNELS,
+                dtype="int16",
+                callback=_callback,
+            )
+            self._stream.start()
+        except sd.PortAudioError as exc:
+            raise RuntimeError(describe_sounddevice_input_failure(exc)) from exc
 
     def stop(self) -> None:
         """Stop capturing."""

--- a/src/familiar_agent/tools/stt.py
+++ b/src/familiar_agent/tools/stt.py
@@ -21,6 +21,8 @@ import os
 
 import aiohttp
 
+from .mic import describe_sounddevice_input_failure
+
 if TYPE_CHECKING:
     pass
 
@@ -135,7 +137,7 @@ class STTTool:
                         chunks.append(chunk)
                         time.sleep(0.01)  # yield slightly; this is already in a thread
         except sd.PortAudioError as e:
-            logger.warning("STT: PortAudio error (no mic?): %s", e)
+            logger.warning("STT: %s", describe_sounddevice_input_failure(e))
             return None
 
         if not chunks:

--- a/tests/test_gui_diagnostics.py
+++ b/tests/test_gui_diagnostics.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from familiar_agent.diagnostics import build_gui_diagnostics, format_gui_diagnostics
+import pytest
+
+from familiar_agent.diagnostics import (
+    RealtimeSttSession,
+    build_gui_diagnostics,
+    format_gui_diagnostics,
+    test_realtime_stt_connection_from_config,
+)
 from familiar_agent.gui import FamiliarWindow
 
 
@@ -91,3 +99,47 @@ def test_gui_copy_diagnostics_uses_clipboard(monkeypatch) -> None:
 
     assert "familiar-ai diagnostics" in captured["text"]
     win._log.append_line.assert_called_once_with("📋 Diagnostics copied")
+
+
+@pytest.mark.asyncio
+async def test_realtime_stt_connection_reports_microphone_preflight_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = SimpleNamespace(
+        realtime_stt=True,
+        tts=SimpleNamespace(elevenlabs_api_key="sk-test"),
+        stt=SimpleNamespace(language="ja"),
+    )
+
+    monkeypatch.setattr(
+        "familiar_agent.diagnostics.probe_sounddevice_input",
+        lambda: (False, "sounddevice cannot see an input device"),
+    )
+
+    ok, message = await test_realtime_stt_connection_from_config(config)
+
+    assert ok is False
+    assert message == "sounddevice cannot see an input device"
+
+
+@pytest.mark.asyncio
+async def test_realtime_stt_connection_includes_microphone_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = SimpleNamespace(
+        realtime_stt=True,
+        tts=SimpleNamespace(elevenlabs_api_key="sk-test"),
+        stt=SimpleNamespace(language="ja"),
+    )
+
+    monkeypatch.setattr(
+        "familiar_agent.diagnostics.probe_sounddevice_input",
+        lambda: (True, "Mic @ 48000 Hz"),
+    )
+    monkeypatch.setattr(RealtimeSttSession, "_connect_client", AsyncMock(return_value=None))
+    monkeypatch.setattr(RealtimeSttSession, "stop", AsyncMock(return_value=None))
+
+    ok, message = await test_realtime_stt_connection_from_config(config)
+
+    assert ok is True
+    assert message == "Realtime STT websocket connected. Mic: Mic @ 48000 Hz"

--- a/tests/test_mic.py
+++ b/tests/test_mic.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from familiar_agent.tools.mic import describe_sounddevice_input_failure, probe_sounddevice_input
+
+
+def test_describe_sounddevice_input_failure_adds_wsl_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WSL_INTEROP", "/run/WSL/1")
+    monkeypatch.delenv("PULSE_SERVER", raising=False)
+
+    message = describe_sounddevice_input_failure(RuntimeError("Error querying device -1"))
+
+    assert "Error querying device -1" in message
+    assert "WSL2/WSLg" in message
+    assert "PULSE_SERVER=unix:/mnt/wslg/PulseServer" in message
+
+
+def test_probe_sounddevice_input_reports_missing_devices(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WSL_INTEROP", "/run/WSL/1")
+    monkeypatch.setenv("PULSE_SERVER", "unix:/mnt/wslg/PulseServer")
+
+    mock_sd = MagicMock()
+    mock_sd.query_devices.side_effect = [[], RuntimeError("Error querying device -1")]
+
+    with patch.dict("sys.modules", {"sounddevice": mock_sd}):
+        ok, detail = probe_sounddevice_input()
+
+    assert ok is False
+    assert "WSL2/WSLg" in detail
+    assert "python -m sounddevice" in detail
+
+
+def test_probe_sounddevice_input_reports_device_name() -> None:
+    mock_sd = MagicMock()
+    mock_sd.query_devices.side_effect = [
+        [{"name": "Mic", "default_samplerate": 48000}],
+        {"name": "Mic", "default_samplerate": 48000},
+    ]
+
+    with patch.dict("sys.modules", {"sounddevice": mock_sd}):
+        ok, detail = probe_sounddevice_input()
+
+    assert ok is True
+    assert detail == "Mic @ 48000 Hz"


### PR DESCRIPTION
## Summary
- add a reusable sounddevice microphone preflight with WSL2/WSLg-specific hints
- surface microphone availability in the realtime STT diagnostics test and runtime error path
- document the extra WSL2 STT requirements and `python -m sounddevice` self-check

Refs #153.

## Testing
- uv run pytest -q tests/test_mic.py tests/test_gui_diagnostics.py tests/test_stt.py
- uv run pytest -q tests/test_gui_async_stability.py tests/test_gui_bootstrap.py tests/test_realtime_stt_session.py
- uv run ruff check src/familiar_agent/tools/mic.py src/familiar_agent/tools/stt.py src/familiar_agent/diagnostics.py tests/test_mic.py tests/test_gui_diagnostics.py
- uv run --group dev mypy src/familiar_agent/tools/mic.py src/familiar_agent/tools/stt.py src/familiar_agent/diagnostics.py