### PR TITLE
feat: dynamic desire cooldown for remote workers (5min active / 30min idle)

### DIFF
--- a/src/familiar_agent/_ui_helpers.py
+++ b/src/familiar_agent/_ui_helpers.py
@@ -225,6 +225,16 @@ def _format_tom_result(result: str) -> str | None:
 
 IDLE_CHECK_INTERVAL: float = 10.0  # seconds between desire checks when idle
 DESIRE_COOLDOWN: float = float(os.environ.get("DESIRE_COOLDOWN", "90"))  # configurable
+CONVERSATION_WINDOW: float = float(os.environ.get("CONVERSATION_WINDOW", "300"))
+DESIRE_COOLDOWN_CONVO: float = float(os.environ.get("DESIRE_COOLDOWN_CONVO", "300"))
+DESIRE_COOLDOWN_IDLE: float = float(os.environ.get("DESIRE_COOLDOWN_IDLE", "1800"))
+
+
+def get_dynamic_cooldown(last_user_input: float, now: float) -> float:
+    """会話状態に基づいてdesire cooldownを動的に返す。"""
+    if now - last_user_input < CONVERSATION_WINDOW:
+        return DESIRE_COOLDOWN_CONVO  # 会話中: デフォルト5分
+    return DESIRE_COOLDOWN_IDLE  # 非会話: デフォルト30分
 
 
 def should_fire_idle_desire(

--- a/src/familiar_agent/main.py
+++ b/src/familiar_agent/main.py
@@ -22,6 +22,7 @@ from ._ui_helpers import (
     IDLE_CHECK_INTERVAL,
     desire_tick_prompt,
     format_action as _format_action,
+    get_dynamic_cooldown,
     should_fire_idle_desire,
 )
 
@@ -87,6 +88,7 @@ async def repl(agent: EmbodiedAgent, desires: DesireSystem, debug: bool = False)
     # so user input is captured even while the agent is busy.
     input_queue: asyncio.Queue[str | None] = asyncio.Queue()
     last_interaction_time: float = time.time()
+    last_user_input_time: float = time.time()
 
     async def _stdin_reader() -> None:
         """Read stdin continuously into the queue."""
@@ -135,6 +137,7 @@ async def repl(agent: EmbodiedAgent, desires: DesireSystem, debug: bool = False)
                 # Process all buffered user messages before doing anything autonomous
                 for user_input in pending:
                     last_interaction_time = time.time()
+                    last_user_input_time = time.time()
                     await _handle_user(
                         user_input, agent, desires, on_action, on_text, debug, input_queue
                     )
@@ -160,7 +163,7 @@ async def repl(agent: EmbodiedAgent, desires: DesireSystem, debug: bool = False)
                     has_pending_input=not input_queue.empty(),
                     last_interaction=last_interaction_time,
                     now=time.time(),
-                    cooldown=DESIRE_COOLDOWN,
+                    cooldown=get_dynamic_cooldown(last_user_input_time, time.time()),
                 ):
                     continue  # Still in post-conversation cooldown
 
@@ -191,6 +194,7 @@ async def repl(agent: EmbodiedAgent, desires: DesireSystem, debug: bool = False)
                         interrupt_queue=input_queue,
                     )
                     desires.satisfy(desire_name)
+                    last_interaction_time = time.time()  # reset cooldown after desire fire
                     desires.curiosity_target = None
                 elif pending_items:
                     # Had pending input but no desire — process it as user message

--- a/src/familiar_agent/tui.py
+++ b/src/familiar_agent/tui.py
@@ -27,6 +27,7 @@ from ._ui_helpers import (
     desire_tick_prompt,
     format_action as _format_action,
     format_tool_result as _format_tool_result,
+    get_dynamic_cooldown,
     should_fire_idle_desire,
 )
 from .realtime_stt_session import create_realtime_stt_controller, RealtimeSttController
@@ -178,6 +179,7 @@ class FamiliarApp(App):
         self._companion_name = agent.config.companion_name
         self._input_queue: asyncio.Queue[str | None] = asyncio.Queue()
         self._last_interaction = time.time()
+        self._last_user_input_time: float = time.time()
         self._agent_running = False
         self._current_text_buf = ""  # buffer for streaming text
         self._log_path = self._open_log_file()
@@ -334,6 +336,7 @@ class FamiliarApp(App):
 
         self._log_user(text)
         self._last_interaction = time.time()
+        self._last_user_input_time = time.time()
         await self._input_queue.put(text)
 
     # ── agent loop ─────────────────────────────────────────────────
@@ -520,7 +523,7 @@ class FamiliarApp(App):
             has_pending_input=not self._input_queue.empty(),
             last_interaction=self._last_interaction,
             now=now,
-            cooldown=DESIRE_COOLDOWN,
+            cooldown=get_dynamic_cooldown(self._last_user_input_time, now),
         ):
             return
 
@@ -532,7 +535,7 @@ class FamiliarApp(App):
             has_pending_input=not self._input_queue.empty(),
             last_interaction=self._last_interaction,
             now=time.time(),
-            cooldown=DESIRE_COOLDOWN,
+            cooldown=get_dynamic_cooldown(self._last_user_input_time, time.time()),
         ):
             return
 
@@ -570,6 +573,7 @@ class FamiliarApp(App):
                         f"[bold cyan]\U0001f3a4 {self._companion_name}[/bold cyan] {text}"
                     )
                     self._last_interaction = time.time()
+                    self._last_user_input_time = time.time()
                     stream = self.query_one("#stream", Static)
                     stream.update("")
                 except Exception:
@@ -642,6 +646,7 @@ class FamiliarApp(App):
             if text.strip():
                 self._log_user(text)
                 self._last_interaction = time.time()
+                self._last_user_input_time = time.time()
                 await self._input_queue.put(text)
         except Exception as e:
             self._log_system(f"STT error: {e}")


### PR DESCRIPTION
## Summary

週1リモートワーカー向けに不在時のAPI呼び出しを95%削減（320回→16回/8時間）。

- 会話中（CONVERSATION_WINDOW=300秒以内の最終入力）: DESIRE_COOLDOWN_CONVO=300秒（5分）
- 非会話（300秒超えた放置状態）: DESIRE_COOLDOWN_IDLE=1800秒（30分）

## 変更内容

### `_ui_helpers.py`
- `CONVERSATION_WINDOW`, `DESIRE_COOLDOWN_CONVO`, `DESIRE_COOLDOWN_IDLE` の3定数を追加（全て環境変数で上書き可能）
- `get_dynamic_cooldown(last_user_input, now)` 関数を追加

### `tui.py`
- `FamiliarApp._last_user_input_time` フィールドを追加（`__init__`）
- ユーザー実入力時のみ更新（`on_input_submitted`, realtime STT committed, PTT録音完了）
- **desire発火後のリセット（line 547）では更新しない** — これが重要。desire発火は会話ではないため
- `_desire_tick()` でのcooldown引数を `get_dynamic_cooldown()` に変更

### `main.py`（REPL）
- `last_user_input_time` 変数を追加
- `if pending:` ブロック内でユーザー入力時に更新
- desire発火後に `last_interaction_time` をリセット（発火間隔制御）
- `should_fire_idle_desire()` のcooldown引数を動的化

## TUI/REPLの動作差異

tui.pyでは `_last_interaction` が desire発火後もリセットされる（line 547）。これはTextual UIのアイドル状態管理のため。`_last_user_input_time` は**ユーザー実入力のみ**で更新するため、この差異が正しく機能する。

## 環境変数での設定

```bash
export CONVERSATION_WINDOW=300    # 会話とみなす最終入力からの秒数（デフォルト: 5分）
export DESIRE_COOLDOWN_CONVO=300  # 会話中のdesire発火間隔（デフォルト: 5分）
export DESIRE_COOLDOWN_IDLE=1800  # 非会話時のdesire発火間隔（デフォルト: 30分）
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)