### PR TITLE
feat(camera): complete zeroconf camera discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 - Lint and test workflows now run for both `develop` and `main`, matching the new default-branch strategy
 - CI now runs the full pytest suite again instead of excluding GUI async stability coverage
+- Camera discovery now browses `_onvif._tcp.local.` via zeroconf, respects RTSP TXT paths when present, and falls back to socket-based local-prefix detection when `ip route` is unavailable
 - GUI settings dialog now keeps JP labels fully visible (including short labels like `名`), refreshed the app to a bright, soft, rounded light theme, split first-turn startup status from "thinking", and increased GUI font sizing for readability.
 - GUI startup now shows the window before heavyweight agent warmup finishes, and surfaces readiness phases such as setup check, agent init, embedding warmup, MCP connect, and realtime STT connect
 - GUI / TUI / REPL setup paths now share the same runtime-oriented env schema, exposing `BASE_URL`, `TOOLS_MODE`, `UTILITY_*`, `SCENE_*`, `REALTIME_STT`, and `FAMILIAR_AUTO_*` consistently

--- a/src/familiar_agent/camera_discovery.py
+++ b/src/familiar_agent/camera_discovery.py
@@ -19,7 +19,7 @@ from urllib.parse import urlparse
 logger = logging.getLogger(__name__)
 
 _CAMERA_PORTS = (554, 80, 2020)
-_MDNS_SERVICE_TYPES = ("_rtsp._tcp.local.", "_http._tcp.local.")
+_MDNS_SERVICE_TYPES = ("_onvif._tcp.local.", "_rtsp._tcp.local.", "_http._tcp.local.")
 _SSDP_MULTICAST_ADDR = ("239.255.255.250", 1900)
 _SSDP_REQUEST = "\r\n".join(
     [
@@ -48,6 +48,55 @@ def _normalize_camera(entry: dict[str, str]) -> dict[str, str]:
         "port": str(entry.get("port", "") or "").strip(),
         "name": str(entry.get("name", "") or "").strip(),
     }
+
+
+def _decode_zeroconf_properties(raw: Any) -> dict[str, str]:
+    properties: dict[str, str] = {}
+    if not isinstance(raw, dict):
+        return properties
+    for key, value in raw.items():
+        key_text = key.decode("utf-8", errors="ignore") if isinstance(key, bytes) else str(key)
+        if isinstance(value, bytes):
+            value_text = value.decode("utf-8", errors="ignore")
+        else:
+            value_text = str(value)
+        properties[key_text] = value_text
+    return properties
+
+
+def _build_mdns_address(
+    host: str, port: int, service_type: str, properties: dict[str, str]
+) -> str:
+    explicit = properties.get("url") or properties.get("uri")
+    if explicit:
+        if "://" in explicit:
+            return explicit
+        path = explicit if explicit.startswith("/") else f"/{explicit}"
+    elif service_type.startswith("_onvif"):
+        path = "/onvif/device_service"
+    elif service_type.startswith("_rtsp"):
+        txt_path = properties.get("path") or properties.get("rtsp_path") or properties.get("stream")
+        path = ""
+        if txt_path:
+            path = txt_path if txt_path.startswith("/") else f"/{txt_path}"
+    else:
+        path = ""
+
+    scheme = "rtsp" if service_type.startswith("_rtsp") or port == 554 else "http"
+    return f"{scheme}://{host}:{port}{path}" if port else f"{scheme}://{host}{path}"
+
+
+def _extract_ip_prefix(ip_address: str) -> str | None:
+    parts = ip_address.strip().split(".")
+    if len(parts) != 4:
+        return None
+    try:
+        octets = [int(part) for part in parts]
+    except ValueError:
+        return None
+    if any(octet < 0 or octet > 255 for octet in octets):
+        return None
+    return ".".join(str(octet) for octet in octets[:3])
 
 
 def _merge_camera_results(candidates: list[dict[str, str]]) -> list[dict[str, str]]:
@@ -184,17 +233,16 @@ async def _discover_mdns_cameras(timeout: float = 3.0) -> list[dict[str, str]]:
                     return
 
                 port = int(getattr(info, "port", 0) or 0)
-                scheme = "rtsp" if service_type.startswith("_rtsp") or port == 554 else "http"
+                properties = _decode_zeroconf_properties(getattr(info, "properties", {}))
                 for host in addresses:
                     found.append(
                         {
                             "host": host,
-                            "address": f"{scheme}://{host}:{port}"
-                            if port
-                            else f"{scheme}://{host}",
+                            "address": _build_mdns_address(host, port, service_type, properties),
                             "source": "mdns",
                             "port": str(port) if port else "",
                             "name": str(getattr(info, "server", "") or name).rstrip("."),
+                            "service_type": service_type,
                         }
                     )
 
@@ -302,9 +350,27 @@ def get_local_network_prefix() -> str | None:
         if match:
             return match.group(1)
 
+        match = re.search(r"\bdefault via\s+(\d+\.\d+\.\d+\.\d+)\b", output)
+        if match:
+            prefix = _extract_ip_prefix(match.group(1))
+            if prefix:
+                return prefix
+
         match = re.search(r"\b(\d+\.\d+\.\d+)\.\d+/\d+\b", output)
         if match:
             return match.group(1)
+
+    try:
+        probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            probe.connect(("8.8.8.8", 80))
+            prefix = _extract_ip_prefix(str(probe.getsockname()[0]))
+            if prefix:
+                return prefix
+        finally:
+            probe.close()
+    except Exception:
+        pass
 
     return None
 

--- a/src/familiar_agent/camera_discovery.py
+++ b/src/familiar_agent/camera_discovery.py
@@ -64,9 +64,7 @@ def _decode_zeroconf_properties(raw: Any) -> dict[str, str]:
     return properties
 
 
-def _build_mdns_address(
-    host: str, port: int, service_type: str, properties: dict[str, str]
-) -> str:
+def _build_mdns_address(host: str, port: int, service_type: str, properties: dict[str, str]) -> str:
     explicit = properties.get("url") or properties.get("uri")
     if explicit:
         if "://" in explicit:

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import sys
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -131,3 +133,116 @@ def test_main_prints_json_results(
     payload = json.loads(capsys.readouterr().out)
     assert rc == 0
     assert payload[0]["host"] == "192.168.1.50"
+
+
+@pytest.mark.asyncio
+async def test_discover_mdns_cameras_includes_onvif_and_rtsp_txt_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import familiar_agent.camera_discovery as mod
+
+    service_infos = {
+        ("_onvif._tcp.local.", "Tapo._onvif._tcp.local."): SimpleNamespace(
+            port=2020,
+            server="tapo-c220.local.",
+            properties={b"model": b"Tapo C220"},
+            parsed_addresses=lambda: ["192.168.1.44"],
+        ),
+        ("_rtsp._tcp.local.", "Tapo._rtsp._tcp.local."): SimpleNamespace(
+            port=554,
+            server="tapo-c220.local.",
+            properties={b"path": b"/stream1"},
+            parsed_addresses=lambda: ["192.168.1.44"],
+        ),
+    }
+    discovered_types: list[str] = []
+
+    class _FakeBrowser:
+        def __init__(self, zc, service_type, listener):
+            discovered_types.append(service_type)
+            if service_type == "_onvif._tcp.local.":
+                listener.add_service(zc, service_type, "Tapo._onvif._tcp.local.")
+            if service_type == "_rtsp._tcp.local.":
+                listener.add_service(zc, service_type, "Tapo._rtsp._tcp.local.")
+
+        def cancel(self) -> None:
+            return
+
+    class _FakeZeroconf:
+        def get_service_info(self, service_type, name, timeout=None):
+            return service_infos[(service_type, name)]
+
+        def close(self) -> None:
+            return
+
+    monkeypatch.setitem(
+        sys.modules,
+        "zeroconf",
+        SimpleNamespace(ServiceBrowser=_FakeBrowser, Zeroconf=_FakeZeroconf),
+    )
+    monkeypatch.setattr(mod.time, "sleep", lambda _timeout: None)
+
+    results = await mod._discover_mdns_cameras(timeout=1.0)
+
+    assert "_onvif._tcp.local." in discovered_types
+    assert "_rtsp._tcp.local." in discovered_types
+    assert {
+        "host": "192.168.1.44",
+        "address": "http://192.168.1.44:2020/onvif/device_service",
+        "source": "mdns",
+        "port": "2020",
+        "name": "tapo-c220.local",
+        "service_type": "_onvif._tcp.local.",
+    } in results
+    assert {
+        "host": "192.168.1.44",
+        "address": "rtsp://192.168.1.44:554/stream1",
+        "source": "mdns",
+        "port": "554",
+        "name": "tapo-c220.local",
+        "service_type": "_rtsp._tcp.local.",
+    } in results
+
+
+def test_get_local_network_prefix_parses_default_gateway_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import familiar_agent.camera_discovery as mod
+
+    monkeypatch.delenv("FAMILIAR_CAMERA_DISCOVERY_PREFIX", raising=False)
+
+    def _fake_check_output(cmd, text=True, stderr=None):
+        if cmd == ["ip", "route", "get", "1.1.1.1"]:
+            raise RuntimeError("route get unavailable")
+        return "default via 172.28.48.1 dev eth0\n"
+
+    monkeypatch.setattr(mod.subprocess, "check_output", _fake_check_output)
+
+    assert mod.get_local_network_prefix() == "172.28.48"
+
+
+def test_get_local_network_prefix_falls_back_to_socket_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import familiar_agent.camera_discovery as mod
+
+    monkeypatch.delenv("FAMILIAR_CAMERA_DISCOVERY_PREFIX", raising=False)
+    monkeypatch.setattr(
+        mod.subprocess,
+        "check_output",
+        lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError("ip not found")),
+    )
+
+    class _FakeSocket:
+        def connect(self, addr) -> None:
+            assert addr == ("8.8.8.8", 80)
+
+        def getsockname(self):
+            return ("10.0.0.42", 54321)
+
+        def close(self) -> None:
+            return
+
+    monkeypatch.setattr(mod.socket, "socket", lambda *args, **kwargs: _FakeSocket())
+
+    assert mod.get_local_network_prefix() == "10.0.0"


### PR DESCRIPTION
## Summary
- complete zeroconf discovery by browsing `_onvif._tcp.local.` in addition to RTSP/HTTP services
- respect zeroconf TXT metadata such as RTSP `path` values and build a stable ONVIF device-service URL
- restore cross-platform local-prefix detection for the optional port-scan fallback when `ip route` is unavailable

## Upstream notes
Compared with `utenadev/unified_nc_discovery`, this keeps the useful zeroconf idea but avoids a few risky edges:
- the upstream manual WS-Discovery probe references `dn:NetworkVideoTransmitter` without defining `xmlns:dn`
- the upstream port-scan fallback launches an unbounded number of connection tasks at once
- the upstream mDNS path uses IPv4-only address decoding (`socket.inet_ntoa`) and drops TXT path metadata

## Testing
- `uv run pytest -q tests/test_camera_discovery.py`
- `uv run ruff check src/familiar_agent/camera_discovery.py tests/test_camera_discovery.py`
- `uv run --group dev mypy src/familiar_agent/camera_discovery.py`
- `uv run pytest -q tests/test_camera_discovery.py tests/test_setup_wizard.py`
- `uv run pytest -q`

Closes #148.