### PR TITLE
feat(runtime): wire mid_turn_inject, interrupt polling, and RetryDecision into ReActLoop

### DIFF
--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -7,11 +7,13 @@ snapshot building) and the post-end-turn commit (mental-state bus append,
 post-response pipeline kick) so the ReAct loop body in ``agent.py`` reads
 as a thin model/tool dispatcher around the prepared state.
 
-This is *not yet* a runtime ``RuntimeHook`` Protocol implementation; it
-holds a back-reference to the ``EmbodiedAgent`` instance instead.  The
-``RuntimeHook`` substrate (``mid_turn_inject`` / ``RetryDecision`` /
-``InterruptSource``) was reserved in PR2 and is intentionally left for a
-later migration that can re-wire ``AgentRuntime`` end-to-end.
+``EmbodiedAgentHook`` subclasses :class:`RuntimeHookBase`, so it satisfies
+the ``RuntimeHook`` interface (inheriting safe no-op lifecycle methods) while
+still holding a back-reference to the ``EmbodiedAgent`` instance for its
+``prepare_turn`` / ``commit_after_end_turn`` flow.  The substrate now honours
+``mid_turn_inject`` / ``RetryDecision`` / ``InterruptSource`` (wired in
+``ReActLoop``); routing ``EmbodiedAgent.run`` through ``AgentRuntime.run_turn``
+end-to-end remains a later migration.
 """
 
 from __future__ import annotations
@@ -36,6 +38,7 @@ from familiar_neighbor.mind.appraisal import AppraisalContext, AppraisalEngine
 from familiar_neighbor.mind.desires import DesireSystem
 from familiar_neighbor.mind.mental_state import MentalStateBus, MentalStateSnapshot
 from familiar_neighbor.mind.social_policy import SocialPolicyDecision, SocialPolicyEngine
+from familiar_runtime.runtime import RuntimeHookBase
 
 if TYPE_CHECKING:
     from familiar_agent.agent import EmbodiedAgent
@@ -103,7 +106,7 @@ class PreparedTurn:
     unfinished_business: list[dict] = field(default_factory=list)
 
 
-class EmbodiedAgentHook:
+class EmbodiedAgentHook(RuntimeHookBase):
     """Bridges the embodied profile's cognition with the ReAct loop in ``agent.py``.
 
     The hook holds a back-reference to its owning ``EmbodiedAgent`` so it
@@ -111,6 +114,12 @@ class EmbodiedAgentHook:
     appraisal, mental-state bus, …) without taking every dependency as
     a constructor parameter.  The agent itself stays the single owner of
     long-lived state; the hook only encapsulates the per-turn flow.
+
+    Subclassing :class:`RuntimeHookBase` makes it a structural ``RuntimeHook``
+    (inheriting no-op ``before_turn`` / ``build_context`` / ``mid_turn_inject`` /
+    ``after_model_result`` / ``after_tool_result`` / ``after_turn`` defaults);
+    the embodied flow currently drives the loop via ``prepare_turn`` /
+    ``commit_after_end_turn`` rather than those lifecycle hooks.
     """
 
     def __init__(self, agent: "EmbodiedAgent") -> None:

--- a/src/familiar_runtime/react_loop.py
+++ b/src/familiar_runtime/react_loop.py
@@ -15,9 +15,26 @@ from .tools.base import ToolExecutionResult
 from .tools.registry import ToolRegistry
 
 if TYPE_CHECKING:
-    from .runtime import RuntimeHook, TurnContext
+    from .context import ContextBlock
+    from .runtime import InterruptSource, RuntimeHook, TurnContext
 
 logger = logging.getLogger(__name__)
+
+
+def _with_extra_system(
+    system: str | tuple[str, str],
+    extra: str,
+) -> str | tuple[str, str]:
+    """Append ``extra`` to a system prompt, preserving the (stable, variable) split.
+
+    ``mid_turn_inject`` blocks are spliced into the *variable* half of a cached
+    tuple prompt so the stable prefix keeps its cache_control eligibility.
+    """
+    if isinstance(system, tuple):
+        stable, variable = system
+        merged = f"{variable}\n\n{extra}" if variable else extra
+        return (stable, merged)
+    return f"{system}\n\n{extra}" if system else extra
 
 
 @dataclass(slots=True)
@@ -66,7 +83,10 @@ class ReActLoop:
         task_id: str | None = None,
         turn_id: str | None = None,
         context: "TurnContext | None" = None,
+        interrupt_source: "InterruptSource | None" = None,
     ) -> RunTurnResult:
+        from .runtime import RetryDecision  # local import avoids circular import
+
         run_id = run_id or f"run_{uuid.uuid4().hex}"
         turn_id = turn_id or f"turn_{uuid.uuid4().hex}"
         event_ids: list[str] = []
@@ -90,22 +110,51 @@ class ReActLoop:
         emit("system", "turn_start", {})
 
         for iteration in range(self._max_iterations):
+            # Surface any async user input queued since the last model call so
+            # an unprompted remark gets folded into the in-flight turn instead
+            # of being dropped.
+            if interrupt_source is not None and not interrupt_source.empty():
+                drained = await interrupt_source.drain()
+                if drained:
+                    joined = " / ".join(drained)
+                    messages.append(
+                        self._backend.make_user_message(f"[User interrupted]: {joined}")
+                    )
+                    emit("user", "interrupt", {"count": len(drained), "text": joined})
+
+            # Let hooks inject per-iteration context (inner-voice notes, gentle
+            # reminders). Blocks are spliced into this iteration's system prompt
+            # so message-role alternation stays valid after tool results.
+            iter_system = system
+            if context is not None and self._hooks:
+                extra_blocks: list[ContextBlock] = []
+                for hook in self._hooks:
+                    extra_blocks.extend(await hook.mid_turn_inject(context, iteration))
+                if extra_blocks:
+                    rendered = "\n\n".join(block.rendered_text() for block in extra_blocks)
+                    iter_system = _with_extra_system(system, rendered)
+
             emit("model", "model_request_start", {"iteration": iteration + 1})
             result, raw_content = await self._backend.stream_turn(
-                system=system,
+                system=iter_system,
                 messages=messages,
                 tools=self._tools.tool_defs(),
                 max_tokens=max_tokens,
                 on_text=on_text,
             )
             # Allow hooks to inspect or replace the raw model result. The
-            # first hook to return a non-None value wins, and subsequent
-            # hooks observe the replacement.
+            # first hook to return a non-None ``ModelTurnResult`` wins, and
+            # subsequent hooks observe the replacement. A hook may instead
+            # return a ``RetryDecision`` to reject the reply and re-run the
+            # loop with an injected correction message.
+            retry_directive: RetryDecision | None = None
             if context is not None:
                 for hook in self._hooks:
-                    replacement = await hook.after_model_result(context, result)
-                    if replacement is not None:
-                        result = replacement
+                    outcome = await hook.after_model_result(context, result)
+                    if isinstance(outcome, RetryDecision):
+                        retry_directive = outcome
+                    elif outcome is not None:
+                        result = outcome
             input_tokens += result.input_tokens
             output_tokens += result.output_tokens
             emit(
@@ -116,6 +165,21 @@ class ReActLoop:
                     "tool_calls": [tool_call.name for tool_call in result.tool_calls],
                 },
             )
+
+            if retry_directive is not None and retry_directive.retry:
+                # Keep the rejected reply in history for context, then splice the
+                # correction and continue the loop instead of finishing the turn.
+                messages.append(self._backend.make_assistant_message(result, raw_content))
+                if retry_directive.inject_user_message:
+                    messages.append(
+                        self._backend.make_user_message(retry_directive.inject_user_message)
+                    )
+                emit(
+                    "system",
+                    "retry",
+                    {"iteration": iteration + 1, "stop_reason": result.stop_reason},
+                )
+                continue
 
             if result.stop_reason == "end_turn":
                 messages.append(self._backend.make_assistant_message(result, raw_content))

--- a/src/familiar_runtime/runtime.py
+++ b/src/familiar_runtime/runtime.py
@@ -30,15 +30,12 @@ class TurnContext:
 class RetryDecision:
     """Hook-returnable directive for re-running a turn iteration.
 
-    Reserved shape for the upcoming embodied agent thin-wrap (see PR3 in
-    ``plans/familiar-ai-codex-usage-limit-3-familia-agile-castle.md``).
     A hook's ``after_model_result`` can return one of these to tell the
     ReAct loop to reject the model's reply, splice an inserted user
     message back into history, and continue the loop instead of finishing
-    the turn.
-
-    The runtime does NOT yet honour ``RetryDecision`` returns from hooks;
-    this PR only pins the shape so callers can rely on it.
+    the turn (e.g. a coherence gate that found a logical error). The loop
+    honours ``retry=True`` by keeping the rejected reply in history,
+    injecting ``inject_user_message`` when set, and looping again.
     """
 
     retry: bool = False
@@ -48,13 +45,9 @@ class RetryDecision:
 class InterruptSource(Protocol):
     """Polling shim a profile can hand the runtime to surface async user input.
 
-    Reserved shape for the upcoming embodied agent thin-wrap (see PR3).
-    The neighbour profile drains an ``asyncio.Queue`` between ReAct
-    iterations so unprompted user remarks get folded into the in-flight
-    turn rather than dropped on the floor.
-
-    The runtime does NOT yet poll any ``InterruptSource``; this PR only
-    pins the shape so callers can rely on it.
+    The ReAct loop drains the source between iterations so unprompted user
+    remarks (e.g. items pushed onto an ``asyncio.Queue``) get folded into
+    the in-flight turn rather than dropped on the floor.
     """
 
     async def drain(self) -> list[str]:
@@ -73,11 +66,10 @@ class RuntimeHook(Protocol):
     All callbacks are optional in spirit: implementations may inherit from
     :class:`RuntimeHookBase` for safe no-op defaults.
 
-    ``mid_turn_inject`` is a *reserved* hook slot (see PR3 plan): the
-    runtime declares it for type-stability and the base class returns ``[]``,
-    but the ReAct loop does not yet call it.  PR3 wires the call into
-    :class:`ReActLoop` so profiles can inject per-iteration ``ContextBlock``
-    extras (e.g. inner-voice notes, say() reminders).
+    ``mid_turn_inject`` is called by :class:`ReActLoop` once per iteration so
+    profiles can inject per-iteration ``ContextBlock`` extras (e.g. inner-voice
+    notes, say() reminders); the blocks are spliced into that iteration's
+    system prompt.
     """
 
     async def before_turn(self, ctx: TurnContext) -> None: ...
@@ -94,7 +86,7 @@ class RuntimeHook(Protocol):
         self,
         ctx: TurnContext,
         result: ModelTurnResult,
-    ) -> ModelTurnResult | None: ...
+    ) -> ModelTurnResult | RetryDecision | None: ...
 
     async def after_tool_result(
         self,
@@ -126,7 +118,7 @@ class RuntimeHookBase:
         self,
         ctx: TurnContext,  # noqa: ARG002
         result: ModelTurnResult,  # noqa: ARG002
-    ) -> ModelTurnResult | None:
+    ) -> ModelTurnResult | RetryDecision | None:
         return None
 
     async def after_tool_result(
@@ -168,13 +160,10 @@ class AgentRuntime:
         system_prompt: str = "",
         messages: list[Any] | None = None,
         max_tokens: int = 4096,
-        interrupt_source: InterruptSource | None = None,  # noqa: ARG002
+        interrupt_source: InterruptSource | None = None,
     ) -> RunTurnResult:
-        # ``interrupt_source`` is a reserved parameter (see PR3 plan): the
-        # runtime accepts it now so the embodied agent thin-wrap can pass
-        # an ``asyncio.Queue`` adapter without breaking its call site, but
-        # ReActLoop does not yet poll it.  The arg is intentionally not
-        # surfaced into TurnContext until the polling is wired up.
+        # ``interrupt_source`` is polled by the ReAct loop between iterations so
+        # async user input gets folded into the in-flight turn (see ReActLoop.run).
         ctx = TurnContext(user_input=user_input, profile=profile, task_id=task_id)
         for hook in self._hooks:
             await hook.before_turn(ctx)
@@ -207,6 +196,7 @@ class AgentRuntime:
             max_tokens=max_tokens,
             task_id=task_id,
             context=ctx,
+            interrupt_source=interrupt_source,
         )
         for hook in self._hooks:
             await hook.after_turn(ctx, result.final_text)

--- a/tests/test_runtime_hooks.py
+++ b/tests/test_runtime_hooks.py
@@ -210,12 +210,12 @@ async def test_interrupt_source_protocol_acceptable_shape() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_turn_accepts_interrupt_source_without_polling() -> None:
-    """PR2 only reserves the parameter; passing one must not change behaviour."""
+async def test_empty_interrupt_source_is_not_drained() -> None:
+    """An empty source is checked via empty() and never drained."""
 
     class _StubSource:
         async def drain(self) -> list[str]:
-            raise AssertionError("PR2 must not poll the interrupt source yet")
+            raise AssertionError("empty() guards the drain; drain must not run")
 
         def empty(self) -> bool:
             return True
@@ -228,29 +228,138 @@ async def test_run_turn_accepts_interrupt_source_without_polling() -> None:
 
 
 @pytest.mark.asyncio
-async def test_mid_turn_inject_is_reserved_but_not_yet_called() -> None:
-    """RuntimeHook declares mid_turn_inject, but ReActLoop will not call it until PR3."""
+async def test_interrupt_source_drains_into_messages() -> None:
+    """A non-empty source is drained and folded into the turn as a user message."""
 
-    class _Tripwire(RuntimeHookBase):
+    class _OneShotSource:
+        def __init__(self, items: list[str]) -> None:
+            self._items = list(items)
+
+        async def drain(self) -> list[str]:
+            out = self._items
+            self._items = []
+            return out
+
+        def empty(self) -> bool:
+            return not self._items
+
+    backend = _ScriptedBackend([ModelTurnResult(stop_reason="end_turn", text="done")])
+    registry = ToolRegistry()
+    runtime = AgentRuntime(backend=backend, tools=registry, hooks=[])
+    messages: list[Any] = []
+    result = await runtime.run_turn(
+        "go",
+        messages=messages,
+        interrupt_source=_OneShotSource(["hey wait", "look here"]),
+    )
+    assert result.final_text == "done"
+    injected = [
+        m
+        for m in messages
+        if m.get("role") == "user" and "[User interrupted]" in str(m.get("content"))
+    ]
+    assert injected
+    assert "hey wait / look here" in str(injected[0]["content"])
+
+
+@pytest.mark.asyncio
+async def test_mid_turn_inject_called_each_iteration() -> None:
+    """ReActLoop calls mid_turn_inject once per model iteration."""
+
+    class _Counter(RuntimeHookBase):
         def __init__(self) -> None:
-            self.calls = 0
+            self.iterations: list[int] = []
 
         async def mid_turn_inject(
             self,
             ctx: TurnContext,
             iteration: int,
         ) -> list[ContextBlock]:
-            self.calls += 1
+            self.iterations.append(iteration)
             return []
 
-    tripwire = _Tripwire()
+    counter = _Counter()
     runtime, _ = _build_runtime(
-        turns=[ModelTurnResult(stop_reason="end_turn", text="ok")],
-        hooks=[tripwire],
+        turns=[
+            ModelTurnResult(
+                stop_reason="tool_use",
+                text="",
+                tool_calls=[ToolCall(id="tc1", name="echo", input={"text": "x"})],
+            ),
+            ModelTurnResult(stop_reason="end_turn", text="ok"),
+        ],
+        hooks=[counter],
+        tool_provider=_EchoTool(),
     )
     await runtime.run_turn("ping")
-    # The runtime accepts the hook method but has not yet wired the call.
-    assert tripwire.calls == 0
+    # Two model iterations (one tool_use, one end_turn) → two injections.
+    assert counter.iterations == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_mid_turn_inject_blocks_injected_into_system() -> None:
+    """Blocks returned from mid_turn_inject are spliced into the iteration system."""
+    captured_systems: list[Any] = []
+
+    class _SystemCapturingBackend(_ScriptedBackend):
+        async def stream_turn(self, **kwargs: Any) -> tuple[ModelTurnResult, Any]:
+            captured_systems.append(kwargs["system"])
+            return await super().stream_turn(**kwargs)
+
+    class _Injector(RuntimeHookBase):
+        async def mid_turn_inject(
+            self,
+            ctx: TurnContext,
+            iteration: int,
+        ) -> list[ContextBlock]:
+            return [ContextBlock(source="inner", text="[inner] keep it short", priority=1.0)]
+
+    backend = _SystemCapturingBackend([ModelTurnResult(stop_reason="end_turn", text="ok")])
+    registry = ToolRegistry()
+    runtime = AgentRuntime(backend=backend, tools=registry, hooks=[_Injector()])
+    await runtime.run_turn("ping", system_prompt="BASE")
+    assert captured_systems
+    assert "[inner] keep it short" in str(captured_systems[0])
+
+
+@pytest.mark.asyncio
+async def test_after_model_result_retry_decision_continues_loop() -> None:
+    """A RetryDecision from after_model_result rejects the reply and re-runs the loop."""
+
+    class _CoherenceGate(RuntimeHookBase):
+        def __init__(self) -> None:
+            self.seen = 0
+
+        async def after_model_result(
+            self,
+            ctx: TurnContext,
+            result: ModelTurnResult,
+        ) -> ModelTurnResult | RetryDecision | None:
+            self.seen += 1
+            if self.seen == 1:
+                return RetryDecision(
+                    retry=True,
+                    inject_user_message="[SELF-CHECK] fix the contradiction.",
+                )
+            return None
+
+    gate = _CoherenceGate()
+    backend = _ScriptedBackend(
+        [
+            ModelTurnResult(stop_reason="end_turn", text="bad answer"),
+            ModelTurnResult(stop_reason="end_turn", text="good answer"),
+        ]
+    )
+    registry = ToolRegistry()
+    runtime = AgentRuntime(backend=backend, tools=registry, hooks=[gate])
+    messages: list[Any] = []
+    result = await runtime.run_turn("hi", messages=messages)
+    assert result.final_text == "good answer"
+    assert gate.seen == 2
+    injected = [
+        m for m in messages if m.get("role") == "user" and "[SELF-CHECK]" in str(m.get("content"))
+    ]
+    assert injected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The three RuntimeHook shapes reserved in #172 (`mid_turn_inject` / `InterruptSource` / `RetryDecision`) were declared but inert — the runtime docstrings said *"does NOT yet … this PR only pins the shape"* and two tripwire tests guarded against them firing. This PR activates them in the generic `familiar_runtime` substrate so a profile's `RuntimeHook` can actually participate per-iteration.

Scope is intentionally confined to `familiar_runtime` + the structural `EmbodiedAgentHook` tweak. **`EmbodiedAgent.run()` is untouched** (it keeps its own loop); routing it through `AgentRuntime.run_turn` end-to-end remains a follow-up.

## Changes

- **`mid_turn_inject`** — `ReActLoop` calls it once per model iteration and splices returned `ContextBlock`s into *that iteration's* system prompt via a `(stable, variable)`-aware helper (`_with_extra_system`), so a cached tuple prompt keeps its `cache_control`-eligible stable prefix. Splicing into `system` rather than appending a user message keeps message-role alternation valid after `tool_results`.
- **`interrupt_source`** — `run_turn` now forwards it to `ReActLoop.run`, which drains a non-empty source between iterations and folds the input in as a user message (`[User interrupted]: …`). Empty sources are guarded by `empty()` and never drained.
- **`RetryDecision`** — `after_model_result` may now return a `RetryDecision`; `retry=True` keeps the rejected reply in history, injects `inject_user_message`, and re-runs the loop instead of finishing the turn (the coherence-gate pattern).
- **`EmbodiedAgentHook`** now subclasses `RuntimeHookBase`, making it a structural `RuntimeHook` (inherits no-op lifecycle defaults). No behavior change — it still drives the embodied turn via `prepare_turn` / `commit_after_end_turn`.
- Docstrings updated to drop the "reserved / not yet wired" language.

## Tests

- The two #172 tripwires are replaced/repurposed to assert the **live** behavior:
  - `test_mid_turn_inject_is_reserved_but_not_yet_called` → `test_mid_turn_inject_called_each_iteration`
  - `test_run_turn_accepts_interrupt_source_without_polling` → `test_empty_interrupt_source_is_not_drained`
- New positive coverage: `test_interrupt_source_drains_into_messages`, `test_mid_turn_inject_blocks_injected_into_system`, `test_after_model_result_retry_decision_continues_loop`.

## Validation

- `uv run ruff check .` ✅
- `uv run ruff format --check .` ✅
- `uv run --group dev mypy src/familiar_agent src/familiar_runtime src/familiar_capabilities src/familiar_neighbor` ✅ (no issues, 111 files)
- `uv run pytest -q` ✅ **985 passed**

## Follow-up (not in this PR)

Route `EmbodiedAgent.run()` through `AgentRuntime.run_turn`, moving `prepare_turn` / `commit_after_end_turn` + the four inline behaviors (TAPE replan, coherence retry, interrupt drain, say reminder) onto `EmbodiedAgentHook`'s lifecycle methods. High-risk (touches the 23 `test_agent_react_loop.py` tests + fragile loop behaviors) — left for a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)