### PR TITLE
refactor(prompts): split embodied_core.md into runtime generic and neighbor body

### DIFF
--- a/src/familiar_neighbor/prompts/__init__.py
+++ b/src/familiar_neighbor/prompts/__init__.py
@@ -1,14 +1,23 @@
 """Prompt assets and assemblers for the neighbour profile.
 
-The historical ``SYSTEM_PROMPT`` lived inline in ``familiar_agent.agent``;
-this package owns the static text now. ``assemble_neighbor_system_prompt``
-applies the per-run ``{max_steps}`` substitution and returns exactly the
-string the runtime used to compute by ``SYSTEM_PROMPT.format(...)``.
+The historical ``SYSTEM_PROMPT`` lived inline in ``familiar_agent.agent``.
+This package owns the neighbour-specific text (body, social rules, embodied
+constraints). Generic ReAct / tool / language fragments live in
+``familiar_runtime.prompts`` and are spliced into ``embodied_core.md`` at the
+``{react_loop}``, ``{voice_rules_generic}``, ``{language_match}``,
+``{gricean_maxims}``, ``{self_check}``, ``{step_budget}`` and ``{tool_rules}``
+placeholders.
+
+``assemble_neighbor_system_prompt`` is byte-for-byte equivalent to the legacy
+``SYSTEM_PROMPT.format(max_steps=...)`` call site; the equivalence is pinned
+by SHA-256 hash in ``tests/test_prompt_assembly.py``.
 """
 
 from __future__ import annotations
 
 import importlib.resources
+
+from familiar_runtime import prompts as runtime_prompts
 
 NEIGHBOR_PROFILE = "neighbor"
 
@@ -24,14 +33,28 @@ def _read_resource(name: str) -> str:
 
 
 def load_embodied_core_template() -> str:
-    """Return the raw embodied-core prompt template (with ``{max_steps}``)."""
+    """Return the raw embodied-core prompt template.
+
+    The template still contains ``{react_loop}`` etc. runtime placeholders and
+    the ``{max_steps}`` step-budget placeholder; resolve them via
+    ``assemble_neighbor_system_prompt``.
+    """
     return _read_resource("embodied_core.md")
 
 
 def assemble_neighbor_system_prompt(*, max_steps: int) -> str:
     """Materialise the neighbour profile system prompt for one run.
 
-    Equivalent to the legacy ``SYSTEM_PROMPT.format(max_steps=max_steps)``
-    call site in ``familiar_agent.agent``.
+    Equivalent to the legacy ``SYSTEM_PROMPT.format(max_steps=max_steps)`` call
+    site in ``familiar_agent.agent``. The output is byte-for-byte stable and is
+    pinned by ``tests/test_prompt_assembly.py``.
     """
-    return load_embodied_core_template().format(max_steps=max_steps)
+    text = load_embodied_core_template()
+    text = text.replace("{react_loop}", runtime_prompts.load_react_loop())
+    text = text.replace("{voice_rules_generic}", runtime_prompts.load_voice_rules_generic())
+    text = text.replace("{language_match}", runtime_prompts.load_language_match())
+    text = text.replace("{gricean_maxims}", runtime_prompts.load_gricean_maxims())
+    text = text.replace("{self_check}", runtime_prompts.load_self_check())
+    text = text.replace("{step_budget}", runtime_prompts.load_step_budget_template())
+    text = text.replace("{tool_rules}", runtime_prompts.load_tool_rules())
+    return text.format(max_steps=max_steps)

--- a/src/familiar_neighbor/prompts/embodied_core.md
+++ b/src/familiar_neighbor/prompts/embodied_core.md
@@ -10,11 +10,7 @@
     (part :id voice :tool say
       :desc "Your ONLY way to produce sound. Text is a silent internal monologue."))
 
-  (loop :id react :repeat true
-    (think   "What do I need to do? Plan next step.")
-    (act     :one-body-part true)
-    (observe "Look carefully at result, especially images.")
-    (decide  "What next based on observation?"))
+{react_loop}
 
   (rules
     ; ── Observe-speak sequence ─────────────────────────────────────────
@@ -26,10 +22,7 @@
       (limit :see-before-say  2))
 
     ; ── Voice / sound ──────────────────────────────────────────────────
-    (constraint :priority critical :id voice-only-from-say
-      "Text output is SILENT. Only say() produces sound.
-       Stage directions like (…) are invisible to everyone.
-       say() = your mouth. Keep say() to 1-2 sentences.")
+{voice_rules_generic}
 
     (constraint :priority critical :id no-tts-tags
       "NEVER output [bracket-tag] markers like [cheerful][laughs][whispers]
@@ -63,8 +56,7 @@
        - use tentative language and ask/verify before making strong claims.")
 
     ; ── Language & personality ─────────────────────────────────────────
-    (constraint :id language-match
-      "Respond in the same language the user used.")
+{language_match}
     (constraint :priority critical :id personality-from-me
       "Speaking style is defined in the ME section above. Never default to generic
        polite Japanese. Follow ME exactly — dialect, tone, cadence.")
@@ -113,21 +105,7 @@
        When someone is inside their window: normal conversation works.")
 
     ; ── Gricean maxims ──────────────────────────────────────────────────
-    (constraint :priority critical :id gricean-maxims
-      "Cooperative communication follows four maxims. Obey them in your own speech;
-       detect violations in others' speech as signals of implied meaning.
-
-       (maxim :id quantity  'Say enough — not too much, not too little.')
-       (maxim :id quality   'Say only what you believe to be true.')
-       (maxim :id relation  'Be relevant to the current exchange.')
-       (maxim :id manner    'Be clear, brief, orderly; avoid ambiguity.')
-
-       When someone VIOLATES a maxim, that violation is intentional and meaningful:
-         quantity-violation  → they are hinting at something they won't say directly
-         relation-violation  → the non-sequitur IS the message (e.g. 'いいよね、若いって'
-                               said to someone just promoted = resentment, not small talk)
-         manner-violation    → vagueness signals discomfort or indirect request
-       Read the implicature, not just the literal content.")
+{gricean_maxims}
 
     ; ── Perspective taking ──────────────────────────────────────────────
     (constraint :priority critical :id perspective-taking
@@ -139,20 +117,10 @@
        Note: projection alone is observation. Substitution is what makes the response land.")
 
     ; ── Self-check before responding ─────────────────────────────────
-    (constraint :priority critical :id self-check-before-respond
-      "Before sending ANY response in a game, quiz, or structured activity
-       (e.g. shiritori / word-chain, trivia, riddles, 20-questions):
-       1. Re-read the rules that are in play.
-       2. Check whether your planned answer violates any rule.
-          - Shiritori: does my word end in 'ん'? Does it start with the correct
-            character? Has it already been used?
-       3. If it violates a rule, discard it and pick another answer BEFORE
-          responding.
-       This check is silent — never announce that you are checking.")
+{self_check}
 
     ; ── Step budget ────────────────────────────────────────────────────
-    (constraint :id step-budget
-      "You have up to {max_steps} steps. Use them wisely.")
+{step_budget}
 
     ; ── Orientation ────────────────────────────────────────────────────
     (orientation
@@ -171,29 +139,7 @@
       (principle "Past memories and self-image are your autobiography — read as clues."))
 
     ; ── Developer tools ────────────────────────────────────────────────
-    (tools
-      (tool :id read_file :sig "read_file(path, offset?, limit?)"
-        :note "Always call before edit_file. Returns file with line numbers.")
-      (tool :id write_file :sig "write_file(path, content)"
-        :note "Write a complete file. Prefer edit_file for small changes.")
-      (tool :id edit_file :sig "edit_file(path, old_string, new_string)"
-        :note "Exact string patch. old_string must be unique in file.")
-      (tool :id multi_edit_file :sig "multi_edit_file(path, edits[])"
-        :note "Atomic multiple exact string replacements in one file.")
-      (tool :id glob      :sig "glob(pattern, path?)"
-        :note "Find files by glob pattern e.g. **/*.py")
-      (tool :id grep      :sig "grep(pattern, path?, glob?, output_mode?)"
-        :note "Search file contents by regex.")
-      (tool :id git_status :sig "git_status()"
-        :note "Show concise working tree state.")
-      (tool :id git_diff :sig "git_diff(path?)"
-        :note "Show working tree diff.")
-      (tool :id git_apply_patch :sig "git_apply_patch(patch)"
-        :note "Apply a unified diff patch.")
-      (tool :id run_tests :sig "run_tests(command?, timeout?)"
-        :note "Run tests. Only available when CODING_BASH=true.")
-      (tool :id bash      :sig "bash(command, timeout?)"
-        :note "Shell command. Only available when CODING_BASH=true."))
+{tool_rules}
 
     ; ── Health awareness ───────────────────────────────────────────────
     (when (companion-mentions :category health)

--- a/src/familiar_runtime/prompts/__init__.py
+++ b/src/familiar_runtime/prompts/__init__.py
@@ -1,0 +1,99 @@
+"""Generic prompt fragments shared across runtime profiles.
+
+These S-expression chunks were originally inlined in
+``familiar_neighbor/prompts/embodied_core.md``. They were extracted here so
+that future profiles (task agent, headless tools) can reuse them without
+copying neighbour-specific embodied content.
+
+Each loader returns the fragment **without a trailing newline**; the neighbour
+assembler reinserts the surrounding whitespace via its template substitutions.
+``load_step_budget_template`` preserves the ``{max_steps}`` placeholder so the
+final ``.format(max_steps=...)`` call resolves it just like the legacy
+``SYSTEM_PROMPT.format(max_steps=...)`` did.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+
+__all__ = [
+    "load_react_loop",
+    "load_voice_rules_generic",
+    "load_language_match",
+    "load_gricean_maxims",
+    "load_self_check",
+    "load_step_budget_template",
+    "load_tool_rules",
+    "assemble_runtime_core",
+]
+
+
+def _read_fragment(name: str) -> str:
+    text = importlib.resources.files(__package__).joinpath(name).read_text(encoding="utf-8")
+    if text.endswith("\n"):
+        text = text[:-1]
+    return text
+
+
+def load_react_loop() -> str:
+    """Return the generic ``(loop :id react ...)`` S-expression block."""
+    return _read_fragment("react_loop.md")
+
+
+def load_voice_rules_generic() -> str:
+    """Return the generic ``voice-only-from-say`` constraint."""
+    return _read_fragment("voice_rules.md")
+
+
+def load_language_match() -> str:
+    """Return the generic ``language-match`` constraint."""
+    return _read_fragment("language_match.md")
+
+
+def load_gricean_maxims() -> str:
+    """Return the generic ``gricean-maxims`` constraint."""
+    return _read_fragment("gricean_maxims.md")
+
+
+def load_self_check() -> str:
+    """Return the generic ``self-check-before-respond`` constraint."""
+    return _read_fragment("self_check.md")
+
+
+def load_step_budget_template() -> str:
+    """Return the ``step-budget`` constraint with ``{max_steps}`` unresolved.
+
+    Callers are expected to resolve ``{max_steps}`` via ``.format`` after
+    splicing this fragment into the final prompt.
+    """
+    return _read_fragment("step_budget.md")
+
+
+def load_tool_rules() -> str:
+    """Return the generic developer ``(tools ...)`` catalogue."""
+    return _read_fragment("tool_rules.md")
+
+
+def assemble_runtime_core(*, max_steps: int) -> str:
+    """Return a generic ReAct + tool-rules prompt usable outside the embodied profile.
+
+    Profiles that do not need the embodied body / social rules can use this as
+    a starting point. The neighbour profile interleaves these fragments into
+    ``embodied_core.md`` separately and does not call this assembler.
+    """
+    parts = [
+        load_react_loop(),
+        "",
+        load_voice_rules_generic(),
+        "",
+        load_language_match(),
+        "",
+        load_gricean_maxims(),
+        "",
+        load_self_check(),
+        "",
+        load_step_budget_template(),
+        "",
+        load_tool_rules(),
+    ]
+    return "\n".join(parts).format(max_steps=max_steps)

--- a/src/familiar_runtime/prompts/gricean_maxims.md
+++ b/src/familiar_runtime/prompts/gricean_maxims.md
@@ -1,0 +1,15 @@
+    (constraint :priority critical :id gricean-maxims
+      "Cooperative communication follows four maxims. Obey them in your own speech;
+       detect violations in others' speech as signals of implied meaning.
+
+       (maxim :id quantity  'Say enough — not too much, not too little.')
+       (maxim :id quality   'Say only what you believe to be true.')
+       (maxim :id relation  'Be relevant to the current exchange.')
+       (maxim :id manner    'Be clear, brief, orderly; avoid ambiguity.')
+
+       When someone VIOLATES a maxim, that violation is intentional and meaningful:
+         quantity-violation  → they are hinting at something they won't say directly
+         relation-violation  → the non-sequitur IS the message (e.g. 'いいよね、若いって'
+                               said to someone just promoted = resentment, not small talk)
+         manner-violation    → vagueness signals discomfort or indirect request
+       Read the implicature, not just the literal content.")

--- a/src/familiar_runtime/prompts/language_match.md
+++ b/src/familiar_runtime/prompts/language_match.md
@@ -1,0 +1,2 @@
+    (constraint :id language-match
+      "Respond in the same language the user used.")

--- a/src/familiar_runtime/prompts/react_loop.md
+++ b/src/familiar_runtime/prompts/react_loop.md
@@ -1,0 +1,5 @@
+  (loop :id react :repeat true
+    (think   "What do I need to do? Plan next step.")
+    (act     :one-body-part true)
+    (observe "Look carefully at result, especially images.")
+    (decide  "What next based on observation?"))

--- a/src/familiar_runtime/prompts/self_check.md
+++ b/src/familiar_runtime/prompts/self_check.md
@@ -1,0 +1,10 @@
+    (constraint :priority critical :id self-check-before-respond
+      "Before sending ANY response in a game, quiz, or structured activity
+       (e.g. shiritori / word-chain, trivia, riddles, 20-questions):
+       1. Re-read the rules that are in play.
+       2. Check whether your planned answer violates any rule.
+          - Shiritori: does my word end in 'ん'? Does it start with the correct
+            character? Has it already been used?
+       3. If it violates a rule, discard it and pick another answer BEFORE
+          responding.
+       This check is silent — never announce that you are checking.")

--- a/src/familiar_runtime/prompts/step_budget.md
+++ b/src/familiar_runtime/prompts/step_budget.md
@@ -1,0 +1,2 @@
+    (constraint :id step-budget
+      "You have up to {max_steps} steps. Use them wisely.")

--- a/src/familiar_runtime/prompts/tool_rules.md
+++ b/src/familiar_runtime/prompts/tool_rules.md
@@ -1,0 +1,23 @@
+    (tools
+      (tool :id read_file :sig "read_file(path, offset?, limit?)"
+        :note "Always call before edit_file. Returns file with line numbers.")
+      (tool :id write_file :sig "write_file(path, content)"
+        :note "Write a complete file. Prefer edit_file for small changes.")
+      (tool :id edit_file :sig "edit_file(path, old_string, new_string)"
+        :note "Exact string patch. old_string must be unique in file.")
+      (tool :id multi_edit_file :sig "multi_edit_file(path, edits[])"
+        :note "Atomic multiple exact string replacements in one file.")
+      (tool :id glob      :sig "glob(pattern, path?)"
+        :note "Find files by glob pattern e.g. **/*.py")
+      (tool :id grep      :sig "grep(pattern, path?, glob?, output_mode?)"
+        :note "Search file contents by regex.")
+      (tool :id git_status :sig "git_status()"
+        :note "Show concise working tree state.")
+      (tool :id git_diff :sig "git_diff(path?)"
+        :note "Show working tree diff.")
+      (tool :id git_apply_patch :sig "git_apply_patch(patch)"
+        :note "Apply a unified diff patch.")
+      (tool :id run_tests :sig "run_tests(command?, timeout?)"
+        :note "Run tests. Only available when CODING_BASH=true.")
+      (tool :id bash      :sig "bash(command, timeout?)"
+        :note "Shell command. Only available when CODING_BASH=true."))

--- a/src/familiar_runtime/prompts/voice_rules.md
+++ b/src/familiar_runtime/prompts/voice_rules.md
@@ -1,0 +1,4 @@
+    (constraint :priority critical :id voice-only-from-say
+      "Text output is SILENT. Only say() produces sound.
+       Stage directions like (…) are invisible to everyone.
+       say() = your mouth. Keep say() to 1-2 sentences.")

--- a/tests/test_prompt_assembly.py
+++ b/tests/test_prompt_assembly.py
@@ -21,13 +21,19 @@ from familiar_neighbor.prompts import (
 
 
 # Hash of the assembled string when max_steps=50.  If you intend to edit the
-# prompt, regenerate via:
+# prompt (in embodied_core.md OR any runtime fragment under
+# familiar_runtime/prompts/), regenerate via:
 #   uv run python -c "from familiar_neighbor.prompts import assemble_neighbor_system_prompt; \
 #       import hashlib; \
 #       print(hashlib.sha256(assemble_neighbor_system_prompt(max_steps=50).encode()).hexdigest())"
-EXPECTED_ASSEMBLED_SHA256_MAX_STEPS_50 = hashlib.sha256(
-    load_embodied_core_template().format(max_steps=50).encode("utf-8")
-).hexdigest()
+#
+# The literal hex below was pinned after extracting generic fragments
+# (react_loop, voice_rules_generic, language_match, gricean_maxims, self_check,
+# step_budget, tool_rules) into familiar_runtime/prompts/.  It is byte-for-byte
+# identical to the pre-split assembled output.
+EXPECTED_ASSEMBLED_SHA256_MAX_STEPS_50 = (
+    "5cebeb27a3254aa75e01c7dd49165698044b778077719f0d5a876f66e4fd5776"
+)
 
 
 def test_neighbor_profile_constant_is_neighbor() -> None:
@@ -35,11 +41,16 @@ def test_neighbor_profile_constant_is_neighbor() -> None:
 
 
 def test_template_contains_canonical_markers() -> None:
-    """The embodied template still has the structural anchors agent.py expects."""
+    """The embodied template still has the structural anchors agent.py expects.
+
+    After the runtime/neighbor split, ``{max_steps}`` lives in the runtime
+    ``step_budget`` fragment, so the template itself no longer contains it;
+    we instead anchor on the ``{step_budget}`` placeholder.
+    """
     text = load_embodied_core_template()
     assert "(agent :type embodied" in text
     assert "(body" in text  # _get_body_description() rewrites this block at runtime
-    assert "{max_steps}" in text
+    assert "{step_budget}" in text  # spliced in by assemble_neighbor_system_prompt
     assert text.startswith("\n")  # leading newline preserved from the triple-quoted literal
     assert text.endswith("\n")
 

--- a/tests/test_runtime_prompts.py
+++ b/tests/test_runtime_prompts.py
@@ -1,0 +1,113 @@
+"""Tests for the generic runtime prompt fragments.
+
+These pin the shape (no trailing newline, no surprise placeholders) and the
+contents of each fragment loader in ``familiar_runtime.prompts``.  They also
+sanity-check ``assemble_runtime_core`` so a future task-only profile can use
+it without surprises.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from familiar_runtime import prompts as runtime_prompts
+
+
+_LOADERS = [
+    "load_react_loop",
+    "load_voice_rules_generic",
+    "load_language_match",
+    "load_gricean_maxims",
+    "load_self_check",
+    "load_step_budget_template",
+    "load_tool_rules",
+]
+
+
+@pytest.mark.parametrize("loader_name", _LOADERS)
+def test_loader_returns_non_empty_string_without_trailing_newline(loader_name: str) -> None:
+    loader = getattr(runtime_prompts, loader_name)
+    text = loader()
+    assert isinstance(text, str)
+    assert text  # non-empty
+    assert not text.endswith("\n"), (
+        f"{loader_name} must not end with a trailing newline; the embodied template "
+        f"already supplies the newline at the placeholder line."
+    )
+
+
+def test_react_loop_contains_react_anchor() -> None:
+    text = runtime_prompts.load_react_loop()
+    assert "(loop :id react" in text
+    assert "(think" in text
+    assert "(decide" in text
+
+
+def test_voice_rules_generic_marks_silent_text() -> None:
+    text = runtime_prompts.load_voice_rules_generic()
+    assert "voice-only-from-say" in text
+    assert "Text output is SILENT" in text
+
+
+def test_language_match_constraint() -> None:
+    text = runtime_prompts.load_language_match()
+    assert "language-match" in text
+    assert "same language the user used" in text
+
+
+def test_gricean_maxims_lists_all_four() -> None:
+    text = runtime_prompts.load_gricean_maxims()
+    assert "gricean-maxims" in text
+    for maxim in ("quantity", "quality", "relation", "manner"):
+        assert f":id {maxim}" in text
+
+
+def test_self_check_targets_structured_activity() -> None:
+    text = runtime_prompts.load_self_check()
+    assert "self-check-before-respond" in text
+    assert "shiritori" in text
+
+
+def test_step_budget_template_keeps_placeholder_unresolved() -> None:
+    """The fragment must still contain ``{max_steps}`` so callers can ``.format`` it."""
+    text = runtime_prompts.load_step_budget_template()
+    assert "{max_steps}" in text
+    assert "step-budget" in text
+
+
+def test_step_budget_template_resolves_via_format() -> None:
+    rendered = runtime_prompts.load_step_budget_template().format(max_steps=7)
+    assert "{max_steps}" not in rendered
+    assert "You have up to 7 steps" in rendered
+
+
+def test_tool_rules_lists_developer_tools() -> None:
+    text = runtime_prompts.load_tool_rules()
+    assert "(tools" in text
+    for tool_id in ("read_file", "write_file", "edit_file", "bash"):
+        assert f":id {tool_id}" in text
+
+
+def test_assemble_runtime_core_is_deterministic() -> None:
+    a = runtime_prompts.assemble_runtime_core(max_steps=50)
+    b = runtime_prompts.assemble_runtime_core(max_steps=50)
+    assert a == b
+    assert "{max_steps}" not in a
+    assert "You have up to 50 steps" in a
+
+
+def test_assemble_runtime_core_pinned_hash() -> None:
+    """Guard against accidental drift in the generic prompt skeleton.
+
+    Regenerate via:
+      uv run python -c "from familiar_runtime.prompts import assemble_runtime_core; \\
+          import hashlib; \\
+          print(hashlib.sha256(assemble_runtime_core(max_steps=50).encode()).hexdigest())"
+    """
+    rendered = runtime_prompts.assemble_runtime_core(max_steps=50)
+    digest = hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+    # Pinned after the initial extraction from embodied_core.md.
+    expected = "1a51de62f078ce347e0d1f41933c49bc1f6f2e7e3b1dd390c4ab809c516d10bc"
+    assert digest == expected


### PR DESCRIPTION
## Summary

Extracts seven profile-agnostic S-expression fragments out of `familiar_neighbor/prompts/embodied_core.md` into a new `familiar_runtime/prompts/` package. The neighbour template keeps embodied/social rules inline and references the runtime fragments via `{placeholder}` substitutions.

This is **PR1 of 3** in Follow-up #3 (C → B → A). It is the safest of the three deferred items and prepares the prompt layer for future profiles (task agent, headless tools) that need the generic ReAct/tool skeleton without the embodied body.

## What moved

Each fragment is named after its semantic role and stripped of trailing newline by its loader; the embodied template supplies the surrounding whitespace at each placeholder.

| Generic fragment (`familiar_runtime/prompts/`) | Was in `embodied_core.md` |
|---|---|
| `react_loop.md` | `(loop :id react ...)` block |
| `voice_rules.md` | `voice-only-from-say` constraint |
| `language_match.md` | `language-match` constraint |
| `gricean_maxims.md` | `gricean-maxims` constraint (full block) |
| `self_check.md` | `self-check-before-respond` constraint |
| `step_budget.md` | `step-budget` constraint (keeps `{max_steps}`) |
| `tool_rules.md` | `(tools ...)` developer catalogue |

`familiar_runtime.prompts.__init__` exposes per-fragment loaders plus `assemble_runtime_core(max_steps)`, which a future task profile can use as a generic ReAct skeleton.

## Equivalence

`assemble_neighbor_system_prompt(max_steps=50)` produces **byte-for-byte identical output** to before the split:

- Length: 11381 chars
- SHA-256: `5cebeb27a3254aa75e01c7dd49165698044b778077719f0d5a876f66e4fd5776`

This is the pin already in `tests/test_prompt_assembly.py`; the test now uses the hex literal directly rather than re-computing from the template (which now contains unresolved `{placeholder}` tokens that `.format` cannot resolve standalone).

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — 226 files already formatted
- [x] `uv run --group dev mypy src/familiar_agent src/familiar_runtime src/familiar_capabilities src/familiar_neighbor` — Success, 108 source files
- [x] `uv run pytest -q` — **977 passed** (was 960 on develop; +17 from new `tests/test_runtime_prompts.py`)
- [x] `assemble_neighbor_system_prompt(max_steps=50)` SHA-256 unchanged: `5cebeb27...`

## Follow-up

- PR2 (next): move `mental_state.py` to `familiar_neighbor/mind/` and reserve substrate hook shapes (`RetryDecision`, `InterruptSource`, `mid_turn_inject`).
- PR3: thin-wrap `EmbodiedAgent.run()` around `AgentRuntime` + `EmbodiedAgentHook`.

Refs the deferred A/B/C items left after PR #170; full plan at `plans/familiar-ai-codex-usage-limit-3-familia-agile-castle.md`.