### PR TITLE
[codex] Add generic task-agent runtime substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Lightweight adaptive confidence updates for semantic facts and behavior policies, including revision history for experience-driven value shifts
 - Lightweight layered self continuity with inertial proto-self updates, recent intention-result traces, and persistent active concerns
 - Freshness-aware MCP interoception ingestion, persisted heartbeat carryover state, SQLite-backed relationship storage with legacy JSON import, and sample autonomy config files for drives / schedule / operator wrappers
+- Generic runtime substrate foundations: model/tool protocols, ToolRegistry, runtime event/task stores, a provider-neutral ReAct loop, neighbor profile boundary, and a non-embodied `familiar task ...` entry point
 
 ### Changed
 - Lint and test workflows now run for both `develop` and `main`, matching the new default-branch strategy
@@ -46,6 +47,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Camera settings now support optional `CAMERA_PTZ_*` overrides, with fallback to the existing `CAMERA_*` values and RTSP URL credentials when stream and PTZ endpoints differ
 - Agent replies no longer wait on post-response memory/self-model updates, and TAPE planning is skipped when no separate utility backend is configured
 - System prompts now surface at most one active concern and one recent misaligned intention trace, while post-response updates carry those states forward without adding hot-path LLM calls
+- Embodied tool routing now goes through the generic ToolRegistry while preserving existing camera, voice, memory, coding, and MCP behavior
 
 ### Fixed
 - `scripts/new_migration.sh` now accepts Windows-style `--dir` paths in Git Bash so cross-platform CI migration tests pass on `windows-latest`

--- a/docs/adr/0001-runtime-core-extraction.md
+++ b/docs/adr/0001-runtime-core-extraction.md
@@ -29,7 +29,9 @@ interfaces. `familiar_neighbor` will register companion prompts, hooks, and embo
 top of that runtime. `familiar_agent` will keep existing imports and entry points working during the
 migration.
 
-The first PR will add documentation and characterization tests only.
+The first PR will add documentation, characterization tests, the initial generic runtime package,
+ToolRegistry-backed routing, durable event/task stores, and a minimal task-mode CLI. Larger neighbor
+cognition moves will remain behind compatibility boundaries.
 
 ## Consequences
 

--- a/docs/adr/0001-runtime-core-extraction.md
+++ b/docs/adr/0001-runtime-core-extraction.md
@@ -1,0 +1,48 @@
+# ADR 0001: Extract a Generic Runtime Core Incrementally
+
+## Status
+
+Accepted
+
+## Context
+
+familiar-ai began as an embodied companion application. Its main loop now also contains the pieces
+needed for a general task agent: model backends, tool calls, coding tools, MCP integration,
+timeouts, interrupts, memory, and post-turn jobs.
+
+The same loop also coordinates neighbor-specific cognition: relationship state, appraisal, social
+policy, desires, workspace competition, prediction, self-state, and embodied behavior. This makes it
+hard to run familiar-ai as a durable task executor without loading companion assumptions.
+
+## Decision
+
+Extract a generic runtime core in small behavior-preserving PRs.
+
+The dependency direction will be:
+
+```text
+familiar_runtime  <-  familiar_neighbor  <-  familiar_agent compatibility layer
+```
+
+`familiar_runtime` will define generic model, tool, context, event, task, checkpoint, and hook
+interfaces. `familiar_neighbor` will register companion prompts, hooks, and embodied capabilities on
+top of that runtime. `familiar_agent` will keep existing imports and entry points working during the
+migration.
+
+The first PR will add documentation and characterization tests only.
+
+## Consequences
+
+- Runtime extraction can proceed behind tests without changing the companion UX.
+- Neighbor cognition remains a specialization, not a set of hidden dependencies inside generic task
+  APIs.
+- Compatibility shims are required until callers and tests move to the new packages.
+- Some duplication may temporarily exist while modules are wrapped or re-exported.
+
+## Non-Goals
+
+- No large package rename in one PR.
+- No prompt rewrite as part of runtime extraction.
+- No memory schema change without migration.
+- No new permission model for `bash`; preserve the current opt-in behavior until sandbox policy is
+  isolated.

--- a/docs/adr/0002-python-first-sidecar-later.md
+++ b/docs/adr/0002-python-first-sidecar-later.md
@@ -1,0 +1,41 @@
+# ADR 0002: Keep Python First, Add a Sidecar Only After Measurement
+
+## Status
+
+Accepted
+
+## Context
+
+The runtime reorganization could tempt a rewrite of process, filesystem, search, or scheduling
+pieces into another language. familiar-ai currently benefits from Python's LLM SDK support, async
+orchestration, ML/embedding ecosystem, hardware libraries, GUI/TUI integration, and existing test
+coverage.
+
+Current likely bottlenecks are not known to be Python CPU execution. More likely sources are model
+latency, utility-model round trips, embedding startup/encoding, SQLite/vector scans, repository
+search, subprocess cancellation, audio/event streams, and cross-platform process behavior.
+
+## Decision
+
+Keep the runtime Python-first.
+
+Introduce a Rust or Go sidecar only when benchmarks show a concrete bottleneck or safety problem
+that Python wrappers cannot handle well enough. If a sidecar becomes justified, prefer a narrow
+supervisor process for file search, process execution, cancellation, git inspection, and workspace
+snapshots.
+
+## Consequences
+
+- Existing packaging and hardware support remain simple.
+- Runtime extraction can focus on architecture rather than language migration.
+- Future sidecar work must start from benchmarks and preserve Python fallbacks.
+- Normal Python package installation must not require a Rust build.
+
+## Decision Gate For A Sidecar
+
+Start a sidecar spike only if one of these is demonstrated:
+
+- `grep`, `glob`, `bash`, or test execution becomes a top latency contributor.
+- Process cancellation or streaming output is unreliable in real task runs.
+- Always-on event/audio processing drops events.
+- Stronger sandbox guarantees are needed than Python subprocess wrappers can provide.

--- a/docs/task-agent-runtime.md
+++ b/docs/task-agent-runtime.md
@@ -1,0 +1,87 @@
+# Task Agent Runtime
+
+## Purpose
+
+familiar-ai currently centers on a neighbor-like companion: embodied perception, voice,
+memory, desires, relationship state, and a ReAct loop live together in
+`familiar_agent.EmbodiedAgent`. The next architecture should keep that experience intact while
+making the generic task machinery a first-class substrate.
+
+The intended direction is:
+
+```text
+familiar_runtime        # generic model/tool/task/event runtime
+  ^
+  |
+familiar_neighbor       # companion profile, cognition hooks, embodied capabilities
+  ^
+  |
+familiar_agent          # compatibility CLI/package while migration is in progress
+```
+
+`familiar_runtime` must not import neighbor-specific modules. Neighbor behavior should plug into
+runtime hooks and profiles.
+
+## Current Baseline
+
+The repository already has the ingredients of a task agent:
+
+- Backend adapters in `familiar_agent.backend` with provider-specific message handling.
+- A ReAct loop in `familiar_agent.agent` with streaming, tool calls, timeouts, interrupts, token
+  accounting, and post-turn background work.
+- Reusable coding tools in `familiar_agent.tools.coding`, with `bash` hidden unless
+  `CODING_BASH=true`.
+- MCP tool discovery and routing in `familiar_agent.mcp_client`.
+- SQLite memory, event logging, and a memory worker.
+- Neighbor cognition layers such as desires, relationship tracking, self-state, prediction,
+  workspace competition, social policy, and default mode.
+
+The coupling problem is that generic loop concerns and neighbor cognition are both orchestrated by
+`EmbodiedAgent.run()`. The migration should extract the generic pieces without changing the
+existing user-facing companion behavior.
+
+## Target Runtime Shape
+
+The generic runtime should eventually own:
+
+- Model backend protocol and provider adapters.
+- Tool provider protocol, tool registry, timeout policy, and sandbox policy.
+- ReAct execution loop with structured turn results.
+- Event emission, replay, and optional persistence.
+- Durable task records, checkpoints, interrupts, and resume behavior.
+- Context block selection and prompt/profile assembly.
+- Background job management and lightweight observability.
+
+Neighbor mode should eventually provide:
+
+- Prompt/profile blocks for embodied and social behavior.
+- Hooks for memory recall, relationship state, appraisal, desires, workspace competition,
+  self-state, prediction, and post-turn adaptation.
+- Camera, voice, mobility, and neighbor-specific memory projection as optional capabilities.
+
+Task mode should eventually provide:
+
+- Coding, filesystem, shell, MCP, and test-running capabilities.
+- Task prompts, checkpoint hooks, patch/test interpretation, and task telemetry.
+- No hardware dependency by default.
+
+## Migration Principles
+
+- Keep `familiar` CLI, TUI, GUI, `.env`, `ME.md`, memory DBs, and existing tests compatible.
+- Extract protocols and registries before moving large modules.
+- Keep compatibility imports in `familiar_agent` while new packages appear.
+- Do not enable `bash` by default.
+- Do not rewrite prompts while extracting runtime code.
+- Do not move cognitive modules into the generic runtime.
+- Keep Python as the main implementation until measurements justify a sidecar.
+
+## First PR Boundary
+
+The first PR is intentionally characterization-only:
+
+- Add architecture docs and ADRs.
+- Add tests that pin current ReAct and coding-tool behavior.
+- Do not move source modules.
+- Do not add new runtime packages yet.
+
+This gives later extraction PRs a stable behavioral fence.

--- a/docs/task-agent-runtime.md
+++ b/docs/task-agent-runtime.md
@@ -75,13 +75,17 @@ Task mode should eventually provide:
 - Do not move cognitive modules into the generic runtime.
 - Keep Python as the main implementation until measurements justify a sidecar.
 
-## First PR Boundary
+## Current PR Boundary
 
-The first PR is intentionally characterization-only:
+This PR keeps the extraction conservative but makes the first runtime layer real:
 
 - Add architecture docs and ADRs.
 - Add tests that pin current ReAct and coding-tool behavior.
-- Do not move source modules.
-- Do not add new runtime packages yet.
+- Add `familiar_runtime` protocols, ToolRegistry, event/task stores, context blocks, job manager,
+  and a provider-neutral ReAct loop.
+- Add `familiar_capabilities` adapters for coding and MCP.
+- Route existing `EmbodiedAgent` tool calls through ToolRegistry while preserving public behavior.
+- Add `familiar task ...` as the first non-embodied task-mode entry point.
 
-This gives later extraction PRs a stable behavioral fence.
+Large neighbor cognition module moves remain out of scope for this PR; compatibility and behavior
+preservation are the guardrails.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,12 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/familiar_agent"]
+packages = [
+    "src/familiar_agent",
+    "src/familiar_runtime",
+    "src/familiar_capabilities",
+    "src/familiar_neighbor",
+]
 
 [tool.uv]
 default-groups = ["dev", "gui", "camera", "voice"]

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -55,6 +55,8 @@ from .tools.stt import STTTool
 from .tools.tts import TTSTool
 from ._i18n import _t
 from .mcp_client import MCPClientManager, _resolve_config_path
+from familiar_runtime.tools.legacy import LegacyToolProvider
+from familiar_runtime.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -101,9 +103,15 @@ _TOOL_TIMEOUTS: dict[str, float] = {
     "recall": 20.0,
     "tom": 20.0,
     "read_file": 30.0,
+    "write_file": 30.0,
     "edit_file": 30.0,
+    "multi_edit_file": 30.0,
     "glob": 20.0,
     "grep": 20.0,
+    "git_status": 20.0,
+    "git_diff": 30.0,
+    "git_apply_patch": 30.0,
+    "run_tests": 120.0,
     "bash": 45.0,
 }
 _BRIEF_REPLY_MAX_ITERATIONS = 2
@@ -315,12 +323,24 @@ SYSTEM_PROMPT = """
     (tools
       (tool :id read_file :sig "read_file(path, offset?, limit?)"
         :note "Always call before edit_file. Returns file with line numbers.")
+      (tool :id write_file :sig "write_file(path, content)"
+        :note "Write a complete file. Prefer edit_file for small changes.")
       (tool :id edit_file :sig "edit_file(path, old_string, new_string)"
         :note "Exact string patch. old_string must be unique in file.")
+      (tool :id multi_edit_file :sig "multi_edit_file(path, edits[])"
+        :note "Atomic multiple exact string replacements in one file.")
       (tool :id glob      :sig "glob(pattern, path?)"
         :note "Find files by glob pattern e.g. **/*.py")
       (tool :id grep      :sig "grep(pattern, path?, glob?, output_mode?)"
         :note "Search file contents by regex.")
+      (tool :id git_status :sig "git_status()"
+        :note "Show concise working tree state.")
+      (tool :id git_diff :sig "git_diff(path?)"
+        :note "Show working tree diff.")
+      (tool :id git_apply_patch :sig "git_apply_patch(patch)"
+        :note "Apply a unified diff patch.")
+      (tool :id run_tests :sig "run_tests(command?, timeout?)"
+        :note "Run tests. Only available when CODING_BASH=true.")
       (tool :id bash      :sig "bash(command, timeout?)"
         :note "Shell command. Only available when CODING_BASH=true."))
 
@@ -1017,54 +1037,104 @@ class EmbodiedAgent:
 
     @property
     def _all_tool_defs(self) -> list[dict]:
-        defs = []
-        if self._camera:
-            defs.extend(self._camera.get_tool_definitions())
-        if self._mobility:
-            defs.extend(self._mobility.get_tool_definitions())
-        if self._tts:
-            defs.extend(self._tts.get_tool_definitions())
-        defs.extend(self._memory_tool.get_tool_definitions())
-        defs.extend(self._tom_tool.get_tool_definitions())
-        defs.extend(self._coding.get_tool_definitions())
-        if self._mcp:
-            defs.extend(self._mcp.get_tool_definitions())
-        return defs
+        return self._build_tool_registry().tool_defs()
 
-    async def _execute_tool(self, name: str, tool_input: dict) -> tuple[str, str | None]:
-        """Route tool call to the right handler. Returns (text, image_b64_or_None)."""
-        camera_tools = {"see", "look"}
-        mobility_tools = {"walk"}
-        tts_tools = {"say"}
-        memory_tools = {"remember", "recall"}
-        coding_tools = {"read_file", "edit_file", "glob", "grep", "bash"}
+    def _build_tool_registry(self) -> ToolRegistry:
+        """Build the per-turn tool registry from configured providers."""
+        registry = ToolRegistry()
 
-        if name in camera_tools and self._camera:
-            result = await self._camera.call(name, tool_input)
+        def _record_embodied_action(name: str, tool_input: dict[str, Any]) -> None:
             if name == "look":
                 self._exploration.record_move(
                     tool_input.get("direction", "center"),
                     tool_input.get("degrees", 30),
                 )
-            return result
-        elif name in mobility_tools and self._mobility:
-            return await self._mobility.call(name, tool_input)
-        elif name in tts_tools and self._tts:
-            return await self._tts.call(name, tool_input)
-        elif name in memory_tools:
-            return await self._memory_tool.call(name, tool_input)
-        elif name == "tom":
-            return await self._tom_tool.call(name, tool_input)
-        elif name in coding_tools:
-            return await self._coding.call(name, tool_input)
-        elif self._mcp:
-            # Wait for background MCP init if still running
+
+        if self._camera:
+            registry.register(
+                LegacyToolProvider(
+                    self._camera,
+                    names={"see", "look"},
+                    category="embodiment",
+                    tags={"neighbor"},
+                    before_call=_record_embodied_action,
+                )
+            )
+        if self._mobility:
+            registry.register(
+                LegacyToolProvider(
+                    self._mobility,
+                    names={"walk"},
+                    category="embodiment",
+                    tags={"neighbor"},
+                )
+            )
+        if self._tts:
+            registry.register(
+                LegacyToolProvider(
+                    self._tts,
+                    names={"say"},
+                    category="voice",
+                    tags={"neighbor"},
+                )
+            )
+        registry.register(
+            LegacyToolProvider(
+                self._memory_tool,
+                names={"remember", "recall"},
+                category="memory",
+                tags={"neighbor", "task"},
+            )
+        )
+        registry.register(
+            LegacyToolProvider(
+                self._tom_tool,
+                names={"tom"},
+                category="social",
+                tags={"neighbor"},
+            )
+        )
+        registry.register(
+            LegacyToolProvider(
+                self._coding,
+                names={
+                    "read_file",
+                    "write_file",
+                    "edit_file",
+                    "multi_edit_file",
+                    "glob",
+                    "grep",
+                    "git_status",
+                    "git_diff",
+                    "git_apply_patch",
+                    "run_tests",
+                    "bash",
+                },
+                category="coding",
+                tags={"task", "coding"},
+            )
+        )
+        if self._mcp:
+            provider = LegacyToolProvider(
+                self._mcp,
+                category="mcp",
+                tags={"neighbor", "task"},
+            )
+            registry.register(provider)
+            registry.register_fallback(provider)
+        return registry
+
+    async def _execute_tool(self, name: str, tool_input: dict) -> tuple[str, str | None]:
+        """Route tool call to the right handler. Returns (text, image_b64_or_None)."""
+        registry = self._build_tool_registry()
+        if self._mcp and not registry.has_tool(name):
             mcp_task = getattr(self, "_mcp_start_task", None)
             if mcp_task and not mcp_task.done():
                 await mcp_task
-            return await self._mcp.call(name, tool_input)
-        else:
-            return f"Tool '{name}' not available (check configuration).", None
+                registry = self._build_tool_registry()
+
+        result = await registry.call(name, tool_input)
+        return result.text, result.image_b64
 
     @staticmethod
     def _tool_timeout_seconds(name: str) -> float:

--- a/src/familiar_agent/main.py
+++ b/src/familiar_agent/main.py
@@ -351,7 +351,7 @@ async def _run_task_command(args: list[str]) -> None:
     from familiar_runtime.events import AgentEvent, EventBus
     from familiar_runtime.models import ModelBackend
     from familiar_runtime.runtime import AgentRuntime
-    from familiar_runtime.tasks import SQLiteTaskStore, TaskStatus
+    from familiar_runtime.tasks import SQLiteTaskStore, TaskStatus, TaskToolProvider
     from familiar_runtime.tools.registry import ToolRegistry
 
     from .backend import create_backend
@@ -398,6 +398,7 @@ async def _run_task_command(args: list[str]) -> None:
         )
 
     event_bus.subscribe(_checkpoint_runtime_event)
+    registry.register(TaskToolProvider(task_store))
 
     system_prompt = (
         "You are familiar task mode: a non-embodied task execution agent. "

--- a/src/familiar_agent/main.py
+++ b/src/familiar_agent/main.py
@@ -9,6 +9,7 @@ import signal
 import sys
 import time
 from pathlib import Path
+from typing import cast
 
 from .agent import EmbodiedAgent
 from .bootstrap import load_app_bootstrap
@@ -342,6 +343,110 @@ def _mcp_command(args: list[str]) -> None:
             print(f"  {name:<22} {cmd} {a}{env_hint}")
 
 
+async def _run_task_command(args: list[str]) -> None:
+    """Run non-embodied task mode on the generic runtime."""
+    import argparse
+
+    from familiar_capabilities import CodingCapability, MCPCapability
+    from familiar_runtime.events import AgentEvent, EventBus
+    from familiar_runtime.models import ModelBackend
+    from familiar_runtime.runtime import AgentRuntime
+    from familiar_runtime.tasks import SQLiteTaskStore, TaskStatus
+    from familiar_runtime.tools.registry import ToolRegistry
+
+    from .backend import create_backend
+    from .mcp_client import MCPClientManager, _resolve_config_path
+
+    parser = argparse.ArgumentParser(prog="familiar task", add_help=True)
+    parser.add_argument("goal", nargs="+", help="Task goal to execute")
+    parsed = parser.parse_args(args)
+    goal = " ".join(parsed.goal).strip()
+
+    config = AgentConfig()
+    backend = cast(ModelBackend, create_backend(config))
+    registry = ToolRegistry()
+    registry.register(CodingCapability(config.coding))
+
+    mcp: MCPClientManager | None = None
+    cfg_path = _resolve_config_path()
+    if cfg_path.exists():
+        mcp = MCPClientManager(cfg_path)
+        await mcp.start()
+        mcp_provider = MCPCapability(mcp)
+        registry.register(mcp_provider)
+        registry.register_fallback(mcp_provider)
+
+    task_dir = Path.home() / ".familiar_ai"
+    task_dir.mkdir(parents=True, exist_ok=True)
+    task_store = SQLiteTaskStore(task_dir / "runtime_tasks.db")
+    event_bus = EventBus(log_dir=task_dir / "runtime_events")
+    task = task_store.create_task(
+        title=goal[:80] or "Task",
+        description=goal,
+        goal=goal,
+        acceptance_criteria=["Provide a final summary with actions taken and evidence."],
+    )
+    task_store.update_status(task.id, TaskStatus.RUNNING)
+
+    def _checkpoint_runtime_event(event: AgentEvent) -> None:
+        if event.type not in {"model_result", "tool_result", "tool_timeout", "tool_error"}:
+            return
+        task_store.checkpoint_task(
+            task.id,
+            summary=f"{event.source}:{event.type}",
+            state={"event_id": event.id, "payload": event.payload},
+        )
+
+    event_bus.subscribe(_checkpoint_runtime_event)
+
+    system_prompt = (
+        "You are familiar task mode: a non-embodied task execution agent. "
+        "Use coding and MCP tools when useful. Do not assume camera, voice, mobility, "
+        "or neighbor-only state exists. Keep bash opt-in behavior unchanged: if bash is "
+        "not listed as a tool, do not claim you can run shell commands. Finish with a "
+        "concise summary of actions taken, files changed, and checks run."
+    )
+
+    try:
+        runtime = AgentRuntime(
+            backend=backend,
+            tools=registry,
+            event_bus=event_bus,
+        )
+        result = await runtime.run_turn(
+            goal,
+            profile="task",
+            task_id=task.id,
+            system_prompt=system_prompt,
+            max_tokens=config.max_tokens,
+        )
+        task_store.checkpoint_task(
+            task.id,
+            summary="Task mode turn completed.",
+            state={
+                "final_text": result.final_text,
+                "tool_calls": [tool_call.name for tool_call in result.tool_calls],
+                "input_tokens": result.input_tokens,
+                "output_tokens": result.output_tokens,
+            },
+        )
+        task_store.update_status(task.id, TaskStatus.SUCCEEDED, evidence=result.final_text[:500])
+        print(result.final_text)
+        print(f"\n[task:{task.id}] succeeded")
+    except Exception as exc:
+        task_store.update_status(task.id, TaskStatus.FAILED, error=str(exc))
+        raise
+    finally:
+        event_bus.close()
+        task_store.close()
+        if mcp is not None:
+            await mcp.stop()
+
+
+def _task_command(args: list[str]) -> None:
+    asyncio.run(_run_task_command(args))
+
+
 def _run_repl(agent: EmbodiedAgent, desires: DesireSystem, debug: bool) -> None:
     """Run the REPL with cross-platform Ctrl+C support.
 
@@ -395,6 +500,10 @@ def main() -> None:
 
     if len(sys.argv) > 1 and sys.argv[1] == "mcp":
         _mcp_command(sys.argv[2:])
+        return
+
+    if len(sys.argv) > 1 and sys.argv[1] == "task":
+        _task_command(sys.argv[2:])
         return
 
     use_gui = "--gui" in sys.argv

--- a/src/familiar_agent/tools/coding.py
+++ b/src/familiar_agent/tools/coding.py
@@ -1,4 +1,4 @@
-"""Coding tools — Read/Edit/Glob/Grep/Bash for agent-driven development.
+"""Coding tools — Read/Edit/Glob/Grep/Git/Bash for agent-driven development.
 
 These tools give the agent CC-style file manipulation capabilities so it can
 read and modify code, search the codebase, and run shell commands.
@@ -71,6 +71,21 @@ class CodingTool:
                 },
             },
             {
+                "name": "write_file",
+                "description": (
+                    "Write a complete file. Creates parent directories when needed. "
+                    "Prefer edit_file for small changes to existing files."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string", "description": "File path to write"},
+                        "content": {"type": "string", "description": "Complete file content"},
+                    },
+                    "required": ["path", "content"],
+                },
+            },
+            {
                 "name": "edit_file",
                 "description": (
                     "Edit a file by replacing old_string with new_string. "
@@ -94,6 +109,32 @@ class CodingTool:
                         },
                     },
                     "required": ["path", "old_string", "new_string"],
+                },
+            },
+            {
+                "name": "multi_edit_file",
+                "description": (
+                    "Apply multiple exact string replacements to one file atomically. "
+                    "Each old_string must appear exactly once after previous edits."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string", "description": "File path to edit"},
+                        "edits": {
+                            "type": "array",
+                            "description": "List of replacements",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "old_string": {"type": "string"},
+                                    "new_string": {"type": "string"},
+                                },
+                                "required": ["old_string", "new_string"],
+                            },
+                        },
+                    },
+                    "required": ["path", "edits"],
                 },
             },
             {
@@ -151,6 +192,34 @@ class CodingTool:
                     "required": ["pattern"],
                 },
             },
+            {
+                "name": "git_status",
+                "description": "Return concise git status for the working tree.",
+                "input_schema": {"type": "object", "properties": {}},
+            },
+            {
+                "name": "git_diff",
+                "description": "Return git diff for the working tree or a specific path.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string", "description": "Optional path to diff"},
+                    },
+                },
+            },
+            {
+                "name": "git_apply_patch",
+                "description": (
+                    "Apply a unified diff patch using git apply. Use only after inspecting context."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "patch": {"type": "string", "description": "Unified diff patch text"},
+                    },
+                    "required": ["patch"],
+                },
+            },
         ]
 
         if self._config.bash_enabled:
@@ -178,6 +247,28 @@ class CodingTool:
                     },
                 }
             )
+            defs.append(
+                {
+                    "name": "run_tests",
+                    "description": (
+                        "Run a test command and return stdout+stderr. "
+                        "Defaults to 'uv run pytest -q'. Requires CODING_BASH=true."
+                    ),
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "command": {
+                                "type": "string",
+                                "description": "Test command (default: uv run pytest -q)",
+                            },
+                            "timeout": {
+                                "type": "integer",
+                                "description": "Timeout in seconds (default: 120)",
+                            },
+                        },
+                    },
+                }
+            )
 
         return defs
 
@@ -187,12 +278,24 @@ class CodingTool:
         try:
             if name == "read_file":
                 return self._read_file(**tool_input), None
+            if name == "write_file":
+                return self._write_file(**tool_input), None
             if name == "edit_file":
                 return self._edit_file(**tool_input), None
+            if name == "multi_edit_file":
+                return self._multi_edit_file(**tool_input), None
             if name == "glob":
                 return self._glob(**tool_input), None
             if name == "grep":
                 return self._grep(**tool_input), None
+            if name == "git_status":
+                return await self._git_status(), None
+            if name == "git_diff":
+                return await self._git_diff(**tool_input), None
+            if name == "git_apply_patch":
+                return await self._git_apply_patch(**tool_input), None
+            if name == "run_tests":
+                return await self._run_tests(**tool_input), None
             if name == "bash":
                 return await self._bash(**tool_input), None
             return f"Unknown coding tool: {name}", None
@@ -233,6 +336,14 @@ class CodingTool:
 
         return result
 
+    def _write_file(self, path: str, content: str) -> str:
+        resolved = self._resolve(path)
+        if resolved.exists() and resolved.is_dir():
+            return f"Path is a directory: {path}"
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        resolved.write_text(content, encoding="utf-8")
+        return f"Wrote {path} ({len(content)} bytes)."
+
     def _edit_file(self, path: str, old_string: str, new_string: str) -> str:
         resolved = self._resolve(path)
         try:
@@ -255,6 +366,32 @@ class CodingTool:
         updated = original.replace(old_string, new_string, 1)
         resolved.write_text(updated, encoding="utf-8")
         return f"Edited {path}: replaced 1 occurrence."
+
+    def _multi_edit_file(self, path: str, edits: list[dict[str, str]]) -> str:
+        resolved = self._resolve(path)
+        try:
+            original = resolved.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return f"File not found: {path}"
+
+        updated = original
+        for idx, edit in enumerate(edits, start=1):
+            old_string = edit.get("old_string", "")
+            new_string = edit.get("new_string", "")
+            if not old_string:
+                return f"multi_edit_file failed: edit {idx} has empty old_string."
+            count = updated.count(old_string)
+            if count == 0:
+                return f"multi_edit_file failed: edit {idx} old_string not found."
+            if count > 1:
+                return (
+                    f"multi_edit_file failed: edit {idx} old_string matches {count} locations. "
+                    "Provide a longer, more unique string."
+                )
+            updated = updated.replace(old_string, new_string, 1)
+
+        resolved.write_text(updated, encoding="utf-8")
+        return f"Edited {path}: applied {len(edits)} replacements."
 
     def _glob(self, pattern: str, path: str = "") -> str:
         root = Path(path) if path else self._workdir()
@@ -316,6 +453,58 @@ class CodingTool:
         if not matched_files:
             return "No matching files found."
         return "\n".join(matched_files)
+
+    async def _run_process(
+        self,
+        args: list[str],
+        *,
+        timeout: int = 30,
+        stdin: str | None = None,
+    ) -> str:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdin=subprocess.PIPE if stdin is not None else None,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                cwd=str(self._workdir()),
+            )
+            try:
+                stdout, _ = await asyncio.wait_for(
+                    proc.communicate(stdin.encode("utf-8") if stdin is not None else None),
+                    timeout=timeout,
+                )
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.communicate()
+                return f"Command timed out after {timeout}s: {' '.join(args)}"
+
+            output = stdout.decode("utf-8", errors="replace") if stdout else ""
+            rc = proc.returncode or 0
+            if rc != 0:
+                return f"Exit {rc}:\n{output}"
+            return output or "(no output)"
+        except FileNotFoundError:
+            return f"Command not found: {args[0]}"
+        except Exception as e:
+            return f"Command error: {e}"
+
+    async def _git_status(self) -> str:
+        return await self._run_process(["git", "status", "--short", "--branch"], timeout=20)
+
+    async def _git_diff(self, path: str = "") -> str:
+        args = ["git", "diff", "--"]
+        if path:
+            args.append(path)
+        return await self._run_process(args, timeout=30)
+
+    async def _git_apply_patch(self, patch: str) -> str:
+        return await self._run_process(["git", "apply", "--whitespace=nowarn", "-"], stdin=patch)
+
+    async def _run_tests(self, command: str = "uv run pytest -q", timeout: int = 120) -> str:
+        if not self._config.bash_enabled:
+            return "run_tests unavailable: set CODING_BASH=true to enable test commands."
+        return await self._bash(command or "uv run pytest -q", timeout=timeout)
 
     async def _bash(self, command: str, timeout: int = 30) -> str:
         cwd = str(self._workdir())

--- a/src/familiar_capabilities/__init__.py
+++ b/src/familiar_capabilities/__init__.py
@@ -1,0 +1,6 @@
+"""Reusable capabilities for familiar runtime profiles."""
+
+from .coding import CodingCapability
+from .mcp import MCPCapability
+
+__all__ = ["CodingCapability", "MCPCapability"]

--- a/src/familiar_capabilities/coding.py
+++ b/src/familiar_capabilities/coding.py
@@ -1,0 +1,31 @@
+"""Coding capability adapter for the generic runtime."""
+
+from __future__ import annotations
+
+from familiar_agent.config import CodingConfig
+from familiar_agent.tools.coding import CodingTool
+from familiar_runtime.tools.legacy import LegacyToolProvider
+
+
+class CodingCapability(LegacyToolProvider):
+    """Expose existing familiar-agent coding tools through ToolProvider."""
+
+    def __init__(self, config: CodingConfig) -> None:
+        super().__init__(
+            CodingTool(config),
+            names={
+                "read_file",
+                "write_file",
+                "edit_file",
+                "multi_edit_file",
+                "glob",
+                "grep",
+                "git_status",
+                "git_diff",
+                "git_apply_patch",
+                "run_tests",
+                "bash",
+            },
+            category="coding",
+            tags={"task", "coding"},
+        )

--- a/src/familiar_capabilities/mcp.py
+++ b/src/familiar_capabilities/mcp.py
@@ -1,0 +1,13 @@
+"""MCP capability adapter for the generic runtime."""
+
+from __future__ import annotations
+
+from familiar_agent.mcp_client import MCPClientManager
+from familiar_runtime.tools.legacy import LegacyToolProvider
+
+
+class MCPCapability(LegacyToolProvider):
+    """Expose MCPClientManager tools through ToolProvider."""
+
+    def __init__(self, manager: MCPClientManager) -> None:
+        super().__init__(manager, category="mcp", tags={"task", "neighbor"})

--- a/src/familiar_neighbor/__init__.py
+++ b/src/familiar_neighbor/__init__.py
@@ -1,0 +1,5 @@
+"""Neighbor profile layer built on top of the generic familiar runtime."""
+
+from .app import NeighborProfile
+
+__all__ = ["NeighborProfile"]

--- a/src/familiar_neighbor/app.py
+++ b/src/familiar_neighbor/app.py
@@ -1,0 +1,19 @@
+"""Neighbor profile descriptors.
+
+The existing `familiar_agent.EmbodiedAgent` remains the compatibility entry point in this PR.
+This module gives the new runtime architecture an explicit neighbor profile boundary without
+moving cognition modules prematurely.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True)
+class NeighborProfile:
+    """Configuration for the embodied companion specialization."""
+
+    name: str = "neighbor"
+    tool_tags: set[str] = field(default_factory=lambda: {"neighbor"})
+    context_budget_chars: int = 6000

--- a/src/familiar_neighbor/mind/__init__.py
+++ b/src/familiar_neighbor/mind/__init__.py
@@ -1,0 +1,31 @@
+"""Compatibility re-exports for neighbor cognition modules.
+
+The physical move of cognition modules is intentionally deferred; this package marks the intended
+dependency direction while `familiar_agent.*` imports remain stable.
+"""
+
+from familiar_agent.attention_schema import AttentionSchema
+from familiar_agent.concern_engine import ConcernEngine
+from familiar_agent.default_mode import DefaultModeProcessor
+from familiar_agent.desires import DesireSystem
+from familiar_agent.meta_monitor import MetaMonitor
+from familiar_agent.prediction import PredictionEngine
+from familiar_agent.relationship import RelationshipTracker
+from familiar_agent.scene import SceneTracker
+from familiar_agent.self_narrative import SelfNarrative
+from familiar_agent.self_state import SelfState
+from familiar_agent.workspace import GlobalWorkspace
+
+__all__ = [
+    "AttentionSchema",
+    "ConcernEngine",
+    "DefaultModeProcessor",
+    "DesireSystem",
+    "GlobalWorkspace",
+    "MetaMonitor",
+    "PredictionEngine",
+    "RelationshipTracker",
+    "SceneTracker",
+    "SelfNarrative",
+    "SelfState",
+]

--- a/src/familiar_neighbor/prompts.py
+++ b/src/familiar_neighbor/prompts.py
@@ -1,0 +1,3 @@
+"""Prompt profile names for neighbor mode."""
+
+NEIGHBOR_PROFILE = "neighbor"

--- a/src/familiar_runtime/__init__.py
+++ b/src/familiar_runtime/__init__.py
@@ -1,0 +1,7 @@
+"""Generic runtime substrate for familiar-ai profiles."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/familiar_runtime/context.py
+++ b/src/familiar_runtime/context.py
@@ -1,0 +1,39 @@
+"""Context block primitives for runtime prompt assembly."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class ContextBlock:
+    """A budgetable block of context produced by runtime hooks."""
+
+    source: str
+    text: str
+    priority: float
+    stable: bool = False
+    max_chars: int | None = None
+
+    def rendered_text(self) -> str:
+        """Return text clipped to the block-local budget."""
+        if self.max_chars is None or len(self.text) <= self.max_chars:
+            return self.text
+        return self.text[: self.max_chars].rstrip()
+
+
+def select_context_blocks(blocks: list[ContextBlock], *, max_chars: int) -> list[ContextBlock]:
+    """Select context blocks by priority while preserving selected order."""
+    ordered = sorted(enumerate(blocks), key=lambda item: item[1].priority, reverse=True)
+    selected_indices: set[int] = set()
+    used = 0
+    for index, block in ordered:
+        text = block.rendered_text()
+        if not text:
+            continue
+        cost = len(text)
+        if used + cost > max_chars and not block.stable:
+            continue
+        selected_indices.add(index)
+        used += cost
+    return [block for index, block in enumerate(blocks) if index in selected_indices]

--- a/src/familiar_runtime/events/__init__.py
+++ b/src/familiar_runtime/events/__init__.py
@@ -1,0 +1,7 @@
+"""Runtime event model and bus."""
+
+from .bus import EventBus
+from .model import AgentEvent
+from .store import SQLiteEventStore
+
+__all__ = ["AgentEvent", "EventBus", "SQLiteEventStore"]

--- a/src/familiar_runtime/events/bus.py
+++ b/src/familiar_runtime/events/bus.py
@@ -1,0 +1,110 @@
+"""Event bus with JSONL logging, subscriptions, and replay."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from .model import AgentEvent
+
+logger = logging.getLogger(__name__)
+EventHandler = Callable[[AgentEvent], None]
+
+
+class EventBus:
+    """Publish-subscribe bus for runtime events."""
+
+    def __init__(self, log_dir: str | Path | None = None) -> None:
+        self._subscribers: list[EventHandler] = []
+        self._lock = threading.Lock()
+        self._log_file = None
+        self._log_path: Path | None = None
+        if log_dir:
+            log_path = Path(log_dir)
+            log_path.mkdir(parents=True, exist_ok=True)
+            self._log_path = log_path / f"events_{int(time.time())}.jsonl"
+            self._log_file = open(self._log_path, "a", encoding="utf-8")
+
+    @property
+    def log_path(self) -> Path | None:
+        return self._log_path
+
+    def subscribe(self, handler: EventHandler) -> None:
+        with self._lock:
+            self._subscribers.append(handler)
+
+    def unsubscribe(self, handler: EventHandler) -> None:
+        with self._lock:
+            self._subscribers = [item for item in self._subscribers if item is not handler]
+
+    def emit(self, event: AgentEvent) -> AgentEvent:
+        if self._log_file is not None:
+            try:
+                self._log_file.write(json.dumps(event.to_dict(), ensure_ascii=False) + "\n")
+                self._log_file.flush()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed to write event: %s", exc)
+
+        with self._lock:
+            subscribers = list(self._subscribers)
+        for handler in subscribers:
+            try:
+                handler(event)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Event handler failed: %s", exc)
+        return event
+
+    def emit_simple(
+        self,
+        *,
+        source: str,
+        type: str,
+        payload: dict,
+        run_id: str | None = None,
+        task_id: str | None = None,
+        turn_id: str | None = None,
+    ) -> AgentEvent:
+        return self.emit(
+            AgentEvent(
+                source=source,
+                type=type,
+                payload=payload,
+                run_id=run_id,
+                task_id=task_id,
+                turn_id=turn_id,
+            )
+        )
+
+    def close(self) -> None:
+        if self._log_file is not None:
+            self._log_file.close()
+            self._log_file = None
+
+    @staticmethod
+    def replay(log_path: str | Path) -> list[AgentEvent]:
+        path = Path(log_path)
+        if not path.exists():
+            return []
+        events: list[AgentEvent] = []
+        with open(path, encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    events.append(AgentEvent.from_dict(json.loads(line)))
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Failed to parse event line: %s", exc)
+        return events
+
+    @staticmethod
+    def replay_all(log_dir: str | Path) -> list[AgentEvent]:
+        events: list[AgentEvent] = []
+        for path in sorted(Path(log_dir).glob("events_*.jsonl")):
+            events.extend(EventBus.replay(path))
+        events.sort(key=lambda event: event.timestamp)
+        return events

--- a/src/familiar_runtime/events/model.py
+++ b/src/familiar_runtime/events/model.py
@@ -1,0 +1,32 @@
+"""Generic runtime event model."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class AgentEvent:
+    """Append-only event emitted by the generic runtime."""
+
+    source: str
+    type: str
+    payload: dict[str, Any]
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    run_id: str | None = None
+    task_id: str | None = None
+    turn_id: str | None = None
+    timestamp: float = field(default_factory=time.time)
+    salience: float = 0.5
+    confidence: float = 1.0
+    parent_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AgentEvent:
+        return cls(**data)

--- a/src/familiar_runtime/events/store.py
+++ b/src/familiar_runtime/events/store.py
@@ -1,0 +1,87 @@
+"""SQLite persistence for runtime events."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from .model import AgentEvent
+
+
+class SQLiteEventStore:
+    """Append and replay runtime events from SQLite."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._conn.row_factory = sqlite3.Row
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS runtime_events (
+                id TEXT PRIMARY KEY,
+                run_id TEXT,
+                task_id TEXT,
+                turn_id TEXT,
+                source TEXT NOT NULL,
+                type TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                timestamp REAL NOT NULL,
+                salience REAL NOT NULL,
+                confidence REAL NOT NULL,
+                parent_id TEXT
+            )
+            """
+        )
+        self._conn.commit()
+
+    def append(self, event: AgentEvent) -> None:
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO runtime_events (
+                id, run_id, task_id, turn_id, source, type, payload,
+                timestamp, salience, confidence, parent_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event.id,
+                event.run_id,
+                event.task_id,
+                event.turn_id,
+                event.source,
+                event.type,
+                json.dumps(event.payload, ensure_ascii=False),
+                event.timestamp,
+                event.salience,
+                event.confidence,
+                event.parent_id,
+            ),
+        )
+        self._conn.commit()
+
+    def replay(self) -> list[AgentEvent]:
+        rows = self._conn.execute(
+            "SELECT * FROM runtime_events ORDER BY timestamp, rowid"
+        ).fetchall()
+        return [
+            AgentEvent(
+                id=row["id"],
+                run_id=row["run_id"],
+                task_id=row["task_id"],
+                turn_id=row["turn_id"],
+                source=row["source"],
+                type=row["type"],
+                payload=json.loads(row["payload"]),
+                timestamp=row["timestamp"],
+                salience=row["salience"],
+                confidence=row["confidence"],
+                parent_id=row["parent_id"],
+            )
+            for row in rows
+        ]
+
+    def close(self) -> None:
+        self._conn.close()

--- a/src/familiar_runtime/jobs.py
+++ b/src/familiar_runtime/jobs.py
@@ -1,0 +1,53 @@
+"""Background job management for runtime post-turn work."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Coroutine
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class BackgroundJobManager:
+    """Track fire-and-forget jobs and drain them during shutdown."""
+
+    def __init__(self) -> None:
+        self._tasks: set[asyncio.Task[None]] = set()
+
+    @property
+    def tasks(self) -> set[asyncio.Task[None]]:
+        return self._tasks
+
+    def spawn(self, coro: Coroutine[Any, Any, None], *, name: str) -> None:
+        task = asyncio.create_task(coro, name=name)
+        self._tasks.add(task)
+
+        def _done(done_task: asyncio.Task[None]) -> None:
+            self._tasks.discard(done_task)
+            try:
+                exc = done_task.exception()
+            except asyncio.CancelledError:
+                return
+            if exc is not None:
+                logger.warning("Background task %s failed: %s", name, exc)
+
+        task.add_done_callback(_done)
+
+    async def drain(self, timeout: float) -> None:
+        pending = {task for task in self._tasks if not task.done()}
+        if not pending:
+            return
+        done, still_pending = await asyncio.wait(pending, timeout=timeout)
+        for task in done:
+            try:
+                task.result()
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Background task failed during drain: %s", exc)
+        if still_pending:
+            for task in still_pending:
+                task.cancel()
+            await asyncio.gather(*still_pending, return_exceptions=True)

--- a/src/familiar_runtime/models/__init__.py
+++ b/src/familiar_runtime/models/__init__.py
@@ -1,0 +1,5 @@
+"""Model backend interfaces for the generic runtime."""
+
+from .base import ModelBackend, ModelTurnResult, ToolCall
+
+__all__ = ["ModelBackend", "ModelTurnResult", "ToolCall"]

--- a/src/familiar_runtime/models/base.py
+++ b/src/familiar_runtime/models/base.py
@@ -1,0 +1,63 @@
+"""Provider-neutral model backend protocol."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass(slots=True)
+class ToolCall:
+    """A normalized model tool-call request."""
+
+    id: str
+    name: str
+    input: dict[str, Any]
+
+
+@dataclass(slots=True)
+class ModelTurnResult:
+    """A normalized model turn result."""
+
+    stop_reason: str
+    text: str
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    input_tokens: int = 0
+    output_tokens: int = 0
+    raw: Any = None
+
+
+class ModelBackend(Protocol):
+    """Protocol implemented by provider-specific model adapters."""
+
+    def make_user_message(self, content: str | list[Any]) -> dict[str, Any]:
+        """Serialize a user message for this provider."""
+
+    def make_assistant_message(
+        self,
+        result: ModelTurnResult,
+        raw_content: Any | None = None,
+    ) -> dict[str, Any]:
+        """Serialize an assistant message for this provider."""
+
+    def make_tool_results(
+        self,
+        tool_calls: Sequence[ToolCall],
+        results: Sequence[tuple[str, str | None]],
+    ) -> list[dict[str, Any]]:
+        """Serialize tool results for this provider."""
+
+    async def stream_turn(
+        self,
+        *,
+        system: str | tuple[str, str],
+        messages: list[Any],
+        tools: list[dict[str, Any]],
+        max_tokens: int,
+        on_text: Callable[[str], None] | None,
+    ) -> tuple[ModelTurnResult, Any]:
+        """Run one streaming model turn and return normalized result plus raw content."""
+
+    async def complete(self, prompt: str, max_tokens: int) -> str:
+        """Run a non-streaming utility completion."""

--- a/src/familiar_runtime/react_loop.py
+++ b/src/familiar_runtime/react_loop.py
@@ -1,0 +1,177 @@
+"""Provider-neutral ReAct loop for task-oriented runtimes."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from .events.bus import EventBus
+from .models.base import ModelBackend, ToolCall
+from .tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class RunTurnResult:
+    """Structured result from a generic runtime turn."""
+
+    final_text: str
+    stop_reason: str
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    input_tokens: int = 0
+    output_tokens: int = 0
+    events: list[str] = field(default_factory=list)
+    task_id: str | None = None
+
+
+class ReActLoop:
+    """Generic model/tool loop independent of neighbor cognition."""
+
+    def __init__(
+        self,
+        *,
+        backend: ModelBackend,
+        tools: ToolRegistry,
+        max_iterations: int = 50,
+        default_tool_timeout: float = 20.0,
+        tool_timeouts: dict[str, float] | None = None,
+        event_bus: EventBus | None = None,
+    ) -> None:
+        self._backend = backend
+        self._tools = tools
+        self._max_iterations = max_iterations
+        self._default_tool_timeout = default_tool_timeout
+        self._tool_timeouts = tool_timeouts or {}
+        self._event_bus = event_bus
+
+    async def run(
+        self,
+        *,
+        system: str | tuple[str, str],
+        messages: list[Any],
+        max_tokens: int,
+        on_text: Callable[[str], None] | None = None,
+        run_id: str | None = None,
+        task_id: str | None = None,
+        turn_id: str | None = None,
+    ) -> RunTurnResult:
+        run_id = run_id or f"run_{uuid.uuid4().hex}"
+        turn_id = turn_id or f"turn_{uuid.uuid4().hex}"
+        event_ids: list[str] = []
+        all_tool_calls: list[ToolCall] = []
+        input_tokens = 0
+        output_tokens = 0
+
+        def emit(source: str, type: str, payload: dict[str, Any]) -> None:
+            if self._event_bus is None:
+                return
+            event = self._event_bus.emit_simple(
+                source=source,
+                type=type,
+                payload=payload,
+                run_id=run_id,
+                task_id=task_id,
+                turn_id=turn_id,
+            )
+            event_ids.append(event.id)
+
+        emit("system", "turn_start", {})
+
+        for iteration in range(self._max_iterations):
+            emit("model", "model_request_start", {"iteration": iteration + 1})
+            result, raw_content = await self._backend.stream_turn(
+                system=system,
+                messages=messages,
+                tools=self._tools.tool_defs(),
+                max_tokens=max_tokens,
+                on_text=on_text,
+            )
+            input_tokens += result.input_tokens
+            output_tokens += result.output_tokens
+            emit(
+                "model",
+                "model_result",
+                {
+                    "stop_reason": result.stop_reason,
+                    "tool_calls": [tool_call.name for tool_call in result.tool_calls],
+                },
+            )
+
+            if result.stop_reason == "end_turn":
+                messages.append(self._backend.make_assistant_message(result, raw_content))
+                final_text = result.text or "(no response)"
+                emit("assistant", "message", {"text": final_text})
+                emit("system", "turn_end", {"stop_reason": "end_turn"})
+                return RunTurnResult(
+                    final_text=final_text,
+                    stop_reason="end_turn",
+                    tool_calls=all_tool_calls,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    events=event_ids,
+                    task_id=task_id,
+                )
+
+            if result.stop_reason == "tool_use":
+                collected: list[tuple[str, str | None]] = []
+                for tool_call in result.tool_calls:
+                    all_tool_calls.append(tool_call)
+                    emit(
+                        "tool",
+                        "tool_call",
+                        {"name": tool_call.name, "input": tool_call.input},
+                    )
+                    timeout = self._tool_timeouts.get(tool_call.name, self._default_tool_timeout)
+                    try:
+                        tool_result = await asyncio.wait_for(
+                            self._tools.call(tool_call.name, tool_call.input),
+                            timeout=timeout,
+                        )
+                    except asyncio.TimeoutError:
+                        text = f"Tool timeout: {tool_call.name} exceeded {timeout:.1f}s."
+                        collected.append((text, None))
+                        emit(
+                            "tool",
+                            "tool_timeout",
+                            {"name": tool_call.name, "timeout": timeout},
+                        )
+                        continue
+                    except Exception as exc:  # noqa: BLE001
+                        text = f"Tool error: {exc}"
+                        collected.append((text, None))
+                        emit("tool", "tool_error", {"name": tool_call.name, "error": str(exc)})
+                        continue
+
+                    collected.append((tool_result.text, tool_result.image_b64))
+                    emit(
+                        "tool",
+                        "tool_result",
+                        {
+                            "name": tool_call.name,
+                            "success": tool_result.success,
+                            "error": tool_result.error,
+                        },
+                    )
+
+                messages.append(self._backend.make_assistant_message(result, raw_content))
+                messages.append(self._backend.make_tool_results(result.tool_calls, collected))
+                continue
+
+            logger.warning("Unexpected stop_reason: %s", result.stop_reason)
+            break
+
+        emit("system", "turn_end", {"stop_reason": "max_iterations"})
+        return RunTurnResult(
+            final_text="(max iterations reached)",
+            stop_reason="max_iterations",
+            tool_calls=all_tool_calls,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            events=event_ids,
+            task_id=task_id,
+        )

--- a/src/familiar_runtime/runtime.py
+++ b/src/familiar_runtime/runtime.py
@@ -1,0 +1,95 @@
+"""Minimal generic runtime facade."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from .context import ContextBlock, select_context_blocks
+from .events.bus import EventBus
+from .models.base import ModelBackend
+from .react_loop import ReActLoop, RunTurnResult
+from .tools.registry import ToolRegistry
+
+
+class RuntimeHook(Protocol):
+    """Hook interface used by profiles to participate in a turn."""
+
+    async def before_turn(self, ctx: "TurnContext") -> None: ...
+
+    async def build_context(self, ctx: "TurnContext") -> list[ContextBlock]: ...
+
+    async def after_turn(self, ctx: "TurnContext", final_text: str) -> None: ...
+
+
+@dataclass(slots=True)
+class TurnContext:
+    """Runtime state for one turn."""
+
+    user_input: str
+    profile: str
+    task_id: str | None = None
+    created_at: float = field(default_factory=time.time)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class AgentRuntime:
+    """Thin generic runtime facade around hooks, context selection, and ReAct."""
+
+    def __init__(
+        self,
+        *,
+        backend: ModelBackend,
+        tools: ToolRegistry,
+        hooks: Sequence[RuntimeHook] = (),
+        event_bus: EventBus | None = None,
+        max_context_chars: int = 6000,
+    ) -> None:
+        self._backend = backend
+        self._tools = tools
+        self._hooks = list(hooks)
+        self._event_bus = event_bus
+        self._max_context_chars = max_context_chars
+
+    async def run_turn(
+        self,
+        user_input: str,
+        *,
+        profile: str = "task",
+        task_id: str | None = None,
+        system_prompt: str = "",
+        messages: list[Any] | None = None,
+        max_tokens: int = 4096,
+    ) -> RunTurnResult:
+        ctx = TurnContext(user_input=user_input, profile=profile, task_id=task_id)
+        for hook in self._hooks:
+            await hook.before_turn(ctx)
+
+        blocks: list[ContextBlock] = []
+        for hook in self._hooks:
+            blocks.extend(await hook.build_context(ctx))
+        selected = select_context_blocks(blocks, max_chars=self._max_context_chars)
+        context_text = "\n\n".join(block.rendered_text() for block in selected)
+        system = f"{system_prompt}\n\n{context_text}".strip()
+
+        turn_messages = messages if messages is not None else []
+        turn_messages.append(self._backend.make_user_message(user_input))
+        if self._event_bus is not None:
+            self._event_bus.emit_simple(
+                source="user",
+                type="message",
+                payload={"text": user_input},
+                task_id=task_id,
+            )
+        loop = ReActLoop(backend=self._backend, tools=self._tools, event_bus=self._event_bus)
+        result = await loop.run(
+            system=system,
+            messages=turn_messages,
+            max_tokens=max_tokens,
+            task_id=task_id,
+        )
+        for hook in self._hooks:
+            await hook.after_turn(ctx, result.final_text)
+        return result

--- a/src/familiar_runtime/tasks/__init__.py
+++ b/src/familiar_runtime/tasks/__init__.py
@@ -2,5 +2,6 @@
 
 from .model import Task, TaskCheckpoint, TaskStatus
 from .store import SQLiteTaskStore
+from .tools import TaskToolProvider
 
-__all__ = ["SQLiteTaskStore", "Task", "TaskCheckpoint", "TaskStatus"]
+__all__ = ["SQLiteTaskStore", "Task", "TaskCheckpoint", "TaskStatus", "TaskToolProvider"]

--- a/src/familiar_runtime/tasks/__init__.py
+++ b/src/familiar_runtime/tasks/__init__.py
@@ -1,0 +1,6 @@
+"""Durable task model and stores."""
+
+from .model import Task, TaskCheckpoint, TaskStatus
+from .store import SQLiteTaskStore
+
+__all__ = ["SQLiteTaskStore", "Task", "TaskCheckpoint", "TaskStatus"]

--- a/src/familiar_runtime/tasks/model.py
+++ b/src/familiar_runtime/tasks/model.py
@@ -1,0 +1,40 @@
+"""Generic task model for task-mode agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class TaskStatus(str, Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    BLOCKED = "blocked"
+    WAITING_FOR_USER = "waiting_for_user"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass(slots=True)
+class Task:
+    id: str
+    title: str
+    description: str
+    status: TaskStatus = TaskStatus.QUEUED
+    goal: str = ""
+    constraints: list[str] = field(default_factory=list)
+    acceptance_criteria: list[str] = field(default_factory=list)
+    created_at: float = 0.0
+    updated_at: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class TaskCheckpoint:
+    id: str
+    task_id: str
+    summary: str
+    state: dict[str, Any]
+    created_at: float

--- a/src/familiar_runtime/tasks/store.py
+++ b/src/familiar_runtime/tasks/store.py
@@ -1,0 +1,182 @@
+"""SQLite-backed durable task store."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from .model import Task, TaskCheckpoint, TaskStatus
+
+
+class SQLiteTaskStore:
+    """Persist tasks and checkpoints in SQLite."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._conn.row_factory = sqlite3.Row
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS runtime_tasks (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                description TEXT NOT NULL,
+                status TEXT NOT NULL,
+                goal TEXT NOT NULL,
+                constraints_json TEXT NOT NULL,
+                acceptance_criteria_json TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                metadata_json TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS runtime_task_checkpoints (
+                id TEXT PRIMARY KEY,
+                task_id TEXT NOT NULL,
+                summary TEXT NOT NULL,
+                state_json TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                FOREIGN KEY(task_id) REFERENCES runtime_tasks(id)
+            );
+            """
+        )
+        self._conn.commit()
+
+    def create_task(
+        self,
+        *,
+        title: str,
+        description: str,
+        goal: str = "",
+        constraints: list[str] | None = None,
+        acceptance_criteria: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Task:
+        now = time.time()
+        task = Task(
+            id=f"task_{uuid.uuid4().hex}",
+            title=title,
+            description=description,
+            goal=goal,
+            constraints=constraints or [],
+            acceptance_criteria=acceptance_criteria or [],
+            created_at=now,
+            updated_at=now,
+            metadata=metadata or {},
+        )
+        self.save_task(task)
+        return task
+
+    def save_task(self, task: Task) -> None:
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO runtime_tasks (
+                id, title, description, status, goal, constraints_json,
+                acceptance_criteria_json, created_at, updated_at, metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                task.id,
+                task.title,
+                task.description,
+                task.status.value,
+                task.goal,
+                json.dumps(task.constraints, ensure_ascii=False),
+                json.dumps(task.acceptance_criteria, ensure_ascii=False),
+                task.created_at,
+                task.updated_at,
+                json.dumps(task.metadata, ensure_ascii=False),
+            ),
+        )
+        self._conn.commit()
+
+    def get_task(self, task_id: str) -> Task | None:
+        row = self._conn.execute(
+            "SELECT * FROM runtime_tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        return self._task_from_row(row) if row else None
+
+    def update_status(self, task_id: str, status: TaskStatus, **metadata: Any) -> Task:
+        task = self.get_task(task_id)
+        if task is None:
+            raise KeyError(f"task not found: {task_id}")
+        task.status = status
+        task.updated_at = time.time()
+        task.metadata.update(metadata)
+        self.save_task(task)
+        return task
+
+    def checkpoint_task(
+        self,
+        task_id: str,
+        *,
+        summary: str,
+        state: dict[str, Any],
+    ) -> TaskCheckpoint:
+        checkpoint = TaskCheckpoint(
+            id=f"checkpoint_{uuid.uuid4().hex}",
+            task_id=task_id,
+            summary=summary,
+            state=state,
+            created_at=time.time(),
+        )
+        self._conn.execute(
+            """
+            INSERT INTO runtime_task_checkpoints (id, task_id, summary, state_json, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                checkpoint.id,
+                checkpoint.task_id,
+                checkpoint.summary,
+                json.dumps(checkpoint.state, ensure_ascii=False),
+                checkpoint.created_at,
+            ),
+        )
+        self._conn.commit()
+        return checkpoint
+
+    def checkpoints_for_task(self, task_id: str) -> list[TaskCheckpoint]:
+        rows = self._conn.execute(
+            """
+            SELECT * FROM runtime_task_checkpoints
+            WHERE task_id = ?
+            ORDER BY created_at, rowid
+            """,
+            (task_id,),
+        ).fetchall()
+        return [
+            TaskCheckpoint(
+                id=row["id"],
+                task_id=row["task_id"],
+                summary=row["summary"],
+                state=json.loads(row["state_json"]),
+                created_at=row["created_at"],
+            )
+            for row in rows
+        ]
+
+    def _task_from_row(self, row: sqlite3.Row) -> Task:
+        return Task(
+            id=row["id"],
+            title=row["title"],
+            description=row["description"],
+            status=TaskStatus(row["status"]),
+            goal=row["goal"],
+            constraints=json.loads(row["constraints_json"]),
+            acceptance_criteria=json.loads(row["acceptance_criteria_json"]),
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            metadata=json.loads(row["metadata_json"]),
+        )
+
+    def close(self) -> None:
+        self._conn.close()

--- a/src/familiar_runtime/tasks/tools.py
+++ b/src/familiar_runtime/tasks/tools.py
@@ -1,0 +1,96 @@
+"""Task management tools exposed through the generic ToolProvider protocol."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from familiar_runtime.tools import ToolExecutionResult, ToolSpec
+
+from .model import TaskStatus
+from .store import SQLiteTaskStore
+
+
+class TaskToolProvider:
+    """Expose create/checkpoint/finish operations as runtime tools."""
+
+    def __init__(self, store: SQLiteTaskStore) -> None:
+        self._store = store
+
+    def specs(self) -> list[ToolSpec]:
+        return [
+            ToolSpec(
+                name="create_task",
+                description="Create a durable task record.",
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "description": {"type": "string"},
+                        "acceptance_criteria": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                    },
+                    "required": ["title", "description"],
+                },
+                category="task",
+                tags={"task"},
+            ),
+            ToolSpec(
+                name="checkpoint_task",
+                description="Persist a task checkpoint.",
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "task_id": {"type": "string"},
+                        "summary": {"type": "string"},
+                        "state": {"type": "object"},
+                    },
+                    "required": ["task_id", "summary", "state"],
+                },
+                category="task",
+                tags={"task"},
+            ),
+            ToolSpec(
+                name="finish_task",
+                description="Mark a task succeeded with evidence.",
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "task_id": {"type": "string"},
+                        "evidence": {"type": "string"},
+                    },
+                    "required": ["task_id", "evidence"],
+                },
+                category="task",
+                tags={"task"},
+            ),
+        ]
+
+    async def call(self, name: str, tool_input: dict[str, Any]) -> ToolExecutionResult:
+        if name == "create_task":
+            task = self._store.create_task(
+                title=str(tool_input.get("title", "")),
+                description=str(tool_input.get("description", "")),
+                acceptance_criteria=list(tool_input.get("acceptance_criteria", []) or []),
+            )
+            return ToolExecutionResult(text=f"Created task {task.id}.")
+        if name == "checkpoint_task":
+            checkpoint = self._store.checkpoint_task(
+                str(tool_input["task_id"]),
+                summary=str(tool_input["summary"]),
+                state=dict(tool_input.get("state", {})),
+            )
+            return ToolExecutionResult(text=f"Checkpointed task {checkpoint.task_id}.")
+        if name == "finish_task":
+            task = self._store.update_status(
+                str(tool_input["task_id"]),
+                TaskStatus.SUCCEEDED,
+                evidence=str(tool_input["evidence"]),
+            )
+            return ToolExecutionResult(text=f"Finished task {task.id}.")
+        return ToolExecutionResult(
+            text=f"Unknown task tool: {name}",
+            success=False,
+            error="unknown_task_tool",
+        )

--- a/src/familiar_runtime/tools/__init__.py
+++ b/src/familiar_runtime/tools/__init__.py
@@ -2,5 +2,6 @@
 
 from .base import ToolExecutionResult, ToolProvider, ToolSpec
 from .registry import ToolRegistry
+from .sandbox_policy import SandboxPolicy
 
-__all__ = ["ToolExecutionResult", "ToolProvider", "ToolRegistry", "ToolSpec"]
+__all__ = ["SandboxPolicy", "ToolExecutionResult", "ToolProvider", "ToolRegistry", "ToolSpec"]

--- a/src/familiar_runtime/tools/__init__.py
+++ b/src/familiar_runtime/tools/__init__.py
@@ -1,0 +1,6 @@
+"""Tool provider interfaces and registry."""
+
+from .base import ToolExecutionResult, ToolProvider, ToolSpec
+from .registry import ToolRegistry
+
+__all__ = ["ToolExecutionResult", "ToolProvider", "ToolRegistry", "ToolSpec"]

--- a/src/familiar_runtime/tools/base.py
+++ b/src/familiar_runtime/tools/base.py
@@ -1,0 +1,51 @@
+"""Generic tool protocol and result types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass(slots=True)
+class ToolSpec:
+    """Provider-neutral description of a callable tool."""
+
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+    category: str = "generic"
+    risk: str = "low"
+    timeout_seconds: float = 20.0
+    tags: set[str] = field(default_factory=set)
+    backend_schema: dict[str, Any] | None = None
+
+    def to_anthropic_schema(self) -> dict[str, Any]:
+        """Return the schema shape currently consumed by familiar-ai backends."""
+        if self.backend_schema is not None:
+            return dict(self.backend_schema)
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": self.input_schema,
+        }
+
+
+@dataclass(slots=True)
+class ToolExecutionResult:
+    """Normalized output from a tool invocation."""
+
+    text: str
+    image_b64: str | None = None
+    success: bool = True
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class ToolProvider(Protocol):
+    """A source of one or more runtime tools."""
+
+    def specs(self) -> list[ToolSpec]:
+        """Return tool specs exposed by this provider."""
+
+    async def call(self, name: str, tool_input: dict[str, Any]) -> ToolExecutionResult:
+        """Execute a tool by name."""

--- a/src/familiar_runtime/tools/legacy.py
+++ b/src/familiar_runtime/tools/legacy.py
@@ -1,0 +1,76 @@
+"""Compatibility helpers for existing familiar_agent tool objects."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from .base import ToolExecutionResult, ToolSpec
+
+BeforeToolCall = Callable[[str, dict[str, Any]], None | Awaitable[None]]
+
+
+class LegacyToolProvider:
+    """Adapt existing get_tool_definitions()/call() objects to ToolProvider."""
+
+    def __init__(
+        self,
+        tool: Any,
+        *,
+        names: set[str] | None = None,
+        category: str = "generic",
+        tags: set[str] | None = None,
+        before_call: BeforeToolCall | None = None,
+    ) -> None:
+        self._tool = tool
+        self._names = names
+        self._category = category
+        self._tags = tags or set()
+        self._before_call = before_call
+
+    def specs(self) -> list[ToolSpec]:
+        defs: list[dict[str, Any]] = []
+        get_defs = getattr(self._tool, "get_tool_definitions", None)
+        if callable(get_defs):
+            try:
+                defs = list(get_defs())
+            except Exception:
+                defs = []
+        if not defs and self._names:
+            defs = [
+                {
+                    "name": name,
+                    "description": "",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+                for name in sorted(self._names)
+            ]
+        if self._names is not None:
+            defs = [definition for definition in defs if definition.get("name") in self._names]
+
+        specs: list[ToolSpec] = []
+        for definition in defs:
+            input_schema = definition.get("input_schema")
+            if not isinstance(input_schema, dict):
+                input_schema = {"type": "object", "properties": {}}
+            specs.append(
+                ToolSpec(
+                    name=str(definition["name"]),
+                    description=str(definition.get("description", "")),
+                    input_schema=dict(input_schema),
+                    category=self._category,
+                    tags=set(self._tags),
+                    backend_schema=dict(definition),
+                )
+            )
+        return specs
+
+    async def call(self, name: str, tool_input: dict[str, Any]) -> ToolExecutionResult:
+        if self._before_call is not None:
+            maybe_awaitable = self._before_call(name, tool_input)
+            if inspect.isawaitable(maybe_awaitable):
+                await maybe_awaitable
+
+        text, image = await self._tool.call(name, tool_input)
+        return ToolExecutionResult(text=str(text), image_b64=image)

--- a/src/familiar_runtime/tools/registry.py
+++ b/src/familiar_runtime/tools/registry.py
@@ -1,0 +1,80 @@
+"""Tool registry with deterministic routing and optional fallback."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from .base import ToolExecutionResult, ToolProvider, ToolSpec
+
+
+class ToolRegistry:
+    """Register tool providers and route calls by tool name."""
+
+    def __init__(self) -> None:
+        self._providers: list[ToolProvider] = []
+        self._routes: dict[str, ToolProvider] = {}
+        self._specs: dict[str, ToolSpec] = {}
+        self._fallback: ToolProvider | None = None
+
+    def register(self, provider: ToolProvider) -> None:
+        """Register a provider.
+
+        The first provider for a name wins. This preserves existing MCP collision behavior where
+        earlier tool definitions keep priority.
+        """
+        self._providers.append(provider)
+        for spec in provider.specs():
+            if spec.name in self._routes:
+                continue
+            self._routes[spec.name] = provider
+            self._specs[spec.name] = spec
+
+    def register_fallback(self, provider: ToolProvider) -> None:
+        """Register a provider for unknown names, used for dynamic MCP tools."""
+        self._fallback = provider
+
+    def has_tool(self, name: str) -> bool:
+        """Return whether a non-fallback route exists for a name."""
+        return name in self._routes
+
+    def specs(
+        self,
+        *,
+        profile: str | None = None,
+        allowed_tags: set[str] | None = None,
+    ) -> list[ToolSpec]:
+        """Return specs, optionally filtered by profile/tag."""
+        specs = list(self._specs.values())
+        if profile is not None:
+            specs = [
+                spec
+                for spec in specs
+                if not spec.tags or profile in spec.tags or "all" in spec.tags
+            ]
+        if allowed_tags is not None:
+            specs = [spec for spec in specs if spec.tags & allowed_tags]
+        return [replace(spec, tags=set(spec.tags)) for spec in specs]
+
+    def tool_defs(
+        self,
+        *,
+        profile: str | None = None,
+        allowed_tags: set[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return backend-compatible tool definitions."""
+        return [
+            spec.to_anthropic_schema()
+            for spec in self.specs(profile=profile, allowed_tags=allowed_tags)
+        ]
+
+    async def call(self, name: str, tool_input: dict[str, Any]) -> ToolExecutionResult:
+        """Route a call to its provider."""
+        provider = self._routes.get(name) or self._fallback
+        if provider is None:
+            return ToolExecutionResult(
+                text=f"Tool '{name}' not available (check configuration).",
+                success=False,
+                error="tool_not_available",
+            )
+        return await provider.call(name, tool_input)

--- a/src/familiar_runtime/tools/sandbox_policy.py
+++ b/src/familiar_runtime/tools/sandbox_policy.py
@@ -1,0 +1,22 @@
+"""Sandbox policy primitives for process-like tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(slots=True)
+class SandboxPolicy:
+    """Policy object for shell/process capabilities.
+
+    The first implementation preserves the existing opt-in bash behavior while making the policy
+    explicit for future supervision or sidecar work.
+    """
+
+    allow_bash: bool = False
+    workdir: Path | None = None
+    network: str = "inherit"
+    max_timeout_seconds: int = 120
+    allowed_commands: set[str] | None = None
+    denied_commands: set[str] = field(default_factory=lambda: {"rm -rf /", "shutdown", "reboot"})

--- a/tests/test_agent_react_loop.py
+++ b/tests/test_agent_react_loop.py
@@ -418,6 +418,41 @@ async def test_run_tool_results_added_to_messages():
 
 
 @pytest.mark.asyncio
+async def test_run_tool_timeout_is_returned_as_tool_result():
+    """A slow tool call is converted into a textual timeout result."""
+    agent = _make_agent()
+    tc = ToolCall(id="tc1", name="remember", input={"content": "slow"})
+    turn1 = TurnResult(stop_reason="tool_use", text="", tool_calls=[tc])
+    turn2 = TurnResult(stop_reason="end_turn", text="Done.", tool_calls=[])
+    agent.backend.stream_turn = AsyncMock(side_effect=[(turn1, None), (turn2, "Done.")])
+
+    async def _slow_execute(self, name, tool_input):  # noqa: ARG001
+        await asyncio.sleep(0.2)
+        return "late result", None
+
+    patches = dict(_HEAVY_PATCHES)
+    patches["familiar_agent.agent.EmbodiedAgent._execute_tool"] = _slow_execute
+    patches["familiar_agent.agent.EmbodiedAgent._tool_timeout_seconds"] = MagicMock(
+        return_value=0.01
+    )
+
+    ps = [patch(t, n) for t, n in patches.items()]
+    for p in ps:
+        p.start()
+    try:
+        result = await agent.run("remember slowly")
+    finally:
+        for p in ps:
+            p.stop()
+
+    assert result == "Done."
+    collected = agent.backend.make_tool_results.call_args.args[1]
+    assert collected[0][0].startswith("Tool timeout: remember exceeded")
+    assert agent._last_tool_error == collected[0][0]
+    assert agent._tool_failure_streak == 1
+
+
+@pytest.mark.asyncio
 async def test_run_passes_latest_pre_see_action_into_scene_update():
     """The last embodied action before see() conditions the scene update."""
     from familiar_agent.agent import EmbodiedAgent

--- a/tests/test_agent_tool_routing.py
+++ b/tests/test_agent_tool_routing.py
@@ -108,7 +108,22 @@ async def test_execute_tool_routes_tom():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("tool_name", ["read_file", "edit_file", "glob", "grep", "bash"])
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "read_file",
+        "write_file",
+        "edit_file",
+        "multi_edit_file",
+        "glob",
+        "grep",
+        "git_status",
+        "git_diff",
+        "git_apply_patch",
+        "run_tests",
+        "bash",
+    ],
+)
 async def test_execute_tool_routes_coding_tools(tool_name: str):
     agent = _make_agent()
     result, _ = await agent._execute_tool(tool_name, {})

--- a/tests/test_coding_tool.py
+++ b/tests/test_coding_tool.py
@@ -21,7 +21,9 @@ def test_bash_definition_is_hidden_unless_enabled(tmp_path: Path) -> None:
     }
 
     assert "bash" not in disabled_names
+    assert "run_tests" not in disabled_names
     assert "bash" in enabled_names
+    assert "run_tests" in enabled_names
 
 
 @pytest.mark.asyncio
@@ -55,6 +57,39 @@ async def test_edit_file_rejects_non_unique_old_string(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_write_file_creates_parent_directories(tmp_path: Path) -> None:
+    text, image = await _tool(tmp_path).call(
+        "write_file",
+        {"path": "nested/sample.txt", "content": "hello\n"},
+    )
+
+    assert image is None
+    assert "Wrote nested/sample.txt" in text
+    assert (tmp_path / "nested" / "sample.txt").read_text(encoding="utf-8") == "hello\n"
+
+
+@pytest.mark.asyncio
+async def test_multi_edit_file_applies_replacements_atomically(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("alpha\nbeta\n", encoding="utf-8")
+
+    text, image = await _tool(tmp_path).call(
+        "multi_edit_file",
+        {
+            "path": "sample.txt",
+            "edits": [
+                {"old_string": "alpha", "new_string": "one"},
+                {"old_string": "missing", "new_string": "two"},
+            ],
+        },
+    )
+
+    assert image is None
+    assert "old_string not found" in text
+    assert target.read_text(encoding="utf-8") == "alpha\nbeta\n"
+
+
+@pytest.mark.asyncio
 async def test_grep_content_mode_caps_results_at_500_lines(tmp_path: Path) -> None:
     target = tmp_path / "many.txt"
     target.write_text("\n".join("hit" for _ in range(501)) + "\n", encoding="utf-8")
@@ -69,3 +104,21 @@ async def test_grep_content_mode_caps_results_at_500_lines(tmp_path: Path) -> No
     assert len(lines) == 500
     assert lines[0].endswith(":1: hit")
     assert lines[-1].endswith(":500: hit")
+
+
+@pytest.mark.asyncio
+async def test_git_status_uses_workdir(tmp_path: Path) -> None:
+    await _tool(tmp_path)._run_process(["git", "init"], timeout=20)
+
+    text, image = await _tool(tmp_path).call("git_status", {})
+
+    assert image is None
+    assert "##" in text
+
+
+@pytest.mark.asyncio
+async def test_run_tests_requires_bash_enabled(tmp_path: Path) -> None:
+    text, image = await _tool(tmp_path).call("run_tests", {"command": "echo ok"})
+
+    assert image is None
+    assert "CODING_BASH=true" in text

--- a/tests/test_coding_tool.py
+++ b/tests/test_coding_tool.py
@@ -1,0 +1,71 @@
+"""Characterization tests for the coding tool provider."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from familiar_agent.config import CodingConfig
+from familiar_agent.tools.coding import CodingTool
+
+
+def _tool(tmp_path: Path, *, bash_enabled: bool = False) -> CodingTool:
+    return CodingTool(CodingConfig(workdir=str(tmp_path), bash_enabled=bash_enabled))
+
+
+def test_bash_definition_is_hidden_unless_enabled(tmp_path: Path) -> None:
+    disabled_names = {spec["name"] for spec in _tool(tmp_path).get_tool_definitions()}
+    enabled_names = {
+        spec["name"] for spec in _tool(tmp_path, bash_enabled=True).get_tool_definitions()
+    }
+
+    assert "bash" not in disabled_names
+    assert "bash" in enabled_names
+
+
+@pytest.mark.asyncio
+async def test_read_file_returns_cat_n_style_line_numbers(tmp_path: Path) -> None:
+    (tmp_path / "sample.txt").write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+
+    text, image = await _tool(tmp_path).call(
+        "read_file",
+        {"path": "sample.txt", "offset": 1, "limit": 2},
+    )
+
+    assert image is None
+    assert "     1\talpha\n" in text
+    assert "     2\tbeta\n" in text
+    assert "gamma" not in text
+
+
+@pytest.mark.asyncio
+async def test_edit_file_rejects_non_unique_old_string(tmp_path: Path) -> None:
+    target = tmp_path / "sample.txt"
+    target.write_text("same\nsame\n", encoding="utf-8")
+
+    text, image = await _tool(tmp_path).call(
+        "edit_file",
+        {"path": "sample.txt", "old_string": "same", "new_string": "changed"},
+    )
+
+    assert image is None
+    assert "matches 2 locations" in text
+    assert target.read_text(encoding="utf-8") == "same\nsame\n"
+
+
+@pytest.mark.asyncio
+async def test_grep_content_mode_caps_results_at_500_lines(tmp_path: Path) -> None:
+    target = tmp_path / "many.txt"
+    target.write_text("\n".join("hit" for _ in range(501)) + "\n", encoding="utf-8")
+
+    text, image = await _tool(tmp_path).call(
+        "grep",
+        {"pattern": "hit", "path": str(target), "output_mode": "content"},
+    )
+
+    lines = text.splitlines()
+    assert image is None
+    assert len(lines) == 500
+    assert lines[0].endswith(":1: hit")
+    assert lines[-1].endswith(":500: hit")

--- a/tests/test_neighbor_profile.py
+++ b/tests/test_neighbor_profile.py
@@ -1,0 +1,16 @@
+"""Tests for the neighbor profile compatibility boundary."""
+
+from familiar_neighbor import NeighborProfile
+from familiar_neighbor.mind import DesireSystem, GlobalWorkspace
+
+
+def test_neighbor_profile_defaults_to_neighbor_tool_tag() -> None:
+    profile = NeighborProfile()
+
+    assert profile.name == "neighbor"
+    assert profile.tool_tags == {"neighbor"}
+
+
+def test_neighbor_mind_reexports_existing_cognition_modules() -> None:
+    assert DesireSystem.__name__ == "DesireSystem"
+    assert GlobalWorkspace.__name__ == "GlobalWorkspace"

--- a/tests/test_runtime_events.py
+++ b/tests/test_runtime_events.py
@@ -1,0 +1,32 @@
+"""Tests for generic runtime events."""
+
+from __future__ import annotations
+
+from familiar_runtime.events import AgentEvent, EventBus, SQLiteEventStore
+
+
+def test_event_bus_logs_and_replays_jsonl(tmp_path) -> None:
+    bus = EventBus(log_dir=tmp_path)
+    seen: list[str] = []
+    bus.subscribe(lambda event: seen.append(event.type))
+    event = bus.emit_simple(source="user", type="message", payload={"text": "hi"})
+    bus.close()
+
+    assert seen == ["message"]
+    assert bus.log_path is not None
+    replayed = EventBus.replay(bus.log_path)
+    assert [item.id for item in replayed] == [event.id]
+    assert replayed[0].payload == {"text": "hi"}
+
+
+def test_sqlite_event_store_replays_in_timestamp_order(tmp_path) -> None:
+    store = SQLiteEventStore(tmp_path / "events.db")
+    later = AgentEvent(source="tool", type="tool_result", payload={"name": "b"}, timestamp=2.0)
+    earlier = AgentEvent(source="user", type="message", payload={"text": "a"}, timestamp=1.0)
+
+    store.append(later)
+    store.append(earlier)
+    replayed = store.replay()
+    store.close()
+
+    assert [event.id for event in replayed] == [earlier.id, later.id]

--- a/tests/test_runtime_react_loop.py
+++ b/tests/test_runtime_react_loop.py
@@ -1,0 +1,111 @@
+"""Tests for the generic ReAct loop."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from familiar_runtime.events import EventBus
+from familiar_runtime.models import ModelTurnResult, ToolCall
+from familiar_runtime.react_loop import ReActLoop
+from familiar_runtime.tools.base import ToolExecutionResult, ToolSpec
+from familiar_runtime.tools.registry import ToolRegistry
+
+
+class _ScriptedBackend:
+    def __init__(self, turns: list[ModelTurnResult]) -> None:
+        self.turns = list(turns)
+
+    def make_user_message(self, content: str | list[Any]) -> dict[str, Any]:
+        return {"role": "user", "content": content}
+
+    def make_assistant_message(
+        self,
+        result: ModelTurnResult,
+        raw_content: Any | None = None,
+    ) -> dict[str, Any]:
+        return {"role": "assistant", "content": result.text, "raw": raw_content}
+
+    def make_tool_results(
+        self,
+        tool_calls: list[ToolCall],
+        results: list[tuple[str, str | None]],
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "role": "tool",
+                "name": tool_call.name,
+                "content": text,
+                "image": image,
+            }
+            for tool_call, (text, image) in zip(tool_calls, results)
+        ]
+
+    async def stream_turn(self, **kwargs):
+        result = self.turns.pop(0)
+        return result, {"raw": result.text}
+
+    async def complete(self, prompt: str, max_tokens: int) -> str:
+        return ""
+
+
+class _EchoTool:
+    def specs(self) -> list[ToolSpec]:
+        return [
+            ToolSpec(
+                name="echo",
+                description="Echo",
+                input_schema={"type": "object", "properties": {}},
+            )
+        ]
+
+    async def call(self, name: str, tool_input: dict[str, Any]) -> ToolExecutionResult:
+        return ToolExecutionResult(text=f"echo: {tool_input['text']}")
+
+
+@pytest.mark.asyncio
+async def test_react_loop_executes_tool_and_returns_final_text() -> None:
+    backend = _ScriptedBackend(
+        [
+            ModelTurnResult(
+                stop_reason="tool_use",
+                text="",
+                tool_calls=[ToolCall(id="tc1", name="echo", input={"text": "hi"})],
+                input_tokens=10,
+                output_tokens=2,
+            ),
+            ModelTurnResult(
+                stop_reason="end_turn",
+                text="done",
+                input_tokens=11,
+                output_tokens=3,
+            ),
+        ]
+    )
+    registry = ToolRegistry()
+    registry.register(_EchoTool())
+    bus = EventBus()
+    seen: list[str] = []
+    bus.subscribe(lambda event: seen.append(event.type))
+    messages: list[Any] = []
+
+    result = await ReActLoop(backend=backend, tools=registry, event_bus=bus).run(
+        system="sys",
+        messages=messages,
+        max_tokens=100,
+    )
+
+    assert result.final_text == "done"
+    assert result.input_tokens == 21
+    assert result.output_tokens == 5
+    assert [call.name for call in result.tool_calls] == ["echo"]
+    flat_messages = []
+    for message in messages:
+        if isinstance(message, list):
+            flat_messages.extend(message)
+        else:
+            flat_messages.append(message)
+    assert any(message.get("role") == "tool" for message in flat_messages)
+    assert "tool_call" in seen
+    assert "tool_result" in seen

--- a/tests/test_runtime_tasks.py
+++ b/tests/test_runtime_tasks.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from familiar_runtime.tasks import SQLiteTaskStore, TaskStatus
+import pytest
+
+from familiar_runtime.tasks import SQLiteTaskStore, TaskStatus, TaskToolProvider
+from familiar_runtime.tools import SandboxPolicy
 
 
 def test_task_store_creates_updates_checkpoints_and_reloads(tmp_path) -> None:
@@ -34,3 +37,46 @@ def test_task_store_creates_updates_checkpoints_and_reloads(tmp_path) -> None:
     assert loaded.metadata["evidence"] == "pytest passed"
     assert [item.id for item in checkpoints] == [checkpoint.id]
     assert checkpoints[0].state == {"command": "pytest"}
+
+
+def test_sandbox_policy_keeps_bash_disabled_by_default() -> None:
+    policy = SandboxPolicy()
+
+    assert policy.allow_bash is False
+    assert "shutdown" in policy.denied_commands
+
+
+@pytest.mark.asyncio
+async def test_task_tool_provider_exposes_task_lifecycle(tmp_path) -> None:
+    store = SQLiteTaskStore(tmp_path / "tasks.db")
+    provider = TaskToolProvider(store)
+
+    created, checkpointed, finished = provider.specs()
+    assert [created.name, checkpointed.name, finished.name] == [
+        "create_task",
+        "checkpoint_task",
+        "finish_task",
+    ]
+
+    create_result = await provider.call(
+        "create_task",
+        {
+            "title": "runtime",
+            "description": "exercise task tools",
+            "acceptance_criteria": ["done"],
+        },
+    )
+    task_id = create_result.text.removeprefix("Created task ").removesuffix(".")
+    await provider.call(
+        "checkpoint_task",
+        {"task_id": task_id, "summary": "halfway", "state": {"step": 1}},
+    )
+    await provider.call("finish_task", {"task_id": task_id, "evidence": "done"})
+
+    task = store.get_task(task_id)
+    checkpoints = store.checkpoints_for_task(task_id)
+    store.close()
+
+    assert task is not None
+    assert task.status == TaskStatus.SUCCEEDED
+    assert checkpoints[0].summary == "halfway"

--- a/tests/test_runtime_tasks.py
+++ b/tests/test_runtime_tasks.py
@@ -1,0 +1,36 @@
+"""Tests for the durable runtime task store."""
+
+from __future__ import annotations
+
+from familiar_runtime.tasks import SQLiteTaskStore, TaskStatus
+
+
+def test_task_store_creates_updates_checkpoints_and_reloads(tmp_path) -> None:
+    db_path = tmp_path / "tasks.db"
+    store = SQLiteTaskStore(db_path)
+    task = store.create_task(
+        title="Inspect repo",
+        description="Run characterization",
+        goal="green tests",
+        acceptance_criteria=["pytest passes"],
+    )
+    store.update_status(task.id, TaskStatus.RUNNING)
+    checkpoint = store.checkpoint_task(
+        task.id,
+        summary="Tests started",
+        state={"command": "pytest"},
+    )
+    store.update_status(task.id, TaskStatus.SUCCEEDED, evidence="pytest passed")
+    store.close()
+
+    reopened = SQLiteTaskStore(db_path)
+    loaded = reopened.get_task(task.id)
+    checkpoints = reopened.checkpoints_for_task(task.id)
+    reopened.close()
+
+    assert loaded is not None
+    assert loaded.status == TaskStatus.SUCCEEDED
+    assert loaded.acceptance_criteria == ["pytest passes"]
+    assert loaded.metadata["evidence"] == "pytest passed"
+    assert [item.id for item in checkpoints] == [checkpoint.id]
+    assert checkpoints[0].state == {"command": "pytest"}

--- a/tests/test_runtime_tool_registry.py
+++ b/tests/test_runtime_tool_registry.py
@@ -1,0 +1,80 @@
+"""Tests for the generic tool registry."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from familiar_runtime.tools.base import ToolExecutionResult, ToolSpec
+from familiar_runtime.tools.registry import ToolRegistry
+
+
+class _Provider:
+    def __init__(self, name: str, text: str) -> None:
+        self.name = name
+        self.text = text
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def specs(self) -> list[ToolSpec]:
+        return [
+            ToolSpec(
+                name=self.name,
+                description=f"{self.name} tool",
+                input_schema={"type": "object", "properties": {}},
+                category="test",
+            )
+        ]
+
+    async def call(self, name: str, tool_input: dict[str, Any]) -> ToolExecutionResult:
+        self.calls.append((name, tool_input))
+        return ToolExecutionResult(text=self.text)
+
+
+@pytest.mark.asyncio
+async def test_first_registered_provider_wins_name_collision() -> None:
+    first = _Provider("same", "first")
+    second = _Provider("same", "second")
+    registry = ToolRegistry()
+    registry.register(first)
+    registry.register(second)
+
+    result = await registry.call("same", {"x": 1})
+
+    assert result.text == "first"
+    assert first.calls == [("same", {"x": 1})]
+    assert second.calls == []
+
+
+@pytest.mark.asyncio
+async def test_fallback_provider_handles_dynamic_unknown_tools() -> None:
+    fallback = _Provider("declared", "fallback")
+    registry = ToolRegistry()
+    registry.register_fallback(fallback)
+
+    result = await registry.call("dynamic_tool", {"ok": True})
+
+    assert result.text == "fallback"
+    assert fallback.calls == [("dynamic_tool", {"ok": True})]
+
+
+def test_tool_defs_filters_by_allowed_tags() -> None:
+    registry = ToolRegistry()
+    spec = ToolSpec(
+        name="task_tool",
+        description="Task tool",
+        input_schema={"type": "object", "properties": {}},
+        tags={"task"},
+    )
+
+    class _Tagged:
+        def specs(self) -> list[ToolSpec]:
+            return [spec]
+
+        async def call(self, name: str, tool_input: dict[str, Any]) -> ToolExecutionResult:
+            return ToolExecutionResult(text="ok")
+
+    registry.register(_Tagged())
+
+    assert [tool["name"] for tool in registry.tool_defs(allowed_tags={"task"})] == ["task_tool"]
+    assert registry.tool_defs(allowed_tags={"neighbor"}) == []

--- a/tests/test_task_mode_cli.py
+++ b/tests/test_task_mode_cli.py
@@ -1,0 +1,19 @@
+"""Tests for the task-mode CLI entry point."""
+
+from __future__ import annotations
+
+
+def test_main_dispatches_task_subcommand_without_companion_bootstrap(monkeypatch) -> None:
+    from familiar_agent import main as main_mod
+
+    called: list[list[str]] = []
+    monkeypatch.setattr(main_mod.sys, "argv", ["familiar", "task", "inspect", "repo"])
+    monkeypatch.setattr(main_mod, "setup_logging", lambda debug=False: None)
+    monkeypatch.setattr(
+        main_mod, "load_app_bootstrap", lambda: (_ for _ in ()).throw(AssertionError)
+    )
+    monkeypatch.setattr(main_mod, "_task_command", lambda args: called.append(args))
+
+    main_mod.main()
+
+    assert called == [["inspect", "repo"]]


### PR DESCRIPTION
## Summary
- Defines the generic runtime direction in docs/ADRs while preserving the existing neighbor app as a specialization.
- Adds `familiar_runtime` foundations: model/tool protocols, ToolRegistry, context blocks, background jobs, event bus/store, task store + task lifecycle tools, sandbox policy, and a provider-neutral ReAct loop.
- Adds `familiar_capabilities` adapters for coding/MCP, a `familiar_neighbor` profile boundary, and a first non-embodied `familiar task ...` CLI path.
- Routes existing `EmbodiedAgent` tool execution through ToolRegistry while keeping legacy tool schemas and MCP fallback behavior intact.
- Expands coding capabilities with write/multi-edit/git/test helpers while keeping `bash` and `run_tests` opt-in behind `CODING_BASH=true`.

## Compatibility
- Existing `familiar` companion mode, TUI/GUI entry points, `.env` behavior, ME.md persona behavior, and memory DB schema remain unchanged.
- No Rust/Go sidecar is introduced.
- The local instruction file `familiar_ai_agent_runtime_reorg_instructions.md` is intentionally not committed.

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run --group dev mypy src/familiar_agent src/familiar_runtime src/familiar_capabilities src/familiar_neighbor`
- `uv run pytest -q` (`910 passed, 7 warnings`)
- GitHub Actions: lint, ubuntu, macOS, and Windows tests all passed