### PR TITLE
feat(camera): add unified network discovery tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Voice guard protection for TTS-driven realtime STT loops, including speak-time gating, echo fingerprint suppression, watchdog reconnects, and manual STT restart controls in GUI/TUI
 - Dedicated `run-gui.sh` / `run-gui.bat` launchers for opening the desktop GUI without changing the existing TUI defaults
 - Support for full RTSP URLs in `CAMERA_HOST` (enables ATOMCam and other non-standard RTSP paths)
+- A dedicated `familiar-discover-cameras` tool that combines WS-Discovery, mDNS/zeroconf, SSDP, and an opt-in TCP fallback scan for Wi-Fi camera setup
 - Persistent latent self state driven by workspace broadcasts, with prompt-visible interoception updates and dedicated test coverage
 - Action-conditioned prediction with agency-error tracking for `see` / `look` / `walk`, including scene integration and focused tests
 - Online temporal-self context during ordinary turns, with resurfaced memories, unresolved-thread prompts, and within-session self-narrative capture

--- a/README.md
+++ b/README.md
@@ -288,6 +288,21 @@ API_KEY=sk-...
 Run `./run.sh` (macOS/Linux/WSL2) or `run.bat` (Windows) and start chatting. Add hardware as you go.
 If you want the desktop GUI directly, use `./run-gui.sh` or `run-gui.bat`.
 
+### Find Wi-Fi cameras automatically
+
+If you do not know your camera's IP yet, familiar-ai now ships with a small discovery tool:
+
+```bash
+uv run familiar-discover-cameras
+```
+
+This combines **WS-Discovery**, **mDNS / zeroconf**, and **SSDP**. For harder networks, you can
+opt into a slower TCP fallback scan:
+
+```bash
+uv run familiar-discover-cameras --scan
+```
+
 ### Wi-Fi PTZ camera (Tapo C220)
 
 1. In the Tapo app: **Settings → Advanced → Camera Account** — create a local account (not TP-Link account)

--- a/README_ja.md
+++ b/README_ja.md
@@ -238,6 +238,21 @@ API_KEY=sk-...
 
 `./run.sh`（macOS/Linux/WSL2）または `run.bat`（Windows）を実行してチャットを始めましょう。ハードウェアはあとから追加できます。
 
+### Wi-Fi カメラを自動検出する
+
+カメラのIPアドレスがまだ分からない場合は、付属の discovery tool を使えます:
+
+```bash
+uv run familiar-discover-cameras
+```
+
+このツールは **WS-Discovery**、**mDNS / zeroconf**、**SSDP** をまとめて試します。
+見つからない場合だけ、やや遅い TCP fallback scan も試せます:
+
+```bash
+uv run familiar-discover-cameras --scan
+```
+
 ### Wi-Fi PTZカメラ（Tapo C220）
 
 1. Tapoアプリで: **設定 → 詳細設定 → カメラアカウント** — ローカルアカウントを作成（TP-Linkアカウントではなく）

--- a/docs/handson-guide.md
+++ b/docs/handson-guide.md
@@ -613,6 +613,15 @@ USB カメラは自動では WSL2 に見えません。[Step 3-1 の手順](#31-
    応答があれば接続できています。
 3. **ローカルアカウント** を使っているか確認（TP-Link クラウドアカウントでは接続できません）
 4. ONVIF ポートがデフォルトの `2020` でない場合、`.env` に `CAMERA_ONVIF_PORT=` を設定
+5. IP アドレスが分からない場合は discovery tool を試す:
+   ```bash
+   uv run familiar-discover-cameras
+   ```
+   見つからない場合は:
+   ```bash
+   uv run familiar-discover-cameras --scan
+   ```
+   で WS-Discovery / mDNS / SSDP に加えて、やや遅い TCP fallback scan も有効にできます。
 
 ### Q. 音が出ない（ElevenLabs）
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ camera = [
     "opencv-python>=4.00",
     "onvif-zeep-async>=4.0.0",
     "Pillow>=10.0.0",
+    "zeroconf>=0.132.2",
 ]
 voice = [
     "openai-whisper",
@@ -41,6 +42,7 @@ all = [
 
 [project.scripts]
 familiar = "familiar_agent.main:main"
+familiar-discover-cameras = "familiar_agent.camera_discovery:main"
 
 [build-system]
 requires = ["hatchling"]
@@ -83,6 +85,7 @@ camera = [
     "opencv-python>=4.00",
     "onvif-zeep-async>=4.0.0",
     "Pillow>=10.0.0",
+    "zeroconf>=0.132.2",
 ]
 voice = [
     "openai-whisper",

--- a/src/familiar_agent/camera_discovery.py
+++ b/src/familiar_agent/camera_discovery.py
@@ -189,7 +189,9 @@ async def _discover_mdns_cameras(timeout: float = 3.0) -> list[dict[str, str]]:
                     found.append(
                         {
                             "host": host,
-                            "address": f"{scheme}://{host}:{port}" if port else f"{scheme}://{host}",
+                            "address": f"{scheme}://{host}:{port}"
+                            if port
+                            else f"{scheme}://{host}",
                             "source": "mdns",
                             "port": str(port) if port else "",
                             "name": str(getattr(info, "server", "") or name).rstrip("."),
@@ -309,7 +311,9 @@ def get_local_network_prefix() -> str | None:
 
 async def _probe_camera_port(host: str, port: int, timeout: float) -> dict[str, str] | None:
     try:
-        reader, writer = await asyncio.wait_for(asyncio.open_connection(host, port), timeout=timeout)
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port), timeout=timeout
+        )
     except Exception:
         return None
     try:
@@ -359,7 +363,9 @@ async def _discover_port_scan_cameras(timeout: float = 3.0) -> list[dict[str, st
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Discover ONVIF / network cameras on the LAN")
-    parser.add_argument("--timeout", type=float, default=3.0, help="per-strategy timeout in seconds")
+    parser.add_argument(
+        "--timeout", type=float, default=3.0, help="per-strategy timeout in seconds"
+    )
     parser.add_argument(
         "--scan",
         action="store_true",

--- a/src/familiar_agent/camera_discovery.py
+++ b/src/familiar_agent/camera_discovery.py
@@ -1,0 +1,400 @@
+"""Network camera discovery helpers and CLI entrypoint."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import re
+import socket
+import subprocess
+import sys
+import time
+from collections import OrderedDict
+from typing import Any
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+_CAMERA_PORTS = (554, 80, 2020)
+_MDNS_SERVICE_TYPES = ("_rtsp._tcp.local.", "_http._tcp.local.")
+_SSDP_MULTICAST_ADDR = ("239.255.255.250", 1900)
+_SSDP_REQUEST = "\r\n".join(
+    [
+        "M-SEARCH * HTTP/1.1",
+        "HOST: 239.255.255.250:1900",
+        'MAN: "ssdp:discover"',
+        "MX: 1",
+        "ST: ssdp:all",
+        "",
+        "",
+    ]
+).encode("ascii")
+
+
+def _normalize_camera(entry: dict[str, str]) -> dict[str, str]:
+    host = str(entry.get("host", "") or "").strip()
+    address = str(entry.get("address", "") or "").strip()
+    if not host and address:
+        host = urlparse(address).hostname or ""
+    if not host:
+        return {}
+    return {
+        "host": host,
+        "address": address,
+        "source": str(entry.get("source", "") or "").strip(),
+        "port": str(entry.get("port", "") or "").strip(),
+        "name": str(entry.get("name", "") or "").strip(),
+    }
+
+
+def _merge_camera_results(candidates: list[dict[str, str]]) -> list[dict[str, str]]:
+    merged: "OrderedDict[str, dict[str, str]]" = OrderedDict()
+    for raw in candidates:
+        item = _normalize_camera(raw)
+        if not item:
+            continue
+        host = item["host"]
+        if host not in merged:
+            merged[host] = {**item, "sources": item["source"] or ""}
+            continue
+
+        current = merged[host]
+        if not current["address"] and item["address"]:
+            current["address"] = item["address"]
+        if not current["port"] and item["port"]:
+            current["port"] = item["port"]
+        if not current["name"] and item["name"]:
+            current["name"] = item["name"]
+
+        sources = {
+            source
+            for source in (current.get("sources", ""), item["source"])
+            for source in source.split(",")
+            if source
+        }
+        current["sources"] = ",".join(sorted(sources))
+        current["source"] = current["source"] or item["source"]
+
+    return list(merged.values())
+
+
+async def discover_network_cameras(
+    *, timeout: float = 3.0, include_port_scan: bool = False
+) -> list[dict[str, str]]:
+    """Discover network cameras via multiple low-friction protocols."""
+    tasks = [
+        _discover_ws_discovery_cameras(timeout=timeout),
+        _discover_mdns_cameras(timeout=timeout),
+        _discover_ssdp_cameras(timeout=timeout),
+    ]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    candidates: list[dict[str, str]] = []
+    for result in results:
+        if isinstance(result, BaseException):
+            logger.debug("Camera discovery strategy failed: %s", result)
+            continue
+        candidates.extend(result)
+
+    if include_port_scan:
+        try:
+            candidates.extend(await _discover_port_scan_cameras(timeout=timeout))
+        except Exception as exc:
+            logger.debug("Camera port-scan fallback failed: %s", exc)
+
+    return _merge_camera_results(candidates)
+
+
+async def _discover_ws_discovery_cameras(timeout: float = 3.0) -> list[dict[str, str]]:
+    try:
+        from wsdiscovery import WSDiscovery  # type: ignore[import]
+    except ImportError:
+        logger.debug("wsdiscovery not available — skipping WS-Discovery")
+        return []
+
+    def _sync() -> list[dict[str, str]]:
+        wsd = WSDiscovery()
+        try:
+            wsd.start()
+            services = wsd.searchServices()
+        finally:
+            try:
+                wsd.stop()
+            except Exception:
+                pass
+
+        found: list[dict[str, str]] = []
+        for svc in services:
+            try:
+                addrs = svc.getXAddrs()
+                if not addrs:
+                    continue
+                address = str(addrs[0])
+                parsed = urlparse(address)
+                host = parsed.hostname or ""
+                port = parsed.port or 2020
+                if host:
+                    found.append(
+                        {
+                            "host": host,
+                            "address": address,
+                            "source": "ws-discovery",
+                            "port": str(port),
+                            "name": "",
+                        }
+                    )
+            except Exception:
+                continue
+        return found
+
+    try:
+        return await asyncio.wait_for(asyncio.to_thread(_sync), timeout=timeout)
+    except Exception as exc:
+        logger.debug("WS-Discovery failed: %s", exc)
+        return []
+
+
+async def _discover_mdns_cameras(timeout: float = 3.0) -> list[dict[str, str]]:
+    try:
+        from zeroconf import ServiceBrowser, Zeroconf  # type: ignore[import]
+    except ImportError:
+        logger.debug("zeroconf not available — skipping mDNS discovery")
+        return []
+
+    def _sync() -> list[dict[str, str]]:
+        found: list[dict[str, str]] = []
+
+        class _Listener:
+            def add_service(self, zc: Any, service_type: str, name: str) -> None:
+                try:
+                    info = zc.get_service_info(service_type, name, timeout=int(timeout * 1000))
+                except Exception:
+                    return
+                if info is None:
+                    return
+                addresses: list[str] = []
+                try:
+                    addresses = list(info.parsed_addresses())
+                except Exception:
+                    pass
+                if not addresses:
+                    return
+
+                port = int(getattr(info, "port", 0) or 0)
+                scheme = "rtsp" if service_type.startswith("_rtsp") or port == 554 else "http"
+                for host in addresses:
+                    found.append(
+                        {
+                            "host": host,
+                            "address": f"{scheme}://{host}:{port}" if port else f"{scheme}://{host}",
+                            "source": "mdns",
+                            "port": str(port) if port else "",
+                            "name": str(getattr(info, "server", "") or name).rstrip("."),
+                        }
+                    )
+
+            def update_service(self, zc: Any, service_type: str, name: str) -> None:
+                self.add_service(zc, service_type, name)
+
+            def remove_service(self, zc: Any, service_type: str, name: str) -> None:
+                return
+
+        zc = Zeroconf()
+        browsers = []
+        try:
+            listener = _Listener()
+            for service_type in _MDNS_SERVICE_TYPES:
+                browsers.append(ServiceBrowser(zc, service_type, listener))  # type: ignore[arg-type]
+            time.sleep(timeout)
+        finally:
+            for browser in browsers:
+                try:
+                    browser.cancel()
+                except Exception:
+                    pass
+            zc.close()
+        return found
+
+    try:
+        return await asyncio.to_thread(_sync)
+    except Exception as exc:
+        logger.debug("mDNS discovery failed: %s", exc)
+        return []
+
+
+def _parse_ssdp_response(payload: bytes, addr: tuple[str, int]) -> dict[str, str]:
+    text = payload.decode("utf-8", errors="ignore")
+    headers: dict[str, str] = {}
+    for line in text.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        headers[key.strip().lower()] = value.strip()
+
+    address = headers.get("location", "")
+    host = urlparse(address).hostname if address else ""
+    if not host:
+        host = addr[0]
+    if not host:
+        return {}
+
+    port = str(urlparse(address).port or "")
+    name = headers.get("server", "") or headers.get("usn", "")
+    return {
+        "host": host,
+        "address": address,
+        "source": "ssdp",
+        "port": port,
+        "name": name,
+    }
+
+
+async def _discover_ssdp_cameras(timeout: float = 3.0) -> list[dict[str, str]]:
+    def _sync() -> list[dict[str, str]]:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        sock.settimeout(max(0.2, timeout / 4))
+        sock.sendto(_SSDP_REQUEST, _SSDP_MULTICAST_ADDR)
+
+        deadline = time.monotonic() + timeout
+        found: list[dict[str, str]] = []
+        try:
+            while time.monotonic() < deadline:
+                try:
+                    payload, addr = sock.recvfrom(65535)
+                except socket.timeout:
+                    break
+                item = _parse_ssdp_response(payload, addr)
+                if item:
+                    found.append(item)
+        finally:
+            sock.close()
+        return found
+
+    try:
+        return await asyncio.to_thread(_sync)
+    except Exception as exc:
+        logger.debug("SSDP discovery failed: %s", exc)
+        return []
+
+
+def get_local_network_prefix() -> str | None:
+    """Best-effort `/24` prefix for local fallback scanning."""
+    env_prefix = (os.environ.get("FAMILIAR_CAMERA_DISCOVERY_PREFIX", "") or "").strip()
+    if env_prefix:
+        return env_prefix
+
+    commands = (
+        ["ip", "route", "get", "1.1.1.1"],
+        ["ip", "route"],
+    )
+    for cmd in commands:
+        try:
+            output = subprocess.check_output(cmd, text=True, stderr=subprocess.DEVNULL)
+        except Exception:
+            continue
+
+        match = re.search(r"\bsrc\s+(\d+\.\d+\.\d+)\.\d+\b", output)
+        if match:
+            return match.group(1)
+
+        match = re.search(r"\b(\d+\.\d+\.\d+)\.\d+/\d+\b", output)
+        if match:
+            return match.group(1)
+
+    return None
+
+
+async def _probe_camera_port(host: str, port: int, timeout: float) -> dict[str, str] | None:
+    try:
+        reader, writer = await asyncio.wait_for(asyncio.open_connection(host, port), timeout=timeout)
+    except Exception:
+        return None
+    try:
+        writer.close()
+        await writer.wait_closed()
+    except Exception:
+        pass
+
+    scheme = "rtsp" if port == 554 else "http"
+    path = "/onvif/device_service" if port == 2020 else ""
+    return {
+        "host": host,
+        "address": f"{scheme}://{host}:{port}{path}",
+        "source": "port-scan",
+        "port": str(port),
+        "name": "",
+    }
+
+
+async def _discover_port_scan_cameras(timeout: float = 3.0) -> list[dict[str, str]]:
+    prefix = get_local_network_prefix()
+    if not prefix:
+        return []
+
+    hosts = [f"{prefix}.{index}" for index in range(1, 255)]
+    probe_timeout = min(0.2, max(timeout / 20, 0.05))
+    semaphore = asyncio.Semaphore(64)
+
+    async def _scan_host(host: str) -> list[dict[str, str]]:
+        async with semaphore:
+            found: list[dict[str, str]] = []
+            for port in _CAMERA_PORTS:
+                result = await _probe_camera_port(host, port, timeout=probe_timeout)
+                if result is not None:
+                    found.append(result)
+            return found
+
+    tasks = [_scan_host(host) for host in hosts]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    found: list[dict[str, str]] = []
+    for result in results:
+        if isinstance(result, BaseException):
+            continue
+        found.extend(result)
+    return found
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Discover ONVIF / network cameras on the LAN")
+    parser.add_argument("--timeout", type=float, default=3.0, help="per-strategy timeout in seconds")
+    parser.add_argument(
+        "--scan",
+        action="store_true",
+        help="enable slower TCP port-scan fallback in addition to WS-Discovery/mDNS/SSDP",
+    )
+    parser.add_argument("--json", action="store_true", help="print machine-readable JSON")
+    return parser
+
+
+def _render_human(results: list[dict[str, str]]) -> str:
+    if not results:
+        return "No cameras found."
+    lines = ["Discovered cameras:"]
+    for item in results:
+        label = item["name"] or item["host"]
+        details = f"{label} [{item['sources']}]"
+        if item["address"]:
+            details += f" -> {item['address']}"
+        lines.append(details)
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args(sys.argv[1:])
+
+    results = asyncio.run(
+        discover_network_cameras(timeout=args.timeout, include_port_scan=bool(args.scan))
+    )
+    if args.json:
+        print(json.dumps(results, indent=2))
+    else:
+        print(_render_human(results))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/familiar_agent/setup.py
+++ b/src/familiar_agent/setup.py
@@ -15,10 +15,10 @@ import logging
 import re
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
 from dotenv import dotenv_values, set_key, unset_key
 
+from .camera_discovery import discover_network_cameras
 from .settings_schema import SetupConfig, setup_config_to_env_values
 
 logger = logging.getLogger(__name__)
@@ -194,45 +194,14 @@ async def validate_camera_connection(
         return False, str(exc)
 
 
-async def _ws_discover() -> list[Any]:
-    """Run ONVIF WS-Discovery and return raw service objects."""
-    try:
-        import asyncio
-        from wsdiscovery import WSDiscovery  # type: ignore[import]
-
-        def _sync() -> list[Any]:
-            wsd = WSDiscovery()
-            wsd.start()
-            svcs = wsd.searchServices()
-            wsd.stop()
-            return svcs
-
-        return await asyncio.to_thread(_sync)
-    except ImportError:
-        logger.debug("wsdiscovery not available — camera auto-discovery disabled")
-        return []
-
-
 async def discover_onvif_cameras(timeout: float = 3.0) -> list[dict[str, str]]:
-    """Scan the local network for ONVIF cameras via WS-Discovery."""
-    import asyncio
+    """Discover cameras on the local network.
 
+    The historical public API is kept for setup/tests, but discovery now uses a
+    unified backend that combines WS-Discovery, mDNS/zeroconf, and SSDP.
+    """
     try:
-        services = await asyncio.wait_for(_ws_discover(), timeout=timeout)
+        return await discover_network_cameras(timeout=timeout, include_port_scan=False)
     except Exception as exc:
         logger.debug("Camera discovery error: %s", exc)
         return []
-
-    results: list[dict[str, str]] = []
-    for svc in services:
-        try:
-            addrs = svc.getXAddrs()
-            if not addrs:
-                continue
-            parsed = urlparse(addrs[0])
-            host = parsed.hostname or ""
-            if host:
-                results.append({"host": host, "address": addrs[0]})
-        except Exception:
-            continue
-    return results

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_discover_network_cameras_merges_sources_and_dedupes_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import familiar_agent.camera_discovery as mod
+
+    monkeypatch.setattr(
+        mod,
+        "_discover_ws_discovery_cameras",
+        AsyncMock(
+            return_value=[
+                {
+                    "host": "192.168.1.10",
+                    "address": "http://192.168.1.10:2020/onvif/device_service",
+                    "source": "ws-discovery",
+                    "port": "2020",
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_discover_mdns_cameras",
+        AsyncMock(
+            return_value=[
+                {
+                    "host": "192.168.1.10",
+                    "address": "rtsp://192.168.1.10:554/stream1",
+                    "source": "mdns",
+                    "name": "Tapo Cam",
+                    "port": "554",
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "_discover_ssdp_cameras",
+        AsyncMock(
+            return_value=[
+                {
+                    "host": "192.168.1.22",
+                    "address": "http://192.168.1.22:80/device.xml",
+                    "source": "ssdp",
+                    "port": "80",
+                }
+            ]
+        ),
+    )
+    port_scan = AsyncMock(return_value=[])
+    monkeypatch.setattr(mod, "_discover_port_scan_cameras", port_scan)
+
+    results = await mod.discover_network_cameras(timeout=1.0)
+
+    assert [item["host"] for item in results] == ["192.168.1.10", "192.168.1.22"]
+    assert results[0]["name"] == "Tapo Cam"
+    assert results[0]["sources"] == "mdns,ws-discovery"
+    assert results[0]["address"] == "http://192.168.1.10:2020/onvif/device_service"
+    port_scan.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_discover_network_cameras_can_include_port_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import familiar_agent.camera_discovery as mod
+
+    monkeypatch.setattr(mod, "_discover_ws_discovery_cameras", AsyncMock(return_value=[]))
+    monkeypatch.setattr(mod, "_discover_mdns_cameras", AsyncMock(return_value=[]))
+    monkeypatch.setattr(mod, "_discover_ssdp_cameras", AsyncMock(return_value=[]))
+    port_scan = AsyncMock(
+        return_value=[
+            {
+                "host": "192.168.1.77",
+                "address": "rtsp://192.168.1.77:554/stream1",
+                "source": "port-scan",
+                "port": "554",
+            }
+        ]
+    )
+    monkeypatch.setattr(mod, "_discover_port_scan_cameras", port_scan)
+
+    results = await mod.discover_network_cameras(timeout=1.0, include_port_scan=True)
+
+    assert results == [
+        {
+            "host": "192.168.1.77",
+            "address": "rtsp://192.168.1.77:554/stream1",
+            "source": "port-scan",
+            "sources": "port-scan",
+            "port": "554",
+            "name": "",
+        }
+    ]
+    port_scan.assert_awaited_once_with(timeout=1.0)
+
+
+def test_main_prints_json_results(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import familiar_agent.camera_discovery as mod
+
+    monkeypatch.setattr(
+        mod,
+        "discover_network_cameras",
+        AsyncMock(
+            return_value=[
+                {
+                    "host": "192.168.1.50",
+                    "address": "http://192.168.1.50:2020/onvif/device_service",
+                    "source": "ws-discovery",
+                    "sources": "ws-discovery",
+                    "port": "2020",
+                    "name": "",
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(mod.sys, "argv", ["camera-discovery", "--json"])
+
+    rc = mod.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload[0]["host"] == "192.168.1.50"

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -260,7 +260,7 @@ async def test_validate_camera_connection_failure():
 @pytest.mark.asyncio
 async def test_discover_onvif_cameras_returns_list():
     """discover_onvif_cameras() returns a list (possibly empty if no cameras)."""
-    with patch("familiar_agent.setup._ws_discover") as mock_discover:
+    with patch("familiar_agent.setup.discover_network_cameras") as mock_discover:
         mock_discover.return_value = []
         result = await discover_onvif_cameras()
     assert isinstance(result, list)
@@ -269,11 +269,10 @@ async def test_discover_onvif_cameras_returns_list():
 @pytest.mark.asyncio
 async def test_discover_onvif_cameras_parses_host():
     """Discovered camera entries include a 'host' field."""
-    fake_service = MagicMock()
-    fake_service.getXAddrs.return_value = ["http://192.168.1.42:80/onvif/device_service"]
-
-    with patch("familiar_agent.setup._ws_discover") as mock_discover:
-        mock_discover.return_value = [fake_service]
+    with patch("familiar_agent.setup.discover_network_cameras") as mock_discover:
+        mock_discover.return_value = [
+            {"host": "192.168.1.42", "address": "http://192.168.1.42:80/onvif/device_service"}
+        ]
         result = await discover_onvif_cameras()
 
     assert len(result) == 1
@@ -283,7 +282,7 @@ async def test_discover_onvif_cameras_parses_host():
 @pytest.mark.asyncio
 async def test_discover_onvif_cameras_handles_discovery_error():
     """discover_onvif_cameras() returns empty list when discovery raises."""
-    with patch("familiar_agent.setup._ws_discover") as mock_discover:
+    with patch("familiar_agent.setup.discover_network_cameras") as mock_discover:
         mock_discover.side_effect = Exception("Network error")
         result = await discover_onvif_cameras()
     assert result == []

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -674,7 +674,7 @@ wheels = [
 
 [[package]]
 name = "familiar-ai"
-version = "0.2.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -704,11 +704,13 @@ all = [
     { name = "qasync" },
     { name = "sounddevice" },
     { name = "soundfile" },
+    { name = "zeroconf" },
 ]
 camera = [
     { name = "onvif-zeep-async" },
     { name = "opencv-python" },
     { name = "pillow" },
+    { name = "zeroconf" },
 ]
 gui = [
     { name = "pyside6" },
@@ -726,6 +728,7 @@ camera = [
     { name = "onvif-zeep-async" },
     { name = "opencv-python" },
     { name = "pillow" },
+    { name = "zeroconf" },
 ]
 dev = [
     { name = "mypy" },
@@ -769,6 +772,7 @@ requires-dist = [
     { name = "textual-autocomplete", specifier = ">=4.0.6" },
     { name = "tinytuya", specifier = ">=1.15.0" },
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.22.1" },
+    { name = "zeroconf", marker = "extra == 'camera'", specifier = ">=0.132.2" },
 ]
 provides-extras = ["gui", "camera", "voice", "all"]
 
@@ -777,6 +781,7 @@ camera = [
     { name = "onvif-zeep-async", specifier = ">=4.0.0" },
     { name = "opencv-python", specifier = ">=4.0" },
     { name = "pillow", specifier = ">=10.0.0" },
+    { name = "zeroconf", specifier = ">=0.132.2" },
 ]
 dev = [
     { name = "mypy", specifier = ">=1.10.0" },
@@ -1270,6 +1275,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "ifaddr"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ac/fb4c578f4a3256561548cd825646680edcadb9440f3f68add95ade1eb791/ifaddr-0.2.0.tar.gz", hash = "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4", size = 10485, upload-time = "2022-06-15T21:40:27.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/1f/19ebc343cc71a7ffa78f17018535adc5cbdd87afb31d7c34874680148b32/ifaddr-0.2.0-py3-none-any.whl", hash = "sha256:085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748", size = 12314, upload-time = "2022-06-15T21:40:25.756Z" },
 ]
 
 [[package]]
@@ -4143,6 +4157,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ee/efbd56687be60ef9af0c9c0ebe106964c07400eade5b0af8902a1d8cd58c/torch-2.10.0-3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a1ff626b884f8c4e897c4c33782bdacdff842a165fee79817b1dd549fdda1321", size = 915510070, upload-time = "2026-03-11T14:16:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ab/7b562f1808d3f65414cd80a4f7d4bb00979d9355616c034c171249e1a303/torch-2.10.0-3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac5bdcbb074384c66fa160c15b1ead77839e3fe7ed117d667249afce0acabfac", size = 915518691, upload-time = "2026-03-11T14:15:43.147Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
     { url = "https://files.pythonhosted.org/packages/0c/1a/c61f36cfd446170ec27b3a4984f072fd06dab6b5d7ce27e11adb35d6c838/torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d", size = 145992962, upload-time = "2026-01-21T16:24:14.04Z" },
     { url = "https://files.pythonhosted.org/packages/b5/60/6662535354191e2d1555296045b63e4279e5a9dbad49acf55a5d38655a39/torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444", size = 915599237, upload-time = "2026-01-21T16:23:25.497Z" },
     { url = "https://files.pythonhosted.org/packages/40/b8/66bbe96f0d79be2b5c697b2e0b187ed792a15c6c4b8904613454651db848/torch-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a4be6a2a190b32ff5c8002a0977a25ea60e64f7ba46b1be37093c141d9c49aeb", size = 113720931, upload-time = "2026-01-21T16:24:23.743Z" },
@@ -4211,12 +4232,19 @@ name = "triton"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/ba/b1b04f4b291a3205d95ebd24465de0e5bf010a2df27a4e58a9b5f039d8f2/triton-3.6.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c723cfb12f6842a0ae94ac307dba7e7a44741d720a40cf0e270ed4a4e3be781", size = 175972180, upload-time = "2026-01-20T16:15:53.664Z" },
     { url = "https://files.pythonhosted.org/packages/8c/f7/f1c9d3424ab199ac53c2da567b859bcddbb9c9e7154805119f8bd95ec36f/triton-3.6.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6550fae429e0667e397e5de64b332d1e5695b73650ee75a6146e2e902770bea", size = 188105201, upload-time = "2026-01-20T16:00:29.272Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2c/96f92f3c60387e14cc45aed49487f3486f89ea27106c1b1376913c62abe4/triton-3.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49df5ef37379c0c2b5c0012286f80174fcf0e073e5ade1ca9a86c36814553651", size = 176081190, upload-time = "2026-01-20T16:16:00.523Z" },
     { url = "https://files.pythonhosted.org/packages/e0/12/b05ba554d2c623bffa59922b94b0775673de251f468a9609bc9e45de95e9/triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e323d608e3a9bfcc2d9efcc90ceefb764a82b99dea12a86d643c72539ad5d3", size = 188214640, upload-time = "2026-01-20T16:00:35.869Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
     { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
     { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
     { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/5ecf0dcaa0f2fbbd4420f7ef227ee3cb172e91e5fede9d0ecaddc43363b4/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43", size = 176138577, upload-time = "2026-01-20T16:16:25.426Z" },
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
+    { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
 ]
 
@@ -4577,4 +4605,76 @@ wheels = [
 async = [
     { name = "httpx" },
     { name = "packaging" },
+]
+
+[[package]]
+name = "zeroconf"
+version = "0.148.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ifaddr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/46/10db987799629d01930176ae523f70879b63577060d63e05ebf9214aba4b/zeroconf-0.148.0.tar.gz", hash = "sha256:03fcca123df3652e23d945112d683d2f605f313637611b7d4adf31056f681702", size = 164447, upload-time = "2025-10-05T00:21:19.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/47/a2ff13f3a0a7b9bd4cc1a904e7ddfd4f327043387915607db1117e1c1417/zeroconf-0.148.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9146731bb82bc7b42f009aa69619b17a4b6ddecc75eee9a59249c12c804d0637", size = 1708548, upload-time = "2025-10-05T01:07:30.722Z" },
+    { url = "https://files.pythonhosted.org/packages/54/11/7c871eba676458e5f3943e45281db91c3b01743b8e7f5401640855ca863e/zeroconf-0.148.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:db24dc2e5367dc61bacbf302b7c85cc10ee1a9de8f1710380027992afd1ddcb4", size = 1682018, upload-time = "2025-10-05T01:07:33.879Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/73/62149096a758e6036625a66b1053af8600126cb8e50ca8adcb705732e211/zeroconf-0.148.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2202ac7dc2777249561292c9151919d70fbe25a31983b7e127b43878ea67483c", size = 2195888, upload-time = "2025-10-05T01:07:35.833Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/35/9ace30a86ec42b11a1904d63fa260c166c972a743079d6ffaa69f8085924/zeroconf-0.148.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:876e9e61a7065d201d39c466449e01fa9e19c3c7b2c5ee57bc628f15e21653fb", size = 1970965, upload-time = "2025-10-05T01:07:37.809Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/b463e84c221ccbbc04a6d4f69a2e2c2c005ce04a233ec2d398987f50177f/zeroconf-0.148.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:171ff9d59283737946d79c6a290a597a3d10d0d24d6a3a87de67ce3064157afc", size = 2269837, upload-time = "2025-10-05T01:07:39.698Z" },
+    { url = "https://files.pythonhosted.org/packages/85/9d/b56979c5abb14d18790eca845428b417990177ebd9674b1b1f61491efd3b/zeroconf-0.148.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:76d53985fa40cefb3a82c1d5d761217392bbc811964715e1bf73e74084012062", size = 2224442, upload-time = "2025-10-05T01:07:41.816Z" },
+    { url = "https://files.pythonhosted.org/packages/63/61/6b6cf5d1f75f464cb697bc4fcb59baaa792485d5f8a29ac460ed75d1afe8/zeroconf-0.148.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:429e8ed8428737f2586992aaf11a21302184cd4e1c641fbd7abe8946d9ff7089", size = 2017165, upload-time = "2025-10-05T01:07:43.708Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f3/cce930ce7d57da67ce7662b188907415441c3edfca4aac97be53049c0cc9/zeroconf-0.148.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:aa0cdcb91f231789d8f6ba7ed702d05a36975e7b06fd663aff25205ddca2b659", size = 2293150, upload-time = "2025-10-05T01:07:45.695Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2f/d011bc4ba85a8df2796622f91a44f181526e382ff57c69df0dd11a4ce57a/zeroconf-0.148.0-cp310-cp310-win32.whl", hash = "sha256:3c1ec76c031712c6289cc94acee43e7bf7a6cb52b45675278348926eacffc668", size = 1310884, upload-time = "2025-10-05T01:07:47.561Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/7a/abedff888ffc6e79c2a189a7bb9f4b358c57db895a21bbb0e59b40c6e5c8/zeroconf-0.148.0-cp310-cp310-win_amd64.whl", hash = "sha256:144fa2e0246292ea9c62792327d230f1b996c65cec16024b10689ee597b05ab2", size = 1527932, upload-time = "2025-10-05T01:07:49.726Z" },
+    { url = "https://files.pythonhosted.org/packages/00/1f/dcaed909fabbdf760739b3081cbea3f7cd564e61a708dca00a55960da11c/zeroconf-0.148.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b923e26369e302863aa5370eff4d4d72a0b90ba85d3b9f608c62cbab78f14dc2", size = 1723036, upload-time = "2025-10-05T01:07:51.26Z" },
+    { url = "https://files.pythonhosted.org/packages/05/37/849d419ccd60e37e02ca7364ac9451e500e517cebf884bee88e6811c442b/zeroconf-0.148.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0cbffd751877b74cd64c529061e5a524ebfa59af16930330548033e307701fee", size = 1696983, upload-time = "2025-10-05T01:07:52.818Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/1e/1511a2f10e22e51e391638dc58786af74c996513b6588c9219f085cc898e/zeroconf-0.148.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34275f60a5ab01d2d0a190662d16603b75f9225cee4ab58d388ff86d8011352a", size = 2208149, upload-time = "2025-10-05T01:07:54.7Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8e/744b4cc8d9ee314be5fe3fbd597baef4cc3998d24d70ac1265dfa7750544/zeroconf-0.148.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:556ff0b9dfc0189f33c6e6110aa23d9f7564a7475f4cdc624a0584c1133ae44b", size = 1978151, upload-time = "2025-10-05T01:07:56.638Z" },
+    { url = "https://files.pythonhosted.org/packages/42/1f/d8b365a3f3979ea3f0ecb02c22c61d2cdc4fc5bc0bc182ff52547935923c/zeroconf-0.148.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8aa15461e35169b4ec25cc45ec82750023e6c2e96ebc099a014caaf544316f7", size = 2285527, upload-time = "2025-10-05T01:07:58.157Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/0a27fd233240a911a58eae6037357f0d088cdcbff295cf01ad05a0b91bd6/zeroconf-0.148.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:25b8b72177bbe0792f5873c16330d759811540edb24ed9ead305874183eaefd5", size = 2237619, upload-time = "2025-10-05T01:07:59.782Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1a/56d6155eb3b8a77a11dcf0c77ef747c46a1c778d8957b818dfdc0578886e/zeroconf-0.148.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:10ce75cdb524f955773114697633d73644aad6c35daef5315fa478bff9bee24d", size = 2031313, upload-time = "2025-10-05T01:08:01.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/4c/4521a8c469802c16f61e6b12b674a239684d0fe8e51fe66ebe0223ca4d2d/zeroconf-0.148.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:49512e6d59be66be769f36e1f7f025a2841783da1be708d4b4a92a7b63135b68", size = 2309244, upload-time = "2025-10-05T01:08:03.311Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/8b/b34de5602013e6a4d08918adaaadf706985a45990018c9d4339dd6df6b8d/zeroconf-0.148.0-cp311-cp311-win32.whl", hash = "sha256:8ff905f8ff9083a853eb4e65eb31b09fa9d7a6633de92ac1e2018819eee52d30", size = 1305325, upload-time = "2025-10-05T01:08:04.841Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f4/a9f279aee669b03a7e1b435ee7bd4fb1fd4ced040d2188af903d3b276e29/zeroconf-0.148.0-cp311-cp311-win_amd64.whl", hash = "sha256:7339a485403c75aa4f3c38ddcb68eb14f01fd5e1dc1ef75b068b185e703ea7ea", size = 1529930, upload-time = "2025-10-05T01:08:07.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b3/6c08ccbda1e78c8f538d8add49fac2fe49ef85ee34b62877df4154715583/zeroconf-0.148.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aef8699ea47cd47c9219e3f110a35ad50c13c34c7c6db992f3c9f75feec6ef8f", size = 1735431, upload-time = "2025-10-05T01:08:09.375Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/37/6b91c4a4258863e485602e6b1eb098fe406142a653112e8719c49b69afc4/zeroconf-0.148.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9097e7010b9f9a64e5f2084493e9973d446bd85c7a7cbef5032b2b0a2ecc5a12", size = 1701594, upload-time = "2025-10-05T01:08:11.448Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/5eaaf66d39b3bccc17b52187eebb2dde93f761f4ee8b6c83b8fe764273f5/zeroconf-0.148.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdc566c387260fb7bf89f91d00460d0c9b9373dfddcf1fcc980ab3f7270154f9", size = 2134103, upload-time = "2025-10-05T01:08:13.061Z" },
+    { url = "https://files.pythonhosted.org/packages/19/a5/e4ebe7b5fbea512fe13efb466d855124126d2f531a18216c7cb509b8a4dd/zeroconf-0.148.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10cbd4134cacc22c3b3b169d7f782472a1dd36895e1421afa4f681caf181c07b", size = 1930109, upload-time = "2025-10-05T01:08:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/16/7f7c5cee5279afe2a6a8b9657de9a587ccb34168d7c99acc6d2b40b9d87e/zeroconf-0.148.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dde01541e6a45c4d1b6e6d97b532ea241abc32c183745a74021b134d867388d8", size = 2230425, upload-time = "2025-10-05T01:08:16.296Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/41/0e1999db76e390fca9eef8257455955445a0386b94ce0ef6ce74896d7e2a/zeroconf-0.148.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8ceab8f10ab6fc0847a2de74377663793a974fdba77e7e6ba1ff47679f4bb845", size = 2161052, upload-time = "2025-10-05T01:08:17.976Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/6585fe6308b8f1ac0ac4d37ac69064ec2a36b81cf9080813cb666229694c/zeroconf-0.148.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0a8c36c37d8835420fc337be4aaa03c3a34272028919de575124c10d31a7e304", size = 2015005, upload-time = "2025-10-05T01:08:20.318Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ec/a9d0a577be157170f513e6ad6ebb3cd8dd9602c670d74911e9c5534e1c1d/zeroconf-0.148.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:848d57df1bb3b48279ba9b66e6c1f727570e2c8e7e0c4518c2daffaf23419d03", size = 2253785, upload-time = "2025-10-05T01:08:21.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/43/6679c16d4e6897c9aa502ee35c122bb605eee855612fad2ef6e0e13722c4/zeroconf-0.148.0-cp312-cp312-win32.whl", hash = "sha256:ba6eaa6b769924391c213dc391f36bd1c7e3ebe45fa3fa0cd97451b4f9ccef5c", size = 1295810, upload-time = "2025-10-05T01:08:23.575Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/42/a2d61df82086ddd32b9a5870ac683e8e5038cae38e2433c4fa03fe044235/zeroconf-0.148.0-cp312-cp312-win_amd64.whl", hash = "sha256:cec84ae7028db4a3addcc18628d12456cf39a9e973abee4a41e3b94d0db7df4c", size = 1533317, upload-time = "2025-10-05T01:08:26.973Z" },
+    { url = "https://files.pythonhosted.org/packages/46/09/394a24a633645063557c5144c9abb694699df76155dcab5e1e3078dd1323/zeroconf-0.148.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6ad889929bdc3953530546a4a2486d8c07f5a18d4ef494a98446bf17414897a7", size = 1714465, upload-time = "2025-10-05T01:08:28.692Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/db/f57c4bfcceb67fe474705cbadba3f8f7a88bdc95892e74ba6d85e24d28c3/zeroconf-0.148.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:29fb10be743650eb40863f1a1ee868df1869357a0c2ab75140ee3d7079540c1e", size = 1683877, upload-time = "2025-10-05T01:08:30.42Z" },
+    { url = "https://files.pythonhosted.org/packages/54/6c/b3e2d39c40802a8cc9415357acdb76ff01bc29e25ffaa811771b6fffc428/zeroconf-0.148.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f2995e74969c577461060539164c47e1ba674470585cb0f954ebeb77f032f3c2", size = 2122874, upload-time = "2025-10-05T01:08:32.11Z" },
+    { url = "https://files.pythonhosted.org/packages/66/eb/0ac2bf51d58d47cfa854628036a7ad95544a1802bc890f3d69649dc35e46/zeroconf-0.148.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5be50346efdc20823f9d68d8757612767d11ceb8da7637d46080977b87912551", size = 1922164, upload-time = "2025-10-05T01:08:33.78Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ff/c7372507c7e25ad3499fe08d4678deb1ed41c57f78ff5df43bd2d4d98cfc/zeroconf-0.148.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc88fd01b5552ffb4d5bc551d027ac28a1852c03ceab754d02bd0d5f04c54e85", size = 2214119, upload-time = "2025-10-05T01:08:35.478Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/57f0889f47923b4fa4364b62b7b3ffc347f6bad09a25ce4e578b8991a86d/zeroconf-0.148.0-cp313-cp313-manylinux_2_36_x86_64.whl", hash = "sha256:5af260c74187751c0df6a40f38d6fd17cb8658a734b0e1148a86084b71c1977c", size = 2137609, upload-time = "2025-10-05T00:21:15.953Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/33/9cb5558695c1377941dbb10a5591f88a787f9e1fba130642693d5c80663b/zeroconf-0.148.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b6078c73a76d49ba969ca2bb7067e4d58ebd2b79a5f956e45c4c989b11d36e03", size = 2154314, upload-time = "2025-10-05T01:08:37.523Z" },
+    { url = "https://files.pythonhosted.org/packages/38/06/cf4e17a86922b4561d85d36f50f1adada1328723e882d95aa42baefa5479/zeroconf-0.148.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:3e686bf741158f4253d5e0aa6a8f9d34b3140bf5826c0aca9b906273b9c77a5f", size = 2004973, upload-time = "2025-10-05T01:08:39.825Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/61/937a405783317639cd11e7bfab3879669896297b6ca2edfb0d2d9c8dbb30/zeroconf-0.148.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:52d6ac06efe05a1e46089cfde066985782824f64b64c6982e8678e70b4b49453", size = 2237775, upload-time = "2025-10-05T01:08:41.535Z" },
+    { url = "https://files.pythonhosted.org/packages/03/43/a1751c4b63e108a2318c2266e5afdd9d62292250aa8b1a8ed1674090885c/zeroconf-0.148.0-cp313-cp313-win32.whl", hash = "sha256:b9ba58e2bbb0cff020b54330916eaeb8ee8f4b0dde852e84f670f4ca3a0dd059", size = 1291073, upload-time = "2025-10-05T01:08:43.757Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/69/5f4f9eb14506e2afd2d423472e566d5455334d0c8740b933914d642bdbb5/zeroconf-0.148.0-cp313-cp313-win_amd64.whl", hash = "sha256:ee3fcc2edcc04635cf673c400abac2f0c22c9786490fbfb971e0a860a872bf26", size = 1528568, upload-time = "2025-10-05T01:08:45.505Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/46/ac86e3a3ff355058cd0818b01a3a97ca3f2abc0a034f1edb8eea27cea65c/zeroconf-0.148.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:2158d8bfefcdb90237937df65b2235870ccef04644497e4e29d3ab5a4b3199b6", size = 1714870, upload-time = "2025-10-05T01:08:47.624Z" },
+    { url = "https://files.pythonhosted.org/packages/de/02/c5e8cd8dfda0ca16c7309c8d12c09a3114e5b50054bce3c93da65db8b8e4/zeroconf-0.148.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:695f6663bf8df30fe1826a2c4d5acd8213d9cbd9111f59d375bf1ad635790e98", size = 1697756, upload-time = "2025-10-05T01:08:49.472Z" },
+    { url = "https://files.pythonhosted.org/packages/63/04/a66c1011d05d7bb8ae6a847d41ac818271a942390f3d8c83c776389ca094/zeroconf-0.148.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa65a24ec055be0a1cba2b986ac3e1c5d97a40abe164991aabc6a6416cc9df02", size = 2146784, upload-time = "2025-10-05T01:08:51.766Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/d4/2239d87c3f60f886bd2dd299e9c63b811efd58b8b6fc659d8fd0900db3bc/zeroconf-0.148.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:79890df4ff696a5cdc4a59152957be568bea1423ed13632fc09e2a196c6721d5", size = 1899394, upload-time = "2025-10-05T01:08:53.457Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/60/534a4b576a8f9f5edff648ac9a5417323bef3086a77397f2f2058125a3c8/zeroconf-0.148.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c0ca6e8e063eb5a385469bb8d8dec12381368031cb3a82c446225511863ede3", size = 2221319, upload-time = "2025-10-05T01:08:55.271Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/8c/1c8e9b7d604910830243ceb533d796dae98ed0c72902624a642487edfd61/zeroconf-0.148.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ece6f030cc7a771199760963c11ce4e77ed95011eedffb1ca5186247abfec24a", size = 2178586, upload-time = "2025-10-05T01:08:56.966Z" },
+    { url = "https://files.pythonhosted.org/packages/16/55/178c4b95840dc687d45e413a74d2236a25395ab036f4813628271306ab9d/zeroconf-0.148.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c3f860ad0003a8999736fa2ae4c2051dd3c2e5df1bc1eaea2f872f5fcbd1f1c1", size = 1972371, upload-time = "2025-10-05T01:08:59.103Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/86/b599421fe634d9f3a2799f69e6e7db9f13f77d326331fa2bb5982e936665/zeroconf-0.148.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ab8e687255cf54ebeae7ede6a8be0566aec752c570e16dbea84b3f9b149ba829", size = 2244286, upload-time = "2025-10-05T01:09:01.029Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/cb/a30c42057be5da6bb4cbe1ab53bc3a7d9a29cd59caae097d3072a9375c14/zeroconf-0.148.0-cp314-cp314-win32.whl", hash = "sha256:6b1a6ddba3328d741798c895cecff21481863eb945c3e5d30a679461f4435684", size = 1321693, upload-time = "2025-10-05T01:09:02.715Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/38/06873cdf769130af463ef5acadbaf4a50826a7274374bc3b9a4ec5d32678/zeroconf-0.148.0-cp314-cp314-win_amd64.whl", hash = "sha256:2588f1ca889f57cdc09b3da0e51175f1b6153ce0f060bf5eb2a8804c5953b135", size = 1563980, upload-time = "2025-10-05T01:09:04.857Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fb/53d749793689279bc9657d818615176577233ad556d62f76f719e86ead1d/zeroconf-0.148.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:40fe100381365c983a89e4b219a7ececcc2a789ac179cd26d4a6bbe00ae3e8fe", size = 3418152, upload-time = "2025-10-05T01:09:06.71Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/19/5eb647f7277378cbfdb6943dc8e60c3b17cdd1556f5082ccfdd6813e1ce8/zeroconf-0.148.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0b9c7bcae8af8e27593bad76ee0f0c21d43c6a2324cd1e34d06e6e08cb3fd922", size = 3389671, upload-time = "2025-10-05T01:09:08.903Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/3134aa54d30a9ae2e2473212eab586fe1779f845bf241e68729eca63d2ab/zeroconf-0.148.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf8ba75dacd58558769afb5da24d83da4fdc2a5c43a52f619aaa107fa55d3fdc", size = 4123125, upload-time = "2025-10-05T01:09:11.064Z" },
+    { url = "https://files.pythonhosted.org/packages/12/23/4a0284254ebce373ff1aee7240932a0599ecf47e3c711f93242a861aa382/zeroconf-0.148.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:75f9a8212c541a4447c064433862fd4b23d75d47413912a28204d2f9c4929a59", size = 3651426, upload-time = "2025-10-05T01:09:13.725Z" },
+    { url = "https://files.pythonhosted.org/packages/76/9a/7b79ef986b5467bb8f17b9a9e6eea887b0b56ecafc00515c81d118e681b4/zeroconf-0.148.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be64c0eb48efa1972c13f7f17a7ac0ed7932ebb9672e57f55b17536412146206", size = 4263151, upload-time = "2025-10-05T01:09:15.732Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/0a/caa6d05548ca7cf28a0b8aa20a9dbb0f8176172f28799e53ea11f78692a3/zeroconf-0.148.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac1d4ee1d5bac71c27aea6d1dc1e1485423a1631a81be1ea65fb45ac280ade96", size = 4191717, upload-time = "2025-10-05T01:09:18.071Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f6/dbafa3b0f2d7a09315ed3ad588d36de79776ce49e00ec945c6195cad3f18/zeroconf-0.148.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:8da9bdb39ead9d5971136046146cd5e11413cb979c011e19f717b098788b5c37", size = 3793490, upload-time = "2025-10-05T01:09:20.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/05/f8b88937659075116c122355bdd9ce52376cc46e2269d91d7d4f10c9a658/zeroconf-0.148.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f6e3dd22732df47a126aefb5ca4b267e828b47098a945d4468d38c72843dd6df", size = 4311455, upload-time = "2025-10-05T01:09:22.042Z" },
+    { url = "https://files.pythonhosted.org/packages/58/c0/359bdb3b435d9c573aec1f877f8a63d5e81145deb6c160de89647b237363/zeroconf-0.148.0-cp314-cp314t-win32.whl", hash = "sha256:cdc8083f0b5efa908ab6c8e41687bcb75fd3d23f49ee0f34cbc58422437a456f", size = 2755961, upload-time = "2025-10-05T01:09:24.041Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ab/7b487afd5d1fd053c5a018565be734ac6d5e554bce938c7cc126154adcfc/zeroconf-0.148.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f72c1f77a89638e87f243a63979f0fd921ce391f83e18e17ec88f9f453717701", size = 3309977, upload-time = "2025-10-05T01:09:26.039Z" },
 ]


### PR DESCRIPTION
## Summary
- add a reusable `camera_discovery` module and `familiar-discover-cameras` CLI
- combine WS-Discovery, mDNS/zeroconf, SSDP, and optional TCP fallback scanning
- route setup camera discovery through the unified backend and document the new flow

## Testing
- `uv run ruff check src/familiar_agent/camera_discovery.py src/familiar_agent/setup.py tests/test_camera_discovery.py tests/test_setup_wizard.py`
- `uv run --group dev mypy src/familiar_agent/camera_discovery.py src/familiar_agent/setup.py`
- `uv run pytest -q tests/test_camera_discovery.py tests/test_setup_wizard.py`
- `uv run pytest -q`

Refs #148.