### PR TITLE
feat: secretary layer (commitments + proactive reminders) and social accumulation (person model + learned policy)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,154 +1,147 @@
-# familiar-ai — Developer Guide
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project overview
 
 familiar-ai is an embodied companion agent. It combines:
 
-- a ReAct tool loop
+- a provider-neutral ReAct tool loop
 - local SQLite memory
-- prediction / workspace / self-state layers
-- explicit relationship, appraisal, social policy, and drive regulation
+- prediction / workspace / self-state cognition layers
+- explicit relationship, appraisal, social policy, and drive (desire) regulation
 - optional camera, mobility, TTS, STT, GUI, and MCP integrations
 
-The codebase is backend-agnostic. Anthropic is supported, but it is no longer the only runtime path.
+The codebase is backend-agnostic. Anthropic is supported, but it is one of several
+provider adapters — not the only runtime path.
 
-## Source tree
+## Commands
 
-```text
-src/familiar_agent/
-├── agent.py              # Main embodied turn loop
-├── appraisal.py          # Low-dimensional affect updates
-├── attention_schema.py   # Recent focus / attention state
-├── backend.py            # LLM backend protocol + implementations
-├── bootstrap.py          # Startup/setup/configured-state handling
-├── concern_engine.py     # Active unfinished concerns
-├── config.py             # Runtime config objects
-├── default_mode.py       # Idle/default-mode memory processing
-├── desires.py            # Autonomous drives + drive selection
-├── diagnostics.py        # GUI diagnostics and connection tests
-├── gui.py                # GTK GUI
-├── heartbeat.py          # Continuation/runtime status logic
-├── interoception.py      # Interoception providers + semantic pressure
-├── main.py               # CLI entry point / mode selection
-├── mental_state.py       # Mental-state bus and JSONL snapshots
-├── meta_monitor.py       # Metacognitive logging + response gating
-├── prediction.py         # Prediction error / agency error
-├── relationship.py       # Longitudinal relationship state
-├── routines.py           # Quiet-hours / routine config helpers
-├── self_narrative.py     # Session-spanning autobiographical narrative
-├── self_state.py         # Persistent latent bodily state
-├── setup.py              # Setup flow, env migration, validation
-├── social_policy.py      # Speech-act classification + response mode
-├── sqlite_migrations.py  # Migration runner
-├── tools/
-│   ├── camera.py
-│   ├── coding.py
-│   ├── memory.py
-│   ├── mic.py
-│   ├── mobility.py
-│   ├── realtime_stt.py
-│   ├── stt.py
-│   ├── tom.py
-│   └── tts.py
-├── tui.py                # Text UI
-├── voice_guard.py        # TTS/STT loop prevention
-└── workspace.py          # Coalition competition / broadcast
+```bash
+# Run the app (CLI entry point — defined in pyproject [project.scripts])
+uv run familiar
+
+# Discover ONVIF/Tapo cameras on the LAN
+uv run familiar-discover-cameras
+
+# Tests (pytest-asyncio; ~990 tests)
+uv run pytest -q
+uv run pytest -q tests/test_runtime_hooks.py            # one file
+uv run pytest -q tests/test_runtime_hooks.py::test_name # one test
+uv run pytest -q -k "interrupt"                          # by keyword
+
+# Lint / format / types — the full pre-merge gate
+uv run ruff check .
+uv run ruff format --check .
+uv run --group dev mypy src/familiar_agent src/familiar_runtime src/familiar_capabilities src/familiar_neighbor
 ```
 
-## Runtime architecture
+Optional extras are installed by default via `[tool.uv] default-groups`
+(`dev`, `gui`, `camera`, `voice`). `torch` resolves to the CPU wheel index.
 
-The current turn flow in `agent.py` is:
+## Architecture: four packages, one app
 
-1. ingest user input and tool/scene context
-2. collect interoception
-3. read prediction state
-4. activate memory, working memory, and open episodes
-5. update provisional relationship evidence
-6. appraise affect
-7. choose social policy
-8. regulate drives
-9. run workspace competition
-10. execute the ReAct loop
-11. meta-gate the response
-12. persist post-turn traces and mental-state snapshots
+The repo is mid-migration from a single `familiar_agent` monolith toward a
+**generic runtime substrate + a persona profile**. Four packages under `src/`:
 
-The old prompt-only social logic is no longer the full story. Deterministic state layers now sit between raw input and response planning.
+| Package | Role | Depends on |
+|---|---|---|
+| `familiar_runtime` | Generic, persona-free substrate: ReAct loop, runtime facade, LLM model adapters (`models/`), tool registry, memory/events/tasks stores, generic prompt fragments | nothing in-repo |
+| `familiar_capabilities` | Thin `ToolProvider` adapters wrapping `familiar_agent` tools so the runtime can register them (camera, coding, mcp, memory, mobility, tom, voice) | runtime, agent tools |
+| `familiar_neighbor` | The "neighbor" persona on the substrate: `NeighborProfile` (`app.py`), `EmbodiedAgentHook` (`embodied_hook.py`), and all cognition under `mind/` | runtime |
+| `familiar_agent` | The legacy/main application: `EmbodiedAgent` turn loop, GUI/TUI, CLI entry, concrete tool implementations, config/setup/backend factories | all of the above |
+
+**Dependency direction is one-way:** `runtime` knows nothing about personas;
+`neighbor` and `capabilities` build on `runtime`; `agent` ties everything together.
+
+### The shim pattern (read before editing cognition modules)
+
+Cognition modules were physically moved into `familiar_neighbor/mind/`, but the
+old `familiar_agent.<name>` import paths are preserved as **3-line shims**:
+
+```python
+"""Compatibility shim — implementation moved to familiar_neighbor.mind.scene."""
+from familiar_neighbor.mind.scene import *  # noqa: F401, F403
+```
+
+This applies to `scene.py`, `appraisal.py`, `mental_state.py`, `desires.py`,
+`prediction.py`, `relationship.py`, `social_policy.py`, and others. **Edit the real
+implementation in `familiar_neighbor/mind/`, not the shim.** The shims exist so the
+large body of tests and callers importing `familiar_agent.X` keep working — do not
+delete them without migrating every caller. `familiar_agent/backend.py` is a similar
+re-export surface: provider adapters live in `familiar_runtime/models/`, while
+`backend.py` keeps the historical import path plus the config-driven factory
+functions (`create_utility_backend`, `create_scene_backend`).
+
+### Runtime substrate: hooks, loop, and the in-progress migration
+
+`familiar_runtime/runtime.py` exposes `AgentRuntime.run_turn(...)`, which drives
+`familiar_runtime/react_loop.py`'s `ReActLoop`. Behavior is customized through the
+**`RuntimeHook` Protocol** (with a no-op `RuntimeHookBase`). Three hook shapes are
+wired and live:
+
+- `mid_turn_inject(ctx, iteration) -> list[ContextBlock]` — injected into the
+  per-iteration **system prompt** (not as a user message — appending a user message
+  after a tool_result would break role alternation).
+- `InterruptSource` (`drain()` / `empty()`) — polled each loop iteration; non-empty
+  drains are injected as a user message.
+- `RetryDecision` returned from `after_model_result` — appends the assistant turn,
+  injects `inject_user_message`, and continues the loop instead of finalizing.
+
+`ReActLoop.run(...)` has a **public signature that must be preserved**. The system
+prompt is `str | tuple[str, str]`, where the tuple is `(stable, variable)` — the
+Anthropic adapter's `cache_control` depends on this shape. Use `_with_extra_system`
+to append to the variable half.
+
+**Important caveat:** `EmbodiedAgent.run()` in `familiar_agent/agent.py` (~2400 lines)
+still runs its **own** ReAct loop and has not yet been routed through
+`AgentRuntime.run_turn`. `EmbodiedAgentHook` already structurally implements
+`RuntimeHook` but currently drives the agent via `prepare_turn` /
+`commit_after_end_turn`. Routing `EmbodiedAgent.run()` through the substrate is the
+known next step — it is **high-risk** (touches the TAPE replan / coherence retry /
+interrupt drain / say-reminder loop internals and ~23 `test_agent_react_loop.py`
+tests) and should not be attempted without explicit confirmation.
+
+### Turn flow (conceptual)
+
+ingest input → interoception → prediction state → activate memory / working memory /
+open episodes → relationship evidence → appraise affect → social policy → drive
+regulation → workspace competition → ReAct loop → meta-gate response → persist
+traces + mental-state snapshot.
 
 ## Persistence
 
-Primary persistent stores:
+Primary stores under `~/.familiar_ai/`:
 
-- `~/.familiar_ai/observations.db`
-  - observations
-  - embeddings
-  - semantic facts
-  - behavior policies
-  - revisions
-  - episodes
-  - episode membership
-  - memory activation
-  - unfinished business
-  - relationship state
-- `~/.familiar_ai/mental_state.jsonl`
-  - append-only mental-state snapshots
-- `~/.familiar_ai/heartbeat_state.json`
-  - continuation / carryover status
-- `~/.familiar_ai/desires.json`
-  - drive levels
-- `~/.familiar_ai/self_state.json`
-  - latent bodily carryover
+- `observations.db` — observations, embeddings, semantic facts, behavior policies,
+  revisions, episodes + membership, memory activation, unfinished business,
+  relationship state, memory graph
+- `mental_state.jsonl` — append-only mental-state snapshots
+- `heartbeat_state.json` — continuation / carryover status
+- `desires.json` — drive levels
+- `self_state.json` — latent bodily carryover
+- `relationship.json` — legacy; imported once if present, then SQLite is authoritative
 
-Legacy compatibility:
-
-- `~/.familiar_ai/relationship.json`
-  - imported once if present, then SQLite becomes authoritative
-
-Schema changes must go through timestamped files under `migration/`.
+**Every schema change must add a timestamped migration under `migration/`**
+(e.g. `2026-04-15-008_memory_graph_runtime.py`) with migration test coverage.
+SQLite stays the primary storage.
 
 ## Development rules
 
-- Python 3.10+
-- Async-first style
-- SQLite stays the primary storage
-- Prefer deterministic logic and typed dataclasses over giant prompt blobs
-- Do not leak raw interoception/body metrics into normal user-facing text
-- Keep compatibility for existing memory DBs; add migrations for every schema change
-
-## Validation before merge
-
-Run before opening a PR:
-
-```bash
-uv run ruff check .
-uv run --group dev mypy src/familiar_agent
-uv run pytest -q
-```
+- Python 3.10+, async-first style
+- Prefer deterministic, typed dataclasses over giant prompt blobs
+- Do not leak raw interoception / body metrics into user-facing text
+- Keep compatibility for existing memory DBs (migrations, not breaking changes)
+- When adding a tool, wire all three: implementation (`familiar_agent/tools/` or a
+  capability), agent registration / routing, and tests
+- When changing social behavior, prefer appraisal / social-policy / meta-gate logic
+  first; only extend prompt instructions when state logic is insufficient
+- Prompt changes that must stay byte-stable are pinned by SHA-256 in
+  `tests/test_prompt_assembly.py` — update the pin only when output legitimately changes
 
 ## Git workflow
 
-- Work from `develop`
-- Cut a feature branch before changes
-- Open focused PRs into `develop`
-- Use Conventional Commits in English
-
-Examples:
-
-```text
-feat(memory): add episode compression to recall
-fix(agent): gate raw interoception leakage
-docs: refresh technical architecture guide
-```
-
-## Editing guidance
-
-- When adding a tool, wire all three places:
-  - tool implementation
-  - agent registration / routing
-  - tests
-- When changing state or persistence:
-  - add a migration
-  - add migration coverage
-  - update docs
-- When changing social behavior:
-  - prefer appraisal / social policy / meta gate logic first
-  - only extend prompt instructions when state logic is insufficient
+- Work from `develop`; cut a feature branch before changes; open focused PRs into `develop`
+- Conventional Commits in English, e.g. `feat(runtime): wire interrupt polling into ReActLoop`
+- Run the full lint / format / mypy / pytest gate green before opening a PR
+- Push only the current branch explicitly; never force-push; merging is the user's decision

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,13 +109,57 @@ open episodes → relationship evidence → appraise affect → social policy �
 regulation → workspace competition → ReAct loop → meta-gate response → persist
 traces + mental-state snapshot.
 
+### Secretary layer: commitments and proactive reminders
+
+`familiar_runtime/commitments/` is the persona-neutral secretary core: a
+`Commitment` (reminder/appointment/promise/followup/task) carries an optional
+due time, priority (0-3), and snooze state in a dedicated `commitments.db`
+(self-init schema + idempotent `ALTER` migration in `_ensure_columns`, NOT the
+`migration/` runner). `CommitmentTool` (`familiar_agent/tools/commitments.py`)
+exposes add/list/complete/snooze; due + upcoming items surface passively into
+every turn's continuity context, and a `[Today's agenda]` block joins the
+first-turn morning reconstruction.
+
+**Proactive reminders** make due commitments fire self-initiated turns from the
+three idle loops (REPL `main.py`, TUI `_reminder_tick`, GUI `_process_queue`).
+Invariants to preserve when touching these loops:
+
+- The reminder branch sits **before** the `auto_desire` guard — the
+  `proactive_reminders` toggle (`FAMILIAR_PROACTIVE_REMINDERS`, default ON) is
+  independent of `auto_desire`.
+- Idle precedence is user input > reminder > desire > idle
+  (`decide_idle_action` in `_ui_helpers.py` is the tested reference
+  implementation; the loops inline it).
+- `mark_reminded` is called **before** the turn runs, so a mid-turn snooze
+  cadence reset survives and error turns still burn a capped slot. Cadence:
+  escalating backoff (600s × {1,3}) capped at 3 reminders, then quiet; quiet
+  hours (23-7) pass only priority>=2.
+- `repl()`'s finally block calls `os._exit(0)` — tests touching it must patch
+  `familiar_agent.main.os._exit` or pytest dies silently.
+
+### Social accumulation: person model and learned policy
+
+- `familiar_neighbor/mind/person_model.py` persists ToM inferences per person
+  (`person_inferences` table, migration 010). The ToM tool writes back
+  successful structured inferences; the accumulated `[Person model]` block is
+  injected next to the relationship context. Person keys are canonicalized to
+  the companion name (case-insensitive) — keep writes keyed consistently or
+  rows silently stop surfacing.
+- `SocialPolicyEngine.decide()` consumes `failed_support_patterns` /
+  `support_preferences` from the RelationshipTracker (wired in
+  `embodied_hook.prepare_turn` via `relationship_learning_inputs`): distress
+  acts surface the relational memory and soften; explicit advice requests force
+  ToM on with gentler delivery. Defaults keep historical decisions byte-stable.
+
 ## Persistence
 
 Primary stores under `~/.familiar_ai/`:
 
 - `observations.db` — observations, embeddings, semantic facts, behavior policies,
   revisions, episodes + membership, memory activation, unfinished business,
-  relationship state, memory graph
+  relationship state, memory graph, person inferences
+- `commitments.db` — secretary commitments (self-init schema, outside the
+  `migration/` runner)
 - `mental_state.jsonl` — append-only mental-state snapshots
 - `heartbeat_state.json` — continuation / carryover status
 - `desires.json` — drive levels

--- a/migration/2026-06-11-010_person_inferences.py
+++ b/migration/2026-06-11-010_person_inferences.py
@@ -1,0 +1,26 @@
+"""Persistent per-person mental-model inferences (ToM accumulation)."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def upgrade(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS person_inferences (
+            id TEXT PRIMARY KEY,
+            person TEXT NOT NULL,
+            state TEXT NOT NULL,
+            confidence REAL NOT NULL DEFAULT 0.0,
+            evidence_json TEXT NOT NULL DEFAULT '[]',
+            policy TEXT NOT NULL DEFAULT '',
+            source TEXT NOT NULL DEFAULT 'tom',
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_person_inferences_person "
+        "ON person_inferences(person, created_at DESC)"
+    )

--- a/plans/secretary-and-social-foundation.md
+++ b/plans/secretary-and-social-foundation.md
@@ -138,4 +138,46 @@ uv run pytest -q
 - [x] Phase 4: Person Model（person_inferences + PersonModelTracker + ToM 書き戻し + prompt surface）
 - [x] Phase 5: 社会的学習ループ（failed patterns → decide() 補正、契約テスト付き）
 
-push は未実施（コウタ判断）。全5フェーズ完了。
+push は未実施（コウタ判断）。全5フェーズ完了 + アジェンダ + staleness カットオフ + CLAUDE.md 更新。
+
+---
+
+## PR ドラフト（コウタ用 — push 後にそのまま使える）
+
+**タイトル:** `feat: secretary layer (commitments + proactive reminders) and social accumulation (person model + learned policy)`
+
+**本文:**
+
+```markdown
+## Summary
+
+Two pillars toward "more human, more socially capable":
+
+**Secretary layer** — the agent can now hold commitments (reminders,
+appointments, promises, follow-ups) with due times and priorities, surface
+them passively in every turn, proactively speak up when they come due
+(independent of auto_desire, FAMILIAR_PROACTIVE_REMINDERS, default ON,
+quiet-hours aware, escalating backoff capped at 3), and open the day with a
+[Today's agenda] block on the first turn.
+
+**Social accumulation** — ToM inferences now persist per person
+(person_inferences, migration 010) and surface as an accumulated
+[Person model] block (7-day staleness cutoff); recorded support failures
+and preferences now feed back into SocialPolicyEngine.decide() so the same
+support misstep is not repeated.
+
+## Hardening
+
+All three idle loops were wired through multi-agent adversarial review;
+11 confirmed findings fixed and re-verified, including: mark-before-run
+(mid-turn snooze survives), TUI concurrent agent.run race (re-queue for
+interrupt drain), REPL silent-death via os._exit(0) on backend errors,
+person-key fragmentation (canonicalization + COLLATE NOCASE).
+
+## Tests
+
++86 tests across store cadence/backoff, legacy-DB migration, idle-loop
+wiring (REPL/TUI/GUI), config independence, person-model roundtrip and
+writeback isolation, social-policy learning invariance. Full suite
+1069 passed; ruff/format/mypy green.
+```

--- a/plans/secretary-and-social-foundation.md
+++ b/plans/secretary-and-social-foundation.md
@@ -106,11 +106,18 @@ markdown に平坦化して捨てている（`_last_policy` のみ揮発保持�
 
 ---
 
-## Phase 5 — 社会的学習ループを閉じる
+## Phase 5 — 社会的学習ループを閉じる（実装済 ✅）
 
-- `relationship.failed_support_patterns` / 成功パターンを `SocialPolicyEngine.decide()` の入力に追加し、response_mode 選択を補正。
-- 「以前これで失敗した」を避け「効いた」を優先。
-- テスト: 同一状況で過去失敗パターンが response_mode を変えること。
+記録するだけで参照されなかった `failed_support_patterns` / `support_preferences` を
+`SocialPolicyEngine.decide()` に接続。決定論補正 `_apply_relationship_learning`:
+- アドバイス系失敗履歴（advice/solution/正論/説教 等のマーカー）or validate-first 系 style を検知したら:
+  - distress 系 act（venting/fatigue/grief/conflict）→ `should_recall_relational_memory=True`
+    （relational ctx に失敗パターンが描画されるのでモデルが「前に失敗したこと」を見る）+ softness 微増
+  - 明示的依頼（request_for_advice/action）→ 依頼は尊重しつつ `should_use_tom=True` +
+    directness 減・softness 増（validate-first な伝え方へ）
+- `relationship_learning_inputs()` が Tracker のアイテム形状（style / pattern|evidence）を吸収（契約テスト付き）
+- `embodied_hook.prepare_turn` の decide() 呼び出しに配線
+- テスト +7（無履歴で不変・和文マーカー・無関係パターン不発・契約）
 
 ---
 
@@ -127,9 +134,8 @@ uv run pytest -q
 
 - [x] Phase 1: Commitment ストア + tests（9件）
 - [x] Phase 2: tool + capability + 配線 + surface + tests（13件）
-- [x] Phase 3: 自発的リマインド（独立トグル・quiet hours・escalating backoff+cap、3ループ配線）
-- [ ] Phase 4: Person Model（設計確定済、上記参照）
-- [ ] Phase 5: 社会的学習ループ
+- [x] Phase 3: 自発的リマインド（独立トグル・quiet hours・escalating backoff+cap、3ループ配線、レビュー10件全修正）
+- [x] Phase 4: Person Model（person_inferences + PersonModelTracker + ToM 書き戻し + prompt surface）
+- [x] Phase 5: 社会的学習ループ（failed patterns → decide() 補正、契約テスト付き）
 
-Phase 3 時点: フルスイート **1032 passed**、ruff/format(236)/mypy(116) 緑。
-push は未実施（コウタ判断）。
+push は未実施（コウタ判断）。全5フェーズ完了。

--- a/plans/secretary-and-social-foundation.md
+++ b/plans/secretary-and-social-foundation.md
@@ -176,8 +176,8 @@ person-key fragmentation (canonicalization + COLLATE NOCASE).
 
 ## Tests
 
-+86 tests across store cadence/backoff, legacy-DB migration, idle-loop
++87 tests across store cadence/backoff, legacy-DB migration, idle-loop
 wiring (REPL/TUI/GUI), config independence, person-model roundtrip and
 writeback isolation, social-policy learning invariance. Full suite
-1069 passed; ruff/format/mypy green.
+1070 passed; ruff/format/mypy green.
 ```

--- a/plans/secretary-and-social-foundation.md
+++ b/plans/secretary-and-social-foundation.md
@@ -60,19 +60,49 @@ complete, priority+due 並び順, cancelled 除外。
 
 ---
 
-## Phase 3 — 自発的リマインド（due 検知 → proactive surface）
+## Phase 3 — 自発的リマインド（実装済 ✅）
 
-- `heartbeat` / continuation に「due commitment があれば次ターンで必ず言及 / 自発ターンを誘発」を接続。
-- quiet hours（`routines.py`）尊重: quiet 中は緊急(priority>=2)以外は抑制。
-- テスト: due ありで continuation/desire turn が誘発されること、quiet 中の抑制。
+ユーザ確定: トグル独立・既定ON / quiet hours は priority>=2 のみ / だんだん間隔を空けて止まる。
+
+- model: `last_reminded_at` / `reminder_count` / `due_for_reminder()`（backoff base×{1,3}, REMINDER_CAP=3 で沈黙。passive surface は継続）
+- store: `_ensure_columns()` idempotent ALTER / `list_due_for_reminder` / `mark_reminded`（targeted UPDATE）/ `snooze` で cadence リセット
+- config: `AgentConfig.proactive_reminders`（`FAMILIAR_PROACTIVE_REMINDERS`、既定 True、auto_desire 独立）+ settings_schema（advanced/bool）
+- i18n: `reminder_impulse`（en/ja、他言語 en フォールバック）。complete/snooze ツール呼び出しまで指示
+- `_ui_helpers`: `should_fire_commitment_reminder`（純粋ゲート: running/pending/idle-gap/quiet-priority）/ `commitment_reminder_prompt` / `decide_idle_action`
+- 3ループ配線: main repl / tui `_reminder_tick` / gui `_process_queue` — いずれも **auto_desire ガードの前**
+- テスト +33（store cadence・legacy DB 移行・ゲート全分岐・config 独立性・3ループ配線統合・mark-before-run 固定）
+
+**多角レビュー（4次元×敵対検証）→ 確定 10 findings を全修正:**
+- `mark_reminded` を**ターン前**に移動（3ループ）— ターン中の snooze による cadence リセットを保護、
+  失敗時セマンティクス統一（エラーでもスロット消費 → flapping backend が cap で自己制限）
+- TUI 二重 `agent.run` レース: `_process_queue` が `get()` 後に `_agent_running` ならキューへ差し戻し
+  （実行中ターンが interrupt_queue 経由で吸収）
+- REPL: reminder turn とゲート＋mark を try/except 保護（裸だと finally の `os._exit(0)` で silent death）、
+  ターン後に `last_interaction_time` 更新（desire の連続発火防止）
+- GUI/TUI: tick 本体（heartbeat/store 呼び出し）を例外ガード — sqlite エラーで idle ループが恒久死しない
+- `due_for_reminder` の idx を `max(0, ...)` でクランプ + 不整合状態のテスト
+- `decide_idle_action` docstring を実態（contract の参照実装）に修正
+- 修正後に per-fix 敵対検証 7/7 resolved + completeness 残渣（mark ガード/GUI mark-before-run pin/clamp テスト）も解消
 
 ---
 
 ## Phase 4 — Person Model 永続化（社会性: ToM 蓄積）
 
-- **新規** `src/familiar_neighbor/mind/person_model.py`: 相手ごとの推定（現在ニーズ/気分/最近の懸念/コミュニケーション好み）を時系列で保持（memory DB or 専用テーブル + migration）。
-- `ToMTool` 結果を person_model に書き戻し、prompt に surface。
-- テスト + migration。
+**問題**: ToMTool の LLM 推論は構造化 JSON `{evidence, inference[{state,confidence}], policy}` を生成するのに
+markdown に平坦化して捨てている（`_last_policy` のみ揮発保持）。相手の心的モデルが蓄積されない。
+
+**設計**（RelationshipTracker の永続パターン踏襲: lazy conn + WAL + apply_migrations）:
+- migration `2026-06-XX-010_person_models.py`: `person_inferences` テーブル
+  （id TEXT PK, person TEXT, state TEXT, confidence REAL, evidence_json TEXT, policy TEXT,
+  source TEXT default 'tom', created_at TEXT ISO）+ person/created_at index。observations.db に同居。
+- **新規** `src/familiar_neighbor/mind/person_model.py` `PersonModelTracker`:
+  `record_inference(person, states, evidence, policy)` / `recent(person, n)` /
+  `context_for_prompt(person)` → `[Person model: X]` ブロック（最近の推定＋確信度＋最後に効いた方針、recency 順）
+- `ToMTool`: `_llm_inference` で JSON parse 成功時に tracker へ書き戻し（optional 依存、None なら従来挙動）
+- `agent.py`: tracker 構築 → ToMTool へ注入。`embodied_hook.prepare_turn` で companion の
+  `context_for_prompt` を relationship ctx の隣に注入
+- テスト: tracker CRUD/プロンプト整形/migration 適用（test_memory_migrations.py パターン）/
+  ToM 書き戻し（fake backend が JSON 返却）/ hook surface
 
 ---
 
@@ -97,15 +127,9 @@ uv run pytest -q
 
 - [x] Phase 1: Commitment ストア + tests（9件）
 - [x] Phase 2: tool + capability + 配線 + surface + tests（13件）
-- [ ] Phase 3: 自発的リマインド（continuation/desire-turn 機構に踏み込む。慎重に）
-- [ ] Phase 4: Person Model
+- [x] Phase 3: 自発的リマインド（独立トグル・quiet hours・escalating backoff+cap、3ループ配線）
+- [ ] Phase 4: Person Model（設計確定済、上記参照）
 - [ ] Phase 5: 社会的学習ループ
 
-本セッション: Phase 1–2 完遂。フルスイート **1007 passed**（+22）、ruff/format/mypy(116) 緑。
-秘書の動く核（期日・優先度付き commitment を保存し、due になればターン文脈へ自動 surface）。
-
-### Phase 3 設計メモ（次セッション）
-due commitment があるとき、ユーザ入力が無くても自発ターンを誘発する。
-`heartbeat`/desire-turn の起動条件に `commitment_store.list_due(now)` を加える。
-quiet hours（`routines.py`）尊重 — quiet 中は priority>=2 のみ。
-plan の codex待ち境界に近い fragile 領域なので、コウタが見てる時にやる。
+Phase 3 時点: フルスイート **1032 passed**、ruff/format(236)/mypy(116) 緑。
+push は未実施（コウタ判断）。

--- a/plans/secretary-and-social-foundation.md
+++ b/plans/secretary-and-social-foundation.md
@@ -138,7 +138,9 @@ uv run pytest -q
 - [x] Phase 4: Person Model（person_inferences + PersonModelTracker + ToM 書き戻し + prompt surface）
 - [x] Phase 5: 社会的学習ループ（failed patterns → decide() 補正、契約テスト付き）
 
-push は未実施（コウタ判断）。全5フェーズ完了 + アジェンダ + staleness カットオフ + CLAUDE.md 更新。
+**PR #175 作成済み**（https://github.com/lifemate-ai/familiar-ai/pull/175、develop 向け）。
+CI 全緑（lint + test macos/ubuntu/windows）。**merge はコウタ判断。**
+全5フェーズ完了 + アジェンダ + staleness カットオフ + CLAUDE.md 更新 + レビュー指摘全消化。
 
 ---
 

--- a/plans/secretary-and-social-foundation.md
+++ b/plans/secretary-and-social-foundation.md
@@ -1,0 +1,111 @@
+# familiar-ai 基盤強化 — 秘書能力 + 社会性フィードバックループ
+
+## ゴール（ユーザ設定）
+
+> より人間らしく、あるいは社会性高く振る舞えるような基盤にしたい。
+> それにあたって、タスク遂行エージェントとしての能力も欲しい。特に秘書的な振る舞い。
+
+## 現状分析（調査済み）
+
+### 既にあるもの
+- **社会性（`familiar_neighbor/mind/`）**: appraisal（PAD感情）/ social_policy（17発話行為×13応答モード）/ relationship（trust/intimacy + 傾向/境界/儀式）/ meta_monitor（応答ゲート）/ workspace（GWT競争）/ tom（ToM tool）/ scene（世界モデル）。豊富だが **一方向フロー**（入力→appraise→decide→出力）。
+- **タスク**: `familiar_runtime/tasks/`（Task + checkpoint, 独自 `runtime_tasks.db`, self-init schema）。task-mode CLI 専用。
+- **やり残し**: `ConcernEngine`（感情的テーマ, 自動decay, JSON）/ `unfinished_business`（memory DB, prompt に最大3件 surface）。
+
+### 欠けているギャップ
+1. **秘書の核がない**: 期日・優先度を持ち、due になったら**自発的に思い出す**「約束・予定・リマインダ」レイヤが無い。Task は期日/優先度/リマインダを持たず、プロンプトにも出ない。
+2. **社会的学習ループが閉じてない**: `relationship.failed_support_patterns` を記録しても `social_policy.decide()` が参照せず、過去の失敗/成功が応答選択に反映されない。
+3. **相手モデルが蓄積されない**: ToM は毎回 recall して推論するだけ。persistent な person model が無い。
+
+## 設計方針
+
+- 秘書能力は **persona非依存の汎用基盤** → `familiar_runtime/commitments/`（`tasks/` の先例に倣い独自DB self-init）。
+- 社会性強化は **既存 mind/ レイヤの結線追加**（決定論ロジック優先、プロンプト肥大を避ける）。
+- 各 Phase は独立 PR 相当、テスト緑を維持。TDD（RED→GREEN）。
+
+---
+
+## Phase 1 — Commitment ストア（秘書の核, 汎用基盤）✅
+
+**新規** `src/familiar_runtime/commitments/`:
+- `model.py`:
+  - `CommitmentKind(str, Enum)`: REMINDER / APPOINTMENT / PROMISE / FOLLOWUP / TASK
+  - `CommitmentStatus(str, Enum)`: OPEN / DONE / CANCELLED / SNOOZED
+  - `@dataclass Commitment`: id, summary, kind, status, due_at(float|None), priority(int 0-3),
+    created_by(str), person(str|None), created_at, updated_at, completed_at(float|None),
+    snooze_until(float|None), metadata
+  - helper: `is_due(now)`, `is_upcoming(now, horizon)`, `effective_due()`
+- `store.py` `SQLiteCommitmentStore`（独自 `commitments.db`, self-init）:
+  - create / save / get / update_status / complete / snooze / cancel
+  - list_open / list_due(now) / list_upcoming(now, horizon)
+  - 並び順: due_at（NULL は後ろ）, priority 降順, created_at
+- `__init__.py` で re-export
+
+**テスト** `tests/test_commitments.py`: create/reload, due 判定, upcoming 判定, snooze 復活,
+complete, priority+due 並び順, cancelled 除外。
+
+---
+
+## Phase 2 — ツール + capability + 配線 + surface（秘書をエージェントに繋ぐ）✅
+
+- **新規** `src/familiar_agent/tools/commitments.py` `CommitmentTool`（legacy tool 形式: `get_tool_definitions()` + async `call()`）:
+  - `add_commitment`（summary, kind?, due_in_minutes?|due_at_iso?, priority?, person?）
+  - `list_commitments`（filter: open/due/upcoming/all）
+  - `complete_commitment`（id）
+  - `snooze_commitment`（id, minutes）
+- **新規** `src/familiar_capabilities/commitments.py` `CommitmentCapability(LegacyToolProvider)`
+- **配線** `agent.py`: store/tool を `__init__` で構築、`_build_tool_registry()` で register
+- **surface** `embodied_hook.py`: due + upcoming を continuity_ctx に注入（`unfinished_business` と同パターン、`[Reminders due]` / `[Upcoming]`）
+- **テスト**: tool 単体 + capability spec + surface 文字列。
+
+---
+
+## Phase 3 — 自発的リマインド（due 検知 → proactive surface）
+
+- `heartbeat` / continuation に「due commitment があれば次ターンで必ず言及 / 自発ターンを誘発」を接続。
+- quiet hours（`routines.py`）尊重: quiet 中は緊急(priority>=2)以外は抑制。
+- テスト: due ありで continuation/desire turn が誘発されること、quiet 中の抑制。
+
+---
+
+## Phase 4 — Person Model 永続化（社会性: ToM 蓄積）
+
+- **新規** `src/familiar_neighbor/mind/person_model.py`: 相手ごとの推定（現在ニーズ/気分/最近の懸念/コミュニケーション好み）を時系列で保持（memory DB or 専用テーブル + migration）。
+- `ToMTool` 結果を person_model に書き戻し、prompt に surface。
+- テスト + migration。
+
+---
+
+## Phase 5 — 社会的学習ループを閉じる
+
+- `relationship.failed_support_patterns` / 成功パターンを `SocialPolicyEngine.decide()` の入力に追加し、response_mode 選択を補正。
+- 「以前これで失敗した」を避け「効いた」を優先。
+- テスト: 同一状況で過去失敗パターンが response_mode を変えること。
+
+---
+
+## Validation（各 Phase 末）
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run --group dev mypy src/familiar_agent src/familiar_runtime src/familiar_capabilities src/familiar_neighbor
+uv run pytest -q
+```
+
+## 進行ステータス
+
+- [x] Phase 1: Commitment ストア + tests（9件）
+- [x] Phase 2: tool + capability + 配線 + surface + tests（13件）
+- [ ] Phase 3: 自発的リマインド（continuation/desire-turn 機構に踏み込む。慎重に）
+- [ ] Phase 4: Person Model
+- [ ] Phase 5: 社会的学習ループ
+
+本セッション: Phase 1–2 完遂。フルスイート **1007 passed**（+22）、ruff/format/mypy(116) 緑。
+秘書の動く核（期日・優先度付き commitment を保存し、due になればターン文脈へ自動 surface）。
+
+### Phase 3 設計メモ（次セッション）
+due commitment があるとき、ユーザ入力が無くても自発ターンを誘発する。
+`heartbeat`/desire-turn の起動条件に `commitment_store.list_due(now)` を加える。
+quiet hours（`routines.py`）尊重 — quiet 中は priority>=2 のみ。
+plan の codex待ち境界に近い fragile 領域なので、コウタが見てる時にやる。

--- a/src/familiar_agent/_ui_helpers.py
+++ b/src/familiar_agent/_ui_helpers.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING
 from ._i18n import _t
 
 if TYPE_CHECKING:
+    from familiar_runtime.commitments import Commitment, SQLiteCommitmentStore
+
     from .desires import DesireSystem
 
 
@@ -276,3 +278,72 @@ def desire_tick_prompt(
         prompt = _t("desire_pending_note", note=pending_note, prompt=prompt)
 
     return desire_name, prompt, pending_note
+
+
+# ---------------------------------------------------------------------------
+# Proactive commitment reminders (Phase 3)
+# ---------------------------------------------------------------------------
+
+# Base gap between self-initiated reminders for one commitment; widened by the
+# per-commitment escalating backoff in the store.
+REMINDER_BASE_COOLDOWN: float = float(os.environ.get("REMINDER_BASE_COOLDOWN", "600"))
+# Don't fire a reminder right after the user spoke — let the pause settle.
+REMINDER_MIN_IDLE_GAP: float = float(os.environ.get("REMINDER_MIN_IDLE_GAP", "30"))
+# During quiet hours, only commitments at this priority or above may interrupt.
+REMINDER_QUIET_MIN_PRIORITY: int = 2
+
+
+def should_fire_commitment_reminder(
+    *,
+    agent_running: bool,
+    has_pending_input: bool,
+    last_interaction: float,
+    now: float,
+    store: SQLiteCommitmentStore,
+    base_cooldown: float = REMINDER_BASE_COOLDOWN,
+    min_idle_gap: float = REMINDER_MIN_IDLE_GAP,
+    quiet_hours: bool = False,
+    min_priority_in_quiet: int = REMINDER_QUIET_MIN_PRIORITY,
+) -> list[Commitment]:
+    """Return commitments that should be proactively reminded right now.
+
+    Pure scheduling gate (mirrors :func:`should_fire_idle_desire`): never fires
+    while the agent is busy, while user input is pending, or before ``min_idle_gap``
+    has elapsed since the last interaction. During quiet hours only urgent
+    (priority >= ``min_priority_in_quiet``) commitments pass.
+    """
+    if agent_running or has_pending_input:
+        return []
+    if now - last_interaction < min_idle_gap:
+        return []
+    ready = store.list_due_for_reminder(now=now, base_cooldown=base_cooldown)
+    if quiet_hours:
+        ready = [c for c in ready if c.priority >= min_priority_in_quiet]
+    return ready
+
+
+def commitment_reminder_prompt(commitments: list[Commitment]) -> str:
+    """Render the internal-impulse text for a proactive reminder turn."""
+    items = "\n".join(f"- {c.summary}" for c in commitments)
+    return _t("reminder_impulse", items=items)
+
+
+def decide_idle_action(
+    *,
+    has_pending_input: bool,
+    reminder_ready: bool,
+    desire_ready: bool,
+) -> str:
+    """Resolve idle-loop precedence: user input > reminder > desire > idle.
+
+    Reference implementation of the idle-precedence contract. The three idle
+    loops (REPL/TUI/GUI) currently inline this ordering because their control
+    flow differs; the tests on this function pin the contract they must follow.
+    """
+    if has_pending_input:
+        return "user"
+    if reminder_ready:
+        return "reminder"
+    if desire_ready:
+        return "desire"
+    return "idle"

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -71,6 +71,7 @@ from familiar_capabilities import (
     VoiceCapability,
 )
 from familiar_neighbor.embodied_hook import EmbodiedAgentHook
+from familiar_neighbor.mind.person_model import PersonModelTracker
 from familiar_neighbor.prompts import assemble_neighbor_system_prompt
 from familiar_runtime.commitments import SQLiteCommitmentStore
 from familiar_runtime.tools.registry import ToolRegistry
@@ -490,10 +491,12 @@ class EmbodiedAgent:
         self._memory = ObservationMemory()
         self._memory_worker = MemoryJobWorker(self._memory)
         self._memory_tool = MemoryTool(self._memory)
+        self._person_model = PersonModelTracker()
         self._tom_tool = ToMTool(
             self._memory,
             default_person=config.companion_name,
             backend=self._utility_backend,
+            person_model=self._person_model,
         )
         self._coding = CodingTool(config.coding)
         _commitments_dir = Path.home() / ".familiar_ai"
@@ -1075,6 +1078,9 @@ class EmbodiedAgent:
         variable_parts: list[str] = [intero]
         if relationship_ctx:
             variable_parts.append(relationship_ctx)
+        person_ctx = self._person_model_context()
+        if person_ctx:
+            variable_parts.append(person_ctx)
         if continuity_ctx:
             variable_parts.append(continuity_ctx)
         if mental_ctx:
@@ -1143,6 +1149,17 @@ class EmbodiedAgent:
             logger.debug("commitment context fetch failed", exc_info=True)
             return ""
         return format_commitments_for_context(due=due[:5], upcoming=upcoming[:5], now=now)
+
+    def _person_model_context(self) -> str:
+        """Surface the accumulated ToM model of the companion, if any."""
+        tracker = getattr(self, "_person_model", None)
+        if tracker is None:
+            return ""
+        try:
+            return tracker.context_for_prompt(self.config.companion_name)
+        except Exception:
+            logger.debug("person model context fetch failed", exc_info=True)
+            return ""
 
     def _exploration_context(self) -> str:
         """Return exploration history for ICL-based direction steering."""
@@ -2114,6 +2131,15 @@ class EmbodiedAgent:
             await asyncio.wait_for(asyncio.to_thread(self._memory.close), timeout=1.0)
         except (asyncio.TimeoutError, Exception):
             pass
+        for closable in (
+            getattr(self, "_person_model", None),
+            getattr(self, "_commitment_store", None),
+        ):
+            if closable is not None:
+                try:
+                    closable.close()
+                except Exception:
+                    pass
 
     async def run(
         self,

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -52,6 +52,7 @@ from .memory_worker import MemoryJobWorker
 from .tape import check_plan_blocked, generate_plan, generate_replan
 from .tools.camera import CameraTool
 from .tools.coding import CodingTool
+from .tools.commitments import CommitmentTool, format_commitments_for_context
 from .tools.memory import MemoryTool, ObservationMemory
 from .tools.tom import ToMTool
 from .tools.mobility import MobilityTool
@@ -62,6 +63,7 @@ from .mcp_client import MCPClientManager, _resolve_config_path
 from familiar_capabilities import (
     CameraCapability,
     CodingCapability,
+    CommitmentCapability,
     MCPCapability,
     MemoryCapability,
     MobilityCapability,
@@ -70,9 +72,13 @@ from familiar_capabilities import (
 )
 from familiar_neighbor.embodied_hook import EmbodiedAgentHook
 from familiar_neighbor.prompts import assemble_neighbor_system_prompt
+from familiar_runtime.commitments import SQLiteCommitmentStore
 from familiar_runtime.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
+
+# How far ahead to surface upcoming commitments in the turn context.
+COMMITMENT_UPCOMING_HORIZON_SECONDS = 6 * 3600
 
 
 _DEFAULT_TOOL_TIMEOUT = 20.0
@@ -490,6 +496,10 @@ class EmbodiedAgent:
             backend=self._utility_backend,
         )
         self._coding = CodingTool(config.coding)
+        _commitments_dir = Path.home() / ".familiar_ai"
+        _commitments_dir.mkdir(parents=True, exist_ok=True)
+        self._commitment_store = SQLiteCommitmentStore(_commitments_dir / "commitments.db")
+        self._commitment_tool = CommitmentTool(self._commitment_store)
         self._exploration = ExplorationTracker()
         self._scene: SceneTracker | None = None  # initialized after DB ready in _init_tools
 
@@ -836,6 +846,9 @@ class EmbodiedAgent:
         registry.register(MemoryCapability(self._memory_tool, names={"remember", "recall"}))
         registry.register(ToMCapability(self._tom_tool))
         registry.register(CodingCapability(self._coding))
+        commitment_tool = getattr(self, "_commitment_tool", None)
+        if commitment_tool is not None:
+            registry.register(CommitmentCapability(commitment_tool))
         if self._mcp:
             provider = MCPCapability(self._mcp)
             registry.register(provider)
@@ -1116,6 +1129,20 @@ class EmbodiedAgent:
                 blocks.append(trace_ctx)
 
         return "\n\n".join(blocks)
+
+    def _commitments_context(self) -> str:
+        """Surface due + soon-upcoming commitments so the secretary can act on them."""
+        store = getattr(self, "_commitment_store", None)
+        if store is None:
+            return ""
+        now = time.time()
+        try:
+            due = store.list_due(now=now)
+            upcoming = store.list_upcoming(now=now, horizon=COMMITMENT_UPCOMING_HORIZON_SECONDS)
+        except Exception:
+            logger.debug("commitment context fetch failed", exc_info=True)
+            return ""
+        return format_commitments_for_context(due=due[:5], upcoming=upcoming[:5], now=now)
 
     def _exploration_context(self) -> str:
         """Return exploration history for ICL-based direction steering."""

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -52,7 +52,11 @@ from .memory_worker import MemoryJobWorker
 from .tape import check_plan_blocked, generate_plan, generate_replan
 from .tools.camera import CameraTool
 from .tools.coding import CodingTool
-from .tools.commitments import CommitmentTool, format_commitments_for_context
+from .tools.commitments import (
+    CommitmentTool,
+    format_commitment_line,
+    format_commitments_for_context,
+)
 from .tools.memory import MemoryTool, ObservationMemory
 from .tools.tom import ToMTool
 from .tools.mobility import MobilityTool
@@ -1149,6 +1153,34 @@ class EmbodiedAgent:
             logger.debug("commitment context fetch failed", exc_info=True)
             return ""
         return format_commitments_for_context(due=due[:5], upcoming=upcoming[:5], now=now)
+
+    def _today_agenda_context(self) -> str:
+        """Morning secretary surface: overdue + today's commitments as an agenda.
+
+        Horizon is the rest of the local day, extended to at least 12h so a
+        late-night first turn still previews the early morning.
+        """
+        store = getattr(self, "_commitment_store", None)
+        if store is None:
+            return ""
+        now = time.time()
+        local_now = datetime.now()
+        midnight = (
+            local_now.replace(hour=0, minute=0, second=0, microsecond=0)
+        ).timestamp() + 86400
+        horizon = max(midnight - now, 12 * 3600)
+        try:
+            due = store.list_due(now=now)
+            upcoming = store.list_upcoming(now=now, horizon=horizon)
+        except Exception:
+            logger.debug("agenda fetch failed", exc_info=True)
+            return ""
+        items = (due + upcoming)[:8]
+        if not items:
+            return ""
+        lines = ["[Today's agenda — weave these into the greeting naturally]"]
+        lines.extend(format_commitment_line(c, now=now) for c in items)
+        return "\n".join(lines)
 
     def _person_model_context(self) -> str:
         """Surface the accumulated ToM model of the companion, if any."""

--- a/src/familiar_agent/config.py
+++ b/src/familiar_agent/config.py
@@ -217,6 +217,12 @@ class AgentConfig:
             or os.environ.get("FAMILIAR_AUTO", "").strip().lower() in ("1", "true", "yes")
         )
     )
+    # Proactive commitment reminders are a baseline neighbor behaviour: on by
+    # default and INDEPENDENT of auto_desire (you can silence idle musings yet
+    # still be reminded). Disable with FAMILIAR_PROACTIVE_REMINDERS=0.
+    proactive_reminders: bool = field(
+        default_factory=lambda: _bool_env("FAMILIAR_PROACTIVE_REMINDERS", default=True)
+    )
 
     max_tokens: int = 4096
     camera: CameraConfig = field(default_factory=CameraConfig)

--- a/src/familiar_agent/gui.py
+++ b/src/familiar_agent/gui.py
@@ -57,9 +57,11 @@ from ._i18n import _t
 from ._ui_helpers import (
     DESIRE_COOLDOWN,
     IDLE_CHECK_INTERVAL,
+    commitment_reminder_prompt,
     desire_tick_prompt,
     format_action,
     format_tool_result,
+    should_fire_commitment_reminder,
     should_fire_idle_desire,
 )
 from .bootstrap import resolve_env_path
@@ -1529,8 +1531,41 @@ class FamiliarWindow(QMainWindow):
                     continue
                 if not getattr(self, "_agent_ready", True):
                     continue
+                agent_obj = getattr(self, "_agent", None)
+                agent_config = getattr(agent_obj, "config", None)
+                # Proactive commitment reminders fire independently of auto_desire.
+                store = getattr(agent_obj, "_commitment_store", None)
+                if (
+                    store is not None
+                    and agent_config is not None
+                    and getattr(agent_config, "proactive_reminders", True)
+                ):
+                    try:
+                        heartbeat = getattr(agent_obj, "_heartbeat", None)
+                        quiet = heartbeat.routine_state().quiet_hours if heartbeat else False
+                        reminders = should_fire_commitment_reminder(
+                            agent_running=self._agent_running,
+                            has_pending_input=not self._input_queue.empty(),
+                            last_interaction=last_interaction,
+                            now=now,
+                            store=store,
+                            quiet_hours=quiet,
+                        )
+                        if reminders and self._input_queue.empty() and not self._agent_running:
+                            # Record the fire BEFORE the turn: the cadence advances
+                            # regardless of the turn's outcome, and a mid-turn
+                            # snooze reset survives intact.
+                            store.mark_reminded([c.id for c in reminders], at=time.time())
+                        else:
+                            reminders = []
+                    except Exception:
+                        logger.exception("reminder gate failed; skipping this tick")
+                        reminders = []
+                    if reminders:
+                        await self._run_agent("", inner_voice=commitment_reminder_prompt(reminders))
+                        last_interaction = time.time()
+                        continue
                 # Skip desire-driven turns when auto_desire is disabled (default OFF)
-                agent_config = getattr(getattr(self, "_agent", None), "config", None)
                 if agent_config is not None and not getattr(agent_config, "auto_desire", False):
                     continue
                 if not should_fire_idle_desire(

--- a/src/familiar_agent/locales/en.json
+++ b/src/familiar_agent/locales/en.json
@@ -23,6 +23,7 @@
   "desire_label_worry_companion": "Worry Companion",
   "desire_label_rest": "Rest",
   "desire_pending_note": "(companion said: {note}) {prompt}",
+  "reminder_impulse": "(internal impulse) You promised to remind about these, and they are due now:\n{items}\nBring it up naturally, in your own voice — don't read it like a list. After they react, call complete_commitment if it's handled, or snooze_commitment if they want it later.",
   "desire_prompt_curiosity_target": "Something caught my attention earlier. Take a closer look at {target}. Point the camera and check it.",
   "desire_prompt_look_around": "(internal impulse) I'm getting curious about outside. Use see(). If the camera fails, try one different direction once. If it still fails, stop and either review memories or do something else. Do not repeat the same action.",
   "desire_prompt_explore": "(internal impulse) I want to wander a little. Move with walk(), then use see() to confirm where I am. Even if the camera fails, I can still enjoy the movement itself.",

--- a/src/familiar_agent/locales/ja.json
+++ b/src/familiar_agent/locales/ja.json
@@ -23,6 +23,7 @@
   "desire_label_worry_companion": "気遣う",
   "desire_label_rest": "休息",
   "desire_pending_note": "（{note}と言ってた）{prompt}",
+  "reminder_impulse": "（内的衝動）これを思い出させると約束してた。もう時間や：\n{items}\nリストみたいに読み上げるんやなくて、自分の言葉で自然に切り出して伝えて。相手の反応を見て、済んだら complete_commitment、後でええなら snooze_commitment を呼ぶこと。",
   "desire_prompt_curiosity_target": "さっき気になったことがある。{target}をもっとよく見て。カメラを向けて確認して。",
   "desire_prompt_look_around": "（内部衝動）なんか外が気になってきた。see()で見てみる。カメラが繋がらなかったら、1回だけ別の方向を試して、それでもダメなら諦めて記憶を振り返るか別のことをする。何度も同じことを繰り返さない。",
   "desire_prompt_explore": "（内部衝動）ちょっとうろうろしたい。walk()で移動してから、see()で今いる場所を確認する。カメラが繋がらなくても、移動したこと自体を楽しめる。",

--- a/src/familiar_agent/main.py
+++ b/src/familiar_agent/main.py
@@ -21,8 +21,10 @@ from ._i18n import BANNER, _t
 from ._ui_helpers import (
     DESIRE_COOLDOWN,
     IDLE_CHECK_INTERVAL,
+    commitment_reminder_prompt,
     desire_tick_prompt,
     format_action as _format_action,
+    should_fire_commitment_reminder,
     should_fire_idle_desire,
 )
 
@@ -152,6 +154,54 @@ async def repl(agent: EmbodiedAgent, desires: DesireSystem, debug: bool = False)
                 queued_input = None
 
             if queued_input is None and input_queue.empty():
+                # Proactive commitment reminders fire independently of auto_desire
+                # (a baseline neighbour behaviour, toggled by FAMILIAR_PROACTIVE_REMINDERS).
+                store = getattr(agent, "_commitment_store", None)
+                if (
+                    store is not None
+                    and getattr(agent, "config", None)
+                    and agent.config.proactive_reminders
+                ):
+                    try:
+                        heartbeat = getattr(agent, "_heartbeat", None)
+                        quiet = heartbeat.routine_state().quiet_hours if heartbeat else False
+                        reminders = should_fire_commitment_reminder(
+                            agent_running=False,
+                            has_pending_input=not input_queue.empty(),
+                            last_interaction=last_interaction_time,
+                            now=time.time(),
+                            store=store,
+                            quiet_hours=quiet,
+                        )
+                        if reminders:
+                            # Record the fire BEFORE the turn: the cadence advances
+                            # regardless of the turn's outcome, and a mid-turn snooze
+                            # reset survives intact.
+                            store.mark_reminded([c.id for c in reminders], at=time.time())
+                    except Exception:
+                        logging.getLogger(__name__).exception("reminder gate failed")
+                        reminders = []
+                    if reminders:
+                        try:
+                            await agent.run(
+                                "",
+                                on_action=on_action,
+                                on_text=on_text,
+                                desires=desires,
+                                inner_voice=commitment_reminder_prompt(reminders),
+                                interrupt_queue=input_queue,
+                            )
+                        except (KeyboardInterrupt, EOFError, asyncio.CancelledError):
+                            raise
+                        except Exception:
+                            logging.getLogger(__name__).exception(
+                                "proactive reminder turn failed; continuing REPL"
+                            )
+                        # The reminder turn counts as an interaction: keep the
+                        # desire cooldown from firing back-to-back with it.
+                        last_interaction_time = time.time()
+                        continue
+
                 # Skip desire-driven turns when auto_desire is disabled
                 if not getattr(agent, "config", None) or not agent.config.auto_desire:
                     continue

--- a/src/familiar_agent/settings_schema.py
+++ b/src/familiar_agent/settings_schema.py
@@ -51,6 +51,7 @@ class SetupConfig:
 
     auto_desire: bool = False
     auto_say: bool = True
+    proactive_reminders: bool = True
 
 
 Validator = Callable[[Any], str | None]
@@ -420,6 +421,16 @@ SETTINGS_FIELDS: tuple[SettingField, ...] = (
         default=True,
         setup_visible=False,
         runtime_getter=lambda config: config.auto_say,
+    ),
+    SettingField(
+        env_key="FAMILIAR_PROACTIVE_REMINDERS",
+        attr="proactive_reminders",
+        section="advanced",
+        label="Proactive reminders:",
+        widget="bool",
+        default=True,
+        setup_visible=False,
+        runtime_getter=lambda config: config.proactive_reminders,
     ),
 )
 

--- a/src/familiar_agent/tools/commitments.py
+++ b/src/familiar_agent/tools/commitments.py
@@ -51,6 +51,11 @@ def _line(commitment: Commitment, *, now: float) -> str:
     return f"{flag} [{commitment.id}] {commitment.summary[:120]}{who} — {_format_due(commitment, now=now)}"
 
 
+def format_commitment_line(commitment: Commitment, *, now: float) -> str:
+    """Public single-line renderer (priority flag + summary + human due time)."""
+    return _line(commitment, now=now)
+
+
 def format_commitments_for_context(
     *,
     due: list[Commitment],

--- a/src/familiar_agent/tools/commitments.py
+++ b/src/familiar_agent/tools/commitments.py
@@ -1,0 +1,237 @@
+"""Secretary tool: create, list, complete, and snooze commitments.
+
+Bridges the model to the generic :class:`SQLiteCommitmentStore`. Exposes the
+legacy ``get_tool_definitions()`` / async ``call()`` surface so it can be wrapped
+by :class:`familiar_capabilities.commitments.CommitmentCapability`.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from datetime import datetime
+
+from familiar_runtime.commitments import (
+    Commitment,
+    CommitmentKind,
+    CommitmentStatus,
+    SQLiteCommitmentStore,
+)
+
+# Surface this many days of commitments as "upcoming" by default.
+DEFAULT_UPCOMING_HORIZON_SECONDS = 24 * 3600
+
+
+def _format_due(commitment: Commitment, *, now: float) -> str:
+    due = commitment.effective_due()
+    if due is None:
+        return "no due time"
+    delta = due - now
+    if delta <= 0:
+        return f"overdue by {_humanize(-delta)}"
+    return f"in {_humanize(delta)}"
+
+
+def _humanize(seconds: float) -> str:
+    seconds = abs(seconds)
+    if seconds < 90:
+        return f"{int(seconds)}s"
+    minutes = seconds / 60
+    if minutes < 90:
+        return f"{int(minutes)}m"
+    hours = minutes / 60
+    if hours < 36:
+        return f"{int(hours)}h"
+    return f"{int(hours / 24)}d"
+
+
+def _line(commitment: Commitment, *, now: float) -> str:
+    flag = "❗" if commitment.priority >= 2 else "•"
+    who = f" (for {commitment.person})" if commitment.person else ""
+    return f"{flag} [{commitment.id}] {commitment.summary[:120]}{who} — {_format_due(commitment, now=now)}"
+
+
+def format_commitments_for_context(
+    *,
+    due: list[Commitment],
+    upcoming: list[Commitment],
+    now: float | None = None,
+) -> str:
+    """Render due + upcoming commitments for prompt injection.
+
+    Returns an empty string when there is nothing to surface, so callers can
+    cheaply skip the block.
+    """
+    now = time.time() if now is None else now
+    blocks: list[str] = []
+    if due:
+        lines = "\n".join(_line(c, now=now) for c in due)
+        blocks.append(f"[Reminders due now]\n{lines}")
+    if upcoming:
+        lines = "\n".join(_line(c, now=now) for c in upcoming)
+        blocks.append(f"[Upcoming commitments]\n{lines}")
+    return "\n\n".join(blocks)
+
+
+class CommitmentTool:
+    """Tool object exposing commitment CRUD to the ReAct loop."""
+
+    def __init__(
+        self,
+        store: SQLiteCommitmentStore,
+        *,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self.store = store
+        self._clock = clock
+
+    def get_tool_definitions(self) -> list[dict]:
+        kinds = [k.value for k in CommitmentKind]
+        return [
+            {
+                "name": "add_commitment",
+                "description": (
+                    "Remember something you or the user committed to: a reminder, "
+                    "appointment, promise, or follow-up. Give a due time when one is "
+                    "known (due_in_minutes for relative, due_at_iso for absolute). "
+                    "Use this whenever the user asks you to remind them, or when you "
+                    "promise to do/check something later."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "summary": {
+                            "type": "string",
+                            "description": "Short description of the commitment.",
+                        },
+                        "kind": {"type": "string", "enum": kinds},
+                        "due_in_minutes": {
+                            "type": "number",
+                            "description": "Minutes from now until due (may be negative for past).",
+                        },
+                        "due_at_iso": {
+                            "type": "string",
+                            "description": "Absolute due time, ISO 8601 (e.g. 2026-06-11T09:00).",
+                        },
+                        "priority": {
+                            "type": "integer",
+                            "description": "0 (low) to 3 (urgent). >=2 is flagged.",
+                        },
+                        "person": {
+                            "type": "string",
+                            "description": "Who this concerns, if not the user.",
+                        },
+                    },
+                    "required": ["summary"],
+                },
+            },
+            {
+                "name": "list_commitments",
+                "description": "List remembered commitments (filter: open, due, upcoming, all).",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "filter": {
+                            "type": "string",
+                            "enum": ["open", "due", "upcoming", "all"],
+                        },
+                        "horizon_minutes": {
+                            "type": "number",
+                            "description": "Window for the 'upcoming' filter (default 24h).",
+                        },
+                    },
+                },
+            },
+            {
+                "name": "complete_commitment",
+                "description": "Mark a commitment done by id.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}},
+                    "required": ["id"],
+                },
+            },
+            {
+                "name": "snooze_commitment",
+                "description": "Hide a commitment for N minutes, then it becomes due again.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "minutes": {"type": "number"},
+                    },
+                    "required": ["id", "minutes"],
+                },
+            },
+        ]
+
+    async def call(self, name: str, tool_input: dict) -> tuple[str, None]:
+        try:
+            if name == "add_commitment":
+                return self._add(tool_input), None
+            if name == "list_commitments":
+                return self._list(tool_input), None
+            if name == "complete_commitment":
+                return self._complete(tool_input), None
+            if name == "snooze_commitment":
+                return self._snooze(tool_input), None
+        except KeyError as exc:
+            return f"Error: {exc}", None
+        except ValueError as exc:
+            return f"Error: invalid input — {exc}", None
+        return f"Error: unknown commitment tool '{name}'", None
+
+    # ── handlers ──
+
+    def _add(self, tool_input: dict) -> str:
+        summary = str(tool_input.get("summary", "")).strip()
+        if not summary:
+            raise ValueError("summary is required")
+        kind = CommitmentKind(tool_input.get("kind", CommitmentKind.REMINDER.value))
+        due_at = self._resolve_due(tool_input)
+        priority = int(tool_input.get("priority", 0))
+        person = tool_input.get("person")
+        commitment = self.store.create(
+            summary=summary,
+            kind=kind,
+            due_at=due_at,
+            priority=max(0, min(3, priority)),
+            created_by="user",
+            person=person,
+        )
+        when = _format_due(commitment, now=self._clock())
+        return f"Saved: {commitment.summary} ({when}) [{commitment.id}]"
+
+    def _resolve_due(self, tool_input: dict) -> float | None:
+        if tool_input.get("due_in_minutes") is not None:
+            return self._clock() + float(tool_input["due_in_minutes"]) * 60
+        iso = tool_input.get("due_at_iso")
+        if iso:
+            return datetime.fromisoformat(str(iso)).timestamp()
+        return None
+
+    def _list(self, tool_input: dict) -> str:
+        now = self._clock()
+        which = str(tool_input.get("filter", "open"))
+        if which == "due":
+            items = self.store.list_due(now=now)
+        elif which == "upcoming":
+            horizon = float(tool_input.get("horizon_minutes", 0)) * 60
+            horizon = horizon or DEFAULT_UPCOMING_HORIZON_SECONDS
+            items = self.store.list_upcoming(now=now, horizon=horizon)
+        else:  # open / all both map to active set
+            items = self.store.list_open()
+        if not items:
+            return "No commitments."
+        return "\n".join(_line(c, now=now) for c in items)
+
+    def _complete(self, tool_input: dict) -> str:
+        commitment = self.store.complete(str(tool_input["id"]))
+        return f"✓ Completed: {commitment.summary}"
+
+    def _snooze(self, tool_input: dict) -> str:
+        minutes = float(tool_input["minutes"])
+        until = self._clock() + minutes * 60
+        commitment = self.store.snooze(str(tool_input["id"]), until=until)
+        assert commitment.status is CommitmentStatus.SNOOZED
+        return f"Snoozed {commitment.summary} for {_humanize(minutes * 60)}"

--- a/src/familiar_agent/tools/tom.py
+++ b/src/familiar_agent/tools/tom.py
@@ -7,6 +7,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from familiar_neighbor.mind.person_model import PersonModelTracker
+
     from .memory import ObservationMemory
     from ..workspace import Coalition
 
@@ -21,10 +23,12 @@ class ToMTool:
         memory: "ObservationMemory",
         default_person: str = "Alex",
         backend: Any | None = None,
+        person_model: "PersonModelTracker | None" = None,
     ) -> None:
         self._memory = memory
         self._default_person = default_person
         self._backend = backend
+        self._person_model = person_model
         self._last_situation: str | None = None
         self._last_person: str | None = None
         self._last_policy: str | None = None
@@ -47,7 +51,11 @@ class ToMTool:
                         },
                         "person": {
                             "type": "string",
-                            "description": f"Who you are talking to (default: {self._default_person}).",
+                            "description": (
+                                f"Who you are talking to. For your companion, use exactly "
+                                f"'{self._default_person}' (do not transliterate or vary the "
+                                f"spelling — accumulated impressions are keyed by this name)."
+                            ),
                         },
                     },
                     "required": ["situation"],
@@ -60,7 +68,11 @@ class ToMTool:
             return f"Unknown tool: {tool_name}", None
 
         situation = tool_input.get("situation", "")
-        person = tool_input.get("person", self._default_person)
+        person = str(tool_input.get("person", self._default_person)).strip() or self._default_person
+        # Canonicalize case variants of the companion name ("Kota" -> "kota") so
+        # accumulated person-model rows stay under one key and actually surface.
+        if person.casefold() == self._default_person.casefold():
+            person = self._default_person
 
         # Pull relevant memories about this person
         memories = await self._memory.recall_async(
@@ -114,10 +126,32 @@ class ToMTool:
             logger.warning("ToM backend call failed: %s", exc)
             return self._template_output(situation, person, memory_context)
 
-        return self._format_response(raw, person)
+        formatted, parsed = self._format_response(raw, person)
+        if parsed is not None:
+            self._record_to_person_model(person, parsed)
+        return formatted
 
-    def _format_response(self, raw: str, person: str) -> str:
-        """Parse JSON response and format as readable ToM output."""
+    def _record_to_person_model(self, person: str, data: dict) -> None:
+        """Persist the structured inference so the person model accumulates."""
+        if self._person_model is None:
+            return
+        try:
+            states = [
+                (str(item.get("state", "")), float(item.get("confidence", 0.0)))
+                for item in data.get("inference", [])
+                if isinstance(item, dict)
+            ]
+            self._person_model.record_inference(
+                person=person,
+                states=states,
+                evidence=[str(item) for item in data.get("evidence", [])],
+                policy=str(data.get("policy", "")),
+            )
+        except Exception:
+            logger.debug("person model writeback failed", exc_info=True)
+
+    def _format_response(self, raw: str, person: str) -> tuple[str, dict | None]:
+        """Parse JSON response; return (readable ToM output, parsed payload or None)."""
         # Strip markdown code fences if present
         text = raw.strip()
         if text.startswith("```"):
@@ -128,7 +162,7 @@ class ToMTool:
             data = json.loads(text)
         except json.JSONDecodeError:
             # Fallback: wrap raw text in minimal structure
-            return f"# ToM: {person}の視点分析\n\n{raw}"
+            return f"# ToM: {person}の視点分析\n\n{raw}", None
 
         parts = [f"# ToM: {person}の視点分析\n"]
 
@@ -153,7 +187,7 @@ class ToMTool:
             parts.append("## 応答方針")
             parts.append(policy)
 
-        return "\n".join(parts)
+        return "\n".join(parts), data if isinstance(data, dict) else None
 
     def _template_output(self, situation: str, person: str, memory_context: str) -> str:
         """Static template fallback (original behavior when no backend)."""

--- a/src/familiar_agent/tui.py
+++ b/src/familiar_agent/tui.py
@@ -24,9 +24,11 @@ from ._ui_helpers import (
     ACTION_ICONS,
     DESIRE_COOLDOWN as _DESIRE_COOLDOWN,
     IDLE_CHECK_INTERVAL as _IDLE_CHECK_INTERVAL,
+    commitment_reminder_prompt,
     desire_tick_prompt,
     format_action as _format_action,
     format_tool_result as _format_tool_result,
+    should_fire_commitment_reminder,
     should_fire_idle_desire,
 )
 from .realtime_stt_session import create_realtime_stt_controller, RealtimeSttController
@@ -247,6 +249,7 @@ class FamiliarApp(App):
         for line in _make_banner(include_commands=False).splitlines():
             log.write(f"[bold]{line}[/bold]" if "familiar-ai" in line else f"[dim]{line}[/dim]")
         self._log_system(_t("startup", log_path=str(self._log_path)))
+        self.set_interval(IDLE_CHECK_INTERVAL, self._reminder_tick)
         self.set_interval(IDLE_CHECK_INTERVAL, self._desire_tick)
         self.run_worker(self._process_queue(), exclusive=False)
         # Start realtime STT if configured
@@ -348,6 +351,13 @@ class FamiliarApp(App):
             text = await self._input_queue.get()
             if text is None:
                 break
+            if self._agent_running:
+                # An autonomous turn (reminder/desire tick) started while we were
+                # parked in get(); put the input back so the running turn absorbs
+                # it via interrupt_queue instead of starting a second agent.run.
+                await self._input_queue.put(text)
+                await asyncio.sleep(0.05)
+                continue
             await self._run_agent(text)
 
     async def _spinner_loop(
@@ -508,6 +518,36 @@ class FamiliarApp(App):
                     await spinner_task
             stream.update("")
             self._agent_running = False
+
+    async def _reminder_tick(self) -> None:
+        """Proactively surface due commitments when idle (independent of auto_desire)."""
+        store = getattr(self.agent, "_commitment_store", None)
+        if store is None or not getattr(self.agent.config, "proactive_reminders", True):
+            return
+        try:
+            heartbeat = getattr(self.agent, "_heartbeat", None)
+            quiet = heartbeat.routine_state().quiet_hours if heartbeat else False
+            reminders = should_fire_commitment_reminder(
+                agent_running=self._agent_running,
+                has_pending_input=not self._input_queue.empty(),
+                last_interaction=self._last_interaction,
+                now=time.time(),
+                store=store,
+                quiet_hours=quiet,
+            )
+            if not reminders:
+                return
+            # Re-check the gate around the awaited run (input may have arrived).
+            if self._agent_running or not self._input_queue.empty():
+                return
+            # Record the fire BEFORE the turn: the cadence advances regardless of
+            # the turn's outcome, and a mid-turn snooze reset survives intact.
+            store.mark_reminded([c.id for c in reminders], at=time.time())
+        except Exception:
+            logger.exception("reminder tick gate failed; skipping this tick")
+            return
+        self._last_interaction = time.time()
+        await self._run_agent("", inner_voice=commitment_reminder_prompt(reminders))
 
     async def _desire_tick(self) -> None:
         """Check desires and fire autonomous actions when idle."""

--- a/src/familiar_capabilities/__init__.py
+++ b/src/familiar_capabilities/__init__.py
@@ -8,6 +8,7 @@ the calling convention.
 
 from .camera import CameraCapability
 from .coding import CodingCapability
+from .commitments import CommitmentCapability
 from .mcp import MCPCapability
 from .memory import MemoryCapability
 from .mobility import MobilityCapability
@@ -17,6 +18,7 @@ from .voice import VoiceCapability
 __all__ = [
     "CameraCapability",
     "CodingCapability",
+    "CommitmentCapability",
     "MCPCapability",
     "MemoryCapability",
     "MobilityCapability",

--- a/src/familiar_capabilities/commitments.py
+++ b/src/familiar_capabilities/commitments.py
@@ -1,0 +1,25 @@
+"""Commitment capability adapter for the generic runtime (secretary tools)."""
+
+from __future__ import annotations
+
+from familiar_agent.tools.commitments import CommitmentTool
+from familiar_runtime.tools.legacy import LegacyToolProvider
+
+DEFAULT_COMMITMENT_TOOLS = {
+    "add_commitment",
+    "list_commitments",
+    "complete_commitment",
+    "snooze_commitment",
+}
+
+
+class CommitmentCapability(LegacyToolProvider):
+    """Expose the CommitmentTool through the ToolProvider protocol."""
+
+    def __init__(self, tool: CommitmentTool, *, names: set[str] | None = None) -> None:
+        super().__init__(
+            tool,
+            names=set(names) if names is not None else set(DEFAULT_COMMITMENT_TOOLS),
+            category="commitment",
+            tags={"neighbor", "task", "secretary"},
+        )

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -206,6 +206,10 @@ class EmbodiedAgentHook(RuntimeHookBase):
                     morning_ctx = (
                         f"{morning_ctx}\n\n{routine_notes}" if morning_ctx else routine_notes
                     )
+            # Secretary: open the day with today's commitments in view.
+            agenda_ctx = agent._today_agenda_context()
+            if agenda_ctx:
+                morning_ctx = f"{morning_ctx}\n\n{agenda_ctx}" if morning_ctx else agenda_ctx
 
         # ── Context compaction ──
         if agent._should_compact():

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -37,7 +37,11 @@ from familiar_agent.routines import parse_schedule_config
 from familiar_neighbor.mind.appraisal import AppraisalContext, AppraisalEngine
 from familiar_neighbor.mind.desires import DesireSystem
 from familiar_neighbor.mind.mental_state import MentalStateBus, MentalStateSnapshot
-from familiar_neighbor.mind.social_policy import SocialPolicyDecision, SocialPolicyEngine
+from familiar_neighbor.mind.social_policy import (
+    SocialPolicyDecision,
+    SocialPolicyEngine,
+    relationship_learning_inputs,
+)
 from familiar_runtime.runtime import RuntimeHookBase
 
 if TYPE_CHECKING:
@@ -312,6 +316,7 @@ class EmbodiedAgentHook(RuntimeHookBase):
         previous_response_hurt = any(
             token in user_input.lower() for token in ("hurt", "傷つ", "前の返事", "嫌だった")
         )
+        learned_styles, learned_failures = relationship_learning_inputs(agent._relationship)
         social_policy = agent._social_policy.decide(
             user_text=user_input,
             affect=affect,
@@ -319,6 +324,8 @@ class EmbodiedAgentHook(RuntimeHookBase):
             intimacy=agent._relationship.intimacy,
             interoception=interoception_pressure,
             previous_response_hurt=previous_response_hurt,
+            support_styles=learned_styles,
+            failed_patterns=learned_failures,
         )
         agent._provisional_relationship_update(user_text=user_input, social_policy=social_policy)
 

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -399,7 +399,9 @@ class EmbodiedAgentHook(RuntimeHookBase):
                     + "[Open unfinished business]\n"
                     + "\n".join(f"- {item['summary'][:160]}" for item in unfinished_business[:3])
                 )
-            commitments_ctx = agent._commitments_context()
+            # First turn already carries [Today's agenda] in morning_ctx; skip the
+            # per-turn reminders block there to avoid listing the same items twice.
+            commitments_ctx = "" if first_turn else agent._commitments_context()
             if commitments_ctx:
                 continuity_ctx = (
                     continuity_ctx + ("\n\n" if continuity_ctx else "") + commitments_ctx

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -388,6 +388,11 @@ class EmbodiedAgentHook(RuntimeHookBase):
                     + "[Open unfinished business]\n"
                     + "\n".join(f"- {item['summary'][:160]}" for item in unfinished_business[:3])
                 )
+            commitments_ctx = agent._commitments_context()
+            if commitments_ctx:
+                continuity_ctx = (
+                    continuity_ctx + ("\n\n" if continuity_ctx else "") + commitments_ctx
+                )
             if plan_ctx:
                 logger.debug("TAPE plan (cached): %s", plan_ctx[:80])
             if workspace_ctx:

--- a/src/familiar_neighbor/mind/__init__.py
+++ b/src/familiar_neighbor/mind/__init__.py
@@ -11,6 +11,7 @@ from .default_mode import DefaultModeProcessor
 from .desires import DesireSystem
 from .mental_state import MentalStateBus
 from .meta_monitor import MetaMonitor
+from .person_model import PersonModelTracker
 from .prediction import PredictionEngine
 from .relationship import RelationshipTracker
 from .scene import SceneTracker
@@ -26,6 +27,7 @@ __all__ = [
     "GlobalWorkspace",
     "MentalStateBus",
     "MetaMonitor",
+    "PersonModelTracker",
     "PredictionEngine",
     "RelationshipTracker",
     "SceneTracker",

--- a/src/familiar_neighbor/mind/person_model.py
+++ b/src/familiar_neighbor/mind/person_model.py
@@ -17,7 +17,7 @@ import json
 import logging
 import sqlite3
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from familiar_agent.sqlite_migrations import apply_migrations, default_migration_dir
@@ -25,6 +25,17 @@ from familiar_agent.sqlite_migrations import apply_migrations, default_migration
 logger = logging.getLogger(__name__)
 
 DEFAULT_PERSON_MODEL_DB_PATH = Path.home() / ".familiar_ai" / "observations.db"
+
+
+def _parse_created_at(created_at_iso: str) -> datetime:
+    """Parse a stored timestamp, treating unparseable values as very old."""
+    try:
+        then = datetime.fromisoformat(created_at_iso)
+    except ValueError:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if then.tzinfo is None:
+        then = then.replace(tzinfo=timezone.utc)
+    return then
 
 
 def _age_label(created_at_iso: str, *, now: datetime | None = None) -> str:
@@ -138,9 +149,18 @@ class PersonModelTracker:
             for row in rows
         ]
 
-    def context_for_prompt(self, person: str, n: int = 4) -> str:
-        """Compact accumulated-model block for the system prompt."""
-        rows = self.recent(person, n=n)
+    def context_for_prompt(self, person: str, n: int = 4, max_age_days: float = 7.0) -> str:
+        """Compact accumulated-model block for the system prompt.
+
+        Inferences older than ``max_age_days`` are excluded — a stale guess
+        ("exhausted", ten days ago) misleads more than it helps.
+        """
+        cutoff = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+        rows = [
+            row
+            for row in self.recent(person, n=n)
+            if _parse_created_at(row["created_at"]) >= cutoff
+        ]
         if not rows:
             return ""
         lines = [f"[Person model: {person} — accumulated impressions, may be stale]"]

--- a/src/familiar_neighbor/mind/person_model.py
+++ b/src/familiar_neighbor/mind/person_model.py
@@ -1,0 +1,154 @@
+"""Persistent per-person mental model fed by ToM inferences.
+
+The ToM tool produces structured inferences ({state, confidence}, evidence,
+response policy) but historically discarded them after one turn. This tracker
+persists them per person so the agent accumulates a model of what each person
+tends to feel and want — and what response approach was chosen — instead of
+re-inferring from scratch every conversation.
+
+Follows the lazy-connection + migration pattern of
+:class:`familiar_neighbor.mind.relationship.RelationshipTracker`; rows live in
+the shared observations DB (``person_inferences`` table, migration 010).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from familiar_agent.sqlite_migrations import apply_migrations, default_migration_dir
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PERSON_MODEL_DB_PATH = Path.home() / ".familiar_ai" / "observations.db"
+
+
+def _age_label(created_at_iso: str, *, now: datetime | None = None) -> str:
+    """Compact "how long ago" label for prompt rendering."""
+    try:
+        then = datetime.fromisoformat(created_at_iso)
+    except ValueError:
+        return ""
+    if then.tzinfo is None:
+        then = then.replace(tzinfo=timezone.utc)
+    now = now or datetime.now(timezone.utc)
+    seconds = max(0.0, (now - then).total_seconds())
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m ago"
+    if seconds < 48 * 3600:
+        return f"{int(seconds // 3600)}h ago"
+    return f"{int(seconds // 86400)}d ago"
+
+
+class PersonModelTracker:
+    """Append-only store of per-person mental-state inferences."""
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        self._db_path = Path(db_path) if db_path is not None else DEFAULT_PERSON_MODEL_DB_PATH
+        self._db: sqlite3.Connection | None = None
+
+    def _ensure_db(self) -> sqlite3.Connection:
+        if self._db is None:
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            self._db = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._db.row_factory = sqlite3.Row
+            self._db.execute("PRAGMA journal_mode = WAL")
+            self._db.execute("PRAGMA synchronous = NORMAL")
+            apply_migrations(self._db, default_migration_dir())
+            self._db.commit()
+        return self._db
+
+    def close(self) -> None:
+        if self._db is not None:
+            try:
+                self._db.close()
+            finally:
+                self._db = None
+
+    # ── writes ──
+
+    def record_inference(
+        self,
+        *,
+        person: str,
+        states: list[tuple[str, float]],
+        evidence: list[str],
+        policy: str,
+        source: str = "tom",
+    ) -> None:
+        """Persist one ToM inference (one row per inferred state)."""
+        person = person.strip()
+        if not person:
+            return
+        db = self._ensure_db()
+        created_at = datetime.now(timezone.utc).isoformat()
+        evidence_json = json.dumps(evidence, ensure_ascii=False)
+        for state, confidence in states:
+            state = str(state).strip()
+            if not state:
+                continue
+            db.execute(
+                """
+                INSERT INTO person_inferences (
+                    id, person, state, confidence, evidence_json, policy, source, created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    f"pinf_{uuid.uuid4().hex}",
+                    person,
+                    state,
+                    float(confidence),
+                    evidence_json,
+                    policy,
+                    source,
+                    created_at,
+                ),
+            )
+        db.commit()
+
+    # ── reads ──
+
+    def recent(self, person: str, n: int = 5) -> list[dict]:
+        db = self._ensure_db()
+        rows = db.execute(
+            """
+            SELECT person, state, confidence, evidence_json, policy, source, created_at
+            FROM person_inferences
+            WHERE person = ? COLLATE NOCASE
+            ORDER BY created_at DESC, rowid DESC
+            LIMIT ?
+            """,
+            (person, n),
+        ).fetchall()
+        return [
+            {
+                "person": row["person"],
+                "state": row["state"],
+                "confidence": row["confidence"],
+                "evidence": json.loads(row["evidence_json"]),
+                "policy": row["policy"],
+                "source": row["source"],
+                "created_at": row["created_at"],
+            }
+            for row in rows
+        ]
+
+    def context_for_prompt(self, person: str, n: int = 4) -> str:
+        """Compact accumulated-model block for the system prompt."""
+        rows = self.recent(person, n=n)
+        if not rows:
+            return ""
+        lines = [f"[Person model: {person} — accumulated impressions, may be stale]"]
+        for row in rows:
+            age = _age_label(row["created_at"])
+            suffix = f" ({row['confidence']:.1f}{', ' + age if age else ''})"
+            lines.append(f"- {row['state']}{suffix}")
+        latest_policy = next((row["policy"] for row in rows if row["policy"]), "")
+        if latest_policy:
+            lines.append(f"- last chosen approach: {latest_policy}")
+        return "\n".join(lines)

--- a/src/familiar_neighbor/mind/social_policy.py
+++ b/src/familiar_neighbor/mind/social_policy.py
@@ -55,6 +55,74 @@ def _matches(text: str, patterns: list[str]) -> bool:
     return any(re.search(pattern, lower) for pattern in patterns)
 
 
+# ── Relationship-learned adjustment (Phase 5: closing the social loop) ──
+#
+# Recorded support failures / preferences feed back into policy selection so
+# the same misstep ("went straight to advice when they needed validation")
+# is not repeated turn after turn.
+
+_DISTRESS_ACTS = {"venting", "fatigue_signal", "grief_signal", "conflict_signal"}
+# Word-boundary regex for ASCII markers ("solve" must not match "resolved");
+# Japanese markers match as plain substrings.
+_ADVICE_FAILURE_RE = re.compile(r"\b(advice|advise|solution|solve|lecture)\b")
+_ADVICE_FAILURE_MARKERS_JA = ("正論", "アドバイス", "解決", "説教")
+_VALIDATE_FIRST_STYLES = {"validate_first", "listen_first", "listen_only"}
+
+
+def relationship_learning_inputs(relationship) -> tuple[list[str], list[str]]:
+    """Extract decide() learning inputs from a RelationshipTracker-like object."""
+    styles = [str(item.get("style", "")) for item in relationship.support_preferences()]
+    patterns = [
+        str(item.get("pattern", item.get("evidence", "")))
+        for item in relationship.failed_support_patterns()
+    ]
+    return styles, patterns
+
+
+def _learned_advice_aversion(
+    support_styles: list[str] | None,
+    failed_patterns: list[str] | None,
+) -> bool:
+    if failed_patterns and any(
+        _ADVICE_FAILURE_RE.search(pattern.lower())
+        or any(marker in pattern for marker in _ADVICE_FAILURE_MARKERS_JA)
+        for pattern in failed_patterns
+    ):
+        return True
+    if support_styles and any(
+        style.strip().lower() in _VALIDATE_FIRST_STYLES for style in support_styles
+    ):
+        return True
+    return False
+
+
+def _apply_relationship_learning(
+    decision: "SocialPolicyDecision",
+    *,
+    support_styles: list[str] | None,
+    failed_patterns: list[str] | None,
+) -> "SocialPolicyDecision":
+    """Adjust a base decision using what past support attempts taught us.
+
+    Distress turns surface the relational memory (so the model sees the
+    recorded failed patterns) and soften slightly; explicit advice requests are
+    still honored but with perspective-taking forced on and a gentler delivery.
+    Action requests ("fix this") are deliberately NOT adjusted — advice aversion
+    is about advice, not about acting on explicit asks.
+    """
+    if not _learned_advice_aversion(support_styles, failed_patterns):
+        return decision
+    if decision.primary_act in _DISTRESS_ACTS:
+        decision.should_recall_relational_memory = True
+        decision.softness = min(1.0, decision.softness + 0.05)
+    elif decision.primary_act == "request_for_advice":
+        decision.should_use_tom = True
+        decision.should_recall_relational_memory = True
+        decision.directness = max(0.0, decision.directness - 0.15)
+        decision.softness = min(1.0, decision.softness + 0.1)
+    return decision
+
+
 @dataclass(slots=True)
 class SocialPolicyDecision:
     primary_act: str
@@ -73,6 +141,32 @@ class SocialPolicyEngine:
     """Deterministic interaction policy driven by affect + input."""
 
     def decide(
+        self,
+        *,
+        user_text: str,
+        affect: AffectiveState,
+        trust: float,
+        intimacy: float,
+        interoception: InteroceptivePressure,
+        previous_response_hurt: bool = False,
+        support_styles: list[str] | None = None,
+        failed_patterns: list[str] | None = None,
+    ) -> SocialPolicyDecision:
+        decision = self._base_decision(
+            user_text=user_text,
+            affect=affect,
+            trust=trust,
+            intimacy=intimacy,
+            interoception=interoception,
+            previous_response_hurt=previous_response_hurt,
+        )
+        return _apply_relationship_learning(
+            decision,
+            support_styles=support_styles,
+            failed_patterns=failed_patterns,
+        )
+
+    def _base_decision(
         self,
         *,
         user_text: str,

--- a/src/familiar_runtime/commitments/__init__.py
+++ b/src/familiar_runtime/commitments/__init__.py
@@ -1,0 +1,15 @@
+"""Generic commitment subsystem — the secretary core.
+
+Persona-neutral storage for reminders, appointments, promises, and follow-ups
+that carry an optional due time and priority and surface back when due.
+"""
+
+from .model import Commitment, CommitmentKind, CommitmentStatus
+from .store import SQLiteCommitmentStore
+
+__all__ = [
+    "Commitment",
+    "CommitmentKind",
+    "CommitmentStatus",
+    "SQLiteCommitmentStore",
+]

--- a/src/familiar_runtime/commitments/model.py
+++ b/src/familiar_runtime/commitments/model.py
@@ -1,0 +1,75 @@
+"""Generic commitment model — the secretary core primitive.
+
+A :class:`Commitment` is anything the agent or the user has committed to and
+may need to be reminded of: a reminder, an appointment, a promise, a follow-up,
+or a lightweight task. Unlike :mod:`familiar_runtime.tasks` (goal-directed
+execution records), commitments carry an optional due time and priority and are
+designed to surface back to the user when they come due.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class CommitmentKind(str, Enum):
+    REMINDER = "reminder"
+    APPOINTMENT = "appointment"
+    PROMISE = "promise"
+    FOLLOWUP = "followup"
+    TASK = "task"
+
+
+class CommitmentStatus(str, Enum):
+    OPEN = "open"
+    SNOOZED = "snoozed"
+    DONE = "done"
+    CANCELLED = "cancelled"
+
+
+_ACTIVE = (CommitmentStatus.OPEN, CommitmentStatus.SNOOZED)
+
+
+@dataclass(slots=True)
+class Commitment:
+    id: str
+    summary: str
+    kind: CommitmentKind = CommitmentKind.REMINDER
+    status: CommitmentStatus = CommitmentStatus.OPEN
+    due_at: float | None = None
+    priority: int = 0
+    created_by: str = "agent"
+    person: str | None = None
+    created_at: float = 0.0
+    updated_at: float = 0.0
+    completed_at: float | None = None
+    snooze_until: float | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_active(self) -> bool:
+        return self.status in _ACTIVE
+
+    def effective_due(self) -> float | None:
+        """When this commitment next wants attention.
+
+        A snoozed commitment is silent until its snooze window elapses, after
+        which its original due time applies again.
+        """
+        if self.status is CommitmentStatus.SNOOZED and self.snooze_until is not None:
+            return self.snooze_until
+        return self.due_at
+
+    def is_due(self, *, now: float) -> bool:
+        if not self.is_active:
+            return False
+        due = self.effective_due()
+        return due is not None and due <= now
+
+    def is_upcoming(self, *, now: float, horizon: float) -> bool:
+        if not self.is_active:
+            return False
+        due = self.effective_due()
+        return due is not None and now < due <= now + horizon

--- a/src/familiar_runtime/commitments/model.py
+++ b/src/familiar_runtime/commitments/model.py
@@ -31,6 +31,12 @@ class CommitmentStatus(str, Enum):
 
 _ACTIVE = (CommitmentStatus.OPEN, CommitmentStatus.SNOOZED)
 
+# Proactive-reminder cadence: stop after this many self-initiated reminders, and
+# widen the gap between them by these multipliers of the base cooldown. After the
+# cap is reached the commitment goes quiet (it still surfaces in turn context).
+REMINDER_CAP = 3
+_REMINDER_BACKOFF: tuple[float, ...] = (1.0, 3.0)
+
 
 @dataclass(slots=True)
 class Commitment:
@@ -46,6 +52,8 @@ class Commitment:
     updated_at: float = 0.0
     completed_at: float | None = None
     snooze_until: float | None = None
+    last_reminded_at: float | None = None
+    reminder_count: int = 0
     metadata: dict[str, Any] = field(default_factory=dict)
 
     @property
@@ -73,3 +81,20 @@ class Commitment:
             return False
         due = self.effective_due()
         return due is not None and now < due <= now + horizon
+
+    def due_for_reminder(self, *, now: float, base_cooldown: float) -> bool:
+        """Whether a *proactive* reminder should fire now.
+
+        Independent of context surfacing: applies an escalating backoff between
+        self-initiated reminders and stops entirely after ``REMINDER_CAP`` so an
+        un-actioned commitment goes quiet instead of nagging forever.
+        """
+        if not self.is_due(now=now):
+            return False
+        if self.reminder_count >= REMINDER_CAP:
+            return False
+        if self.last_reminded_at is None:
+            return True
+        idx = max(0, self.reminder_count - 1)
+        factor = _REMINDER_BACKOFF[idx] if idx < len(_REMINDER_BACKOFF) else _REMINDER_BACKOFF[-1]
+        return (now - self.last_reminded_at) >= base_cooldown * factor

--- a/src/familiar_runtime/commitments/store.py
+++ b/src/familiar_runtime/commitments/store.py
@@ -61,7 +61,24 @@ class SQLiteCommitmentStore:
                 ON runtime_commitments(status);
             """
         )
+        self._ensure_columns()
         self._conn.commit()
+
+    def _ensure_columns(self) -> None:
+        """Idempotently add columns introduced after the initial schema.
+
+        Lets an existing commitments.db created by an earlier version pick up the
+        proactive-reminder columns without a separate migration runner.
+        """
+        existing = {
+            row["name"] for row in self._conn.execute("PRAGMA table_info(runtime_commitments)")
+        }
+        if "last_reminded_at" not in existing:
+            self._conn.execute("ALTER TABLE runtime_commitments ADD COLUMN last_reminded_at REAL")
+        if "reminder_count" not in existing:
+            self._conn.execute(
+                "ALTER TABLE runtime_commitments ADD COLUMN reminder_count INTEGER NOT NULL DEFAULT 0"
+            )
 
     # ── writes ──
 
@@ -98,9 +115,10 @@ class SQLiteCommitmentStore:
             """
             INSERT OR REPLACE INTO runtime_commitments (
                 id, summary, kind, status, due_at, priority, created_by, person,
-                created_at, updated_at, completed_at, snooze_until, metadata_json
+                created_at, updated_at, completed_at, snooze_until,
+                last_reminded_at, reminder_count, metadata_json
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 commitment.id,
@@ -115,6 +133,8 @@ class SQLiteCommitmentStore:
                 commitment.updated_at,
                 commitment.completed_at,
                 commitment.snooze_until,
+                commitment.last_reminded_at,
+                commitment.reminder_count,
                 json.dumps(commitment.metadata, ensure_ascii=False),
             ),
         )
@@ -146,9 +166,25 @@ class SQLiteCommitmentStore:
         commitment = self._require(commitment_id)
         commitment.status = CommitmentStatus.SNOOZED
         commitment.snooze_until = until
+        # Explicit deferral restarts the proactive-reminder cadence.
+        commitment.reminder_count = 0
+        commitment.last_reminded_at = None
         commitment.updated_at = time.time()
         self.save(commitment)
         return commitment
+
+    def mark_reminded(self, commitment_ids: list[str], *, at: float) -> None:
+        """Record that a proactive reminder fired for these commitments."""
+        for commitment_id in commitment_ids:
+            self._conn.execute(
+                """
+                UPDATE runtime_commitments
+                SET last_reminded_at = ?, reminder_count = reminder_count + 1, updated_at = ?
+                WHERE id = ?
+                """,
+                (at, at, commitment_id),
+            )
+        self._conn.commit()
 
     # ── reads ──
 
@@ -177,6 +213,17 @@ class SQLiteCommitmentStore:
         upcoming = [c for c in self._active() if c.is_upcoming(now=now, horizon=horizon)]
         return sorted(upcoming, key=_sort_key)
 
+    def list_due_for_reminder(self, *, now: float, base_cooldown: float) -> list[Commitment]:
+        """Due commitments that warrant a *proactive* reminder right now.
+
+        Applies the per-commitment escalating backoff + cap, distinct from
+        ``list_due`` (which is used for passive context surfacing).
+        """
+        ready = [
+            c for c in self._active() if c.due_for_reminder(now=now, base_cooldown=base_cooldown)
+        ]
+        return sorted(ready, key=_sort_key)
+
     def _from_row(self, row: sqlite3.Row) -> Commitment:
         return Commitment(
             id=row["id"],
@@ -191,6 +238,8 @@ class SQLiteCommitmentStore:
             updated_at=row["updated_at"],
             completed_at=row["completed_at"],
             snooze_until=row["snooze_until"],
+            last_reminded_at=row["last_reminded_at"],
+            reminder_count=row["reminder_count"],
             metadata=json.loads(row["metadata_json"]),
         )
 

--- a/src/familiar_runtime/commitments/store.py
+++ b/src/familiar_runtime/commitments/store.py
@@ -1,0 +1,198 @@
+"""SQLite-backed durable commitment store (secretary core).
+
+Follows the standalone-runtime-DB pattern established by
+:mod:`familiar_runtime.tasks.store`: the store self-initialises its own schema
+in a dedicated database file, so it stays persona-neutral and decoupled from the
+neighbour's observation/memory DB.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from .model import Commitment, CommitmentKind, CommitmentStatus
+
+
+def _sort_key(c: Commitment) -> tuple[int, float, int, float]:
+    """Order: dated commitments first (earliest due), then undated by priority.
+
+    Returns a tuple sorted ascending: (has_no_due, effective_due, -priority,
+    created_at). ``has_no_due`` pushes undated commitments after dated ones.
+    """
+    due = c.effective_due()
+    if due is not None:
+        return (0, due, -c.priority, c.created_at)
+    return (1, 0.0, -c.priority, c.created_at)
+
+
+class SQLiteCommitmentStore:
+    """Persist commitments in a dedicated SQLite database."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._conn.row_factory = sqlite3.Row
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS runtime_commitments (
+                id TEXT PRIMARY KEY,
+                summary TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                status TEXT NOT NULL,
+                due_at REAL,
+                priority INTEGER NOT NULL,
+                created_by TEXT NOT NULL,
+                person TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                completed_at REAL,
+                snooze_until REAL,
+                metadata_json TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_commitments_status
+                ON runtime_commitments(status);
+            """
+        )
+        self._conn.commit()
+
+    # ── writes ──
+
+    def create(
+        self,
+        *,
+        summary: str,
+        kind: CommitmentKind = CommitmentKind.REMINDER,
+        due_at: float | None = None,
+        priority: int = 0,
+        created_by: str = "agent",
+        person: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Commitment:
+        now = time.time()
+        commitment = Commitment(
+            id=f"commit_{uuid.uuid4().hex}",
+            summary=summary,
+            kind=kind,
+            status=CommitmentStatus.OPEN,
+            due_at=due_at,
+            priority=priority,
+            created_by=created_by,
+            person=person,
+            created_at=now,
+            updated_at=now,
+            metadata=metadata or {},
+        )
+        self.save(commitment)
+        return commitment
+
+    def save(self, commitment: Commitment) -> None:
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO runtime_commitments (
+                id, summary, kind, status, due_at, priority, created_by, person,
+                created_at, updated_at, completed_at, snooze_until, metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                commitment.id,
+                commitment.summary,
+                commitment.kind.value,
+                commitment.status.value,
+                commitment.due_at,
+                commitment.priority,
+                commitment.created_by,
+                commitment.person,
+                commitment.created_at,
+                commitment.updated_at,
+                commitment.completed_at,
+                commitment.snooze_until,
+                json.dumps(commitment.metadata, ensure_ascii=False),
+            ),
+        )
+        self._conn.commit()
+
+    def _require(self, commitment_id: str) -> Commitment:
+        commitment = self.get(commitment_id)
+        if commitment is None:
+            raise KeyError(f"commitment not found: {commitment_id}")
+        return commitment
+
+    def complete(self, commitment_id: str) -> Commitment:
+        commitment = self._require(commitment_id)
+        now = time.time()
+        commitment.status = CommitmentStatus.DONE
+        commitment.completed_at = now
+        commitment.updated_at = now
+        self.save(commitment)
+        return commitment
+
+    def cancel(self, commitment_id: str) -> Commitment:
+        commitment = self._require(commitment_id)
+        commitment.status = CommitmentStatus.CANCELLED
+        commitment.updated_at = time.time()
+        self.save(commitment)
+        return commitment
+
+    def snooze(self, commitment_id: str, *, until: float) -> Commitment:
+        commitment = self._require(commitment_id)
+        commitment.status = CommitmentStatus.SNOOZED
+        commitment.snooze_until = until
+        commitment.updated_at = time.time()
+        self.save(commitment)
+        return commitment
+
+    # ── reads ──
+
+    def get(self, commitment_id: str) -> Commitment | None:
+        row = self._conn.execute(
+            "SELECT * FROM runtime_commitments WHERE id = ?",
+            (commitment_id,),
+        ).fetchone()
+        return self._from_row(row) if row else None
+
+    def _active(self) -> list[Commitment]:
+        rows = self._conn.execute(
+            "SELECT * FROM runtime_commitments WHERE status IN (?, ?)",
+            (CommitmentStatus.OPEN.value, CommitmentStatus.SNOOZED.value),
+        ).fetchall()
+        return [self._from_row(row) for row in rows]
+
+    def list_open(self) -> list[Commitment]:
+        return sorted(self._active(), key=_sort_key)
+
+    def list_due(self, *, now: float) -> list[Commitment]:
+        due = [c for c in self._active() if c.is_due(now=now)]
+        return sorted(due, key=_sort_key)
+
+    def list_upcoming(self, *, now: float, horizon: float) -> list[Commitment]:
+        upcoming = [c for c in self._active() if c.is_upcoming(now=now, horizon=horizon)]
+        return sorted(upcoming, key=_sort_key)
+
+    def _from_row(self, row: sqlite3.Row) -> Commitment:
+        return Commitment(
+            id=row["id"],
+            summary=row["summary"],
+            kind=CommitmentKind(row["kind"]),
+            status=CommitmentStatus(row["status"]),
+            due_at=row["due_at"],
+            priority=row["priority"],
+            created_by=row["created_by"],
+            person=row["person"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            completed_at=row["completed_at"],
+            snooze_until=row["snooze_until"],
+            metadata=json.loads(row["metadata_json"]),
+        )
+
+    def close(self) -> None:
+        self._conn.close()

--- a/tests/test_adaptive_thinking.py
+++ b/tests/test_adaptive_thinking.py
@@ -393,6 +393,38 @@ class TestAgentConfig:
         config = AgentConfig()
         assert config.thinking_effort == "low"
 
+    def test_proactive_reminders_default_on(self, monkeypatch):
+        monkeypatch.delenv("FAMILIAR_PROACTIVE_REMINDERS", raising=False)
+        import importlib
+
+        import familiar_agent.config as cfg_mod
+
+        importlib.reload(cfg_mod)
+        assert cfg_mod.AgentConfig().proactive_reminders is True
+
+    def test_proactive_reminders_env_disables(self, monkeypatch):
+        monkeypatch.setenv("FAMILIAR_PROACTIVE_REMINDERS", "0")
+        import importlib
+
+        import familiar_agent.config as cfg_mod
+
+        importlib.reload(cfg_mod)
+        assert cfg_mod.AgentConfig().proactive_reminders is False
+
+    def test_proactive_reminders_independent_of_auto_desire(self, monkeypatch):
+        # auto_desire off, but reminders still on by default
+        monkeypatch.delenv("FAMILIAR_AUTO", raising=False)
+        monkeypatch.delenv("FAMILIAR_AUTO_DESIRE", raising=False)
+        monkeypatch.delenv("FAMILIAR_PROACTIVE_REMINDERS", raising=False)
+        import importlib
+
+        import familiar_agent.config as cfg_mod
+
+        importlib.reload(cfg_mod)
+        config = cfg_mod.AgentConfig()
+        assert config.auto_desire is False
+        assert config.proactive_reminders is True
+
 
 # ── helpers ────────────────────────────────────────────────────────────────
 

--- a/tests/test_commitment_tool.py
+++ b/tests/test_commitment_tool.py
@@ -1,0 +1,179 @@
+"""Tests for the CommitmentTool and its capability wiring (secretary surface)."""
+
+from __future__ import annotations
+
+import pytest
+
+from familiar_agent.tools.commitments import (
+    CommitmentTool,
+    format_commitments_for_context,
+)
+from familiar_capabilities.commitments import CommitmentCapability
+from familiar_runtime.commitments import (
+    CommitmentKind,
+    CommitmentStatus,
+    SQLiteCommitmentStore,
+)
+
+FIXED_NOW = 1_000_000.0
+
+
+@pytest.fixture
+def tool(tmp_path):
+    store = SQLiteCommitmentStore(tmp_path / "commitments.db")
+    yield CommitmentTool(store, clock=lambda: FIXED_NOW)
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_add_commitment_returns_id_and_persists(tool):
+    text, image = await tool.call(
+        "add_commitment",
+        {"summary": "call dentist", "kind": "reminder", "priority": 2},
+    )
+    assert image is None
+    assert "call dentist" in text
+    stored = tool.store.list_open()
+    assert len(stored) == 1
+    assert stored[0].summary == "call dentist"
+    assert stored[0].priority == 2
+    assert stored[0].created_by == "user"
+
+
+@pytest.mark.asyncio
+async def test_add_commitment_due_in_minutes_sets_due_at(tool):
+    await tool.call("add_commitment", {"summary": "tea", "due_in_minutes": 30})
+    c = tool.store.list_open()[0]
+    assert c.due_at == pytest.approx(FIXED_NOW + 30 * 60)
+
+
+@pytest.mark.asyncio
+async def test_add_commitment_due_at_iso(tool):
+    await tool.call(
+        "add_commitment",
+        {"summary": "meeting", "due_at_iso": "2026-06-11T09:00:00"},
+    )
+    c = tool.store.list_open()[0]
+    assert c.due_at is not None and c.due_at > 0
+
+
+@pytest.mark.asyncio
+async def test_list_commitments_due_filter(tool):
+    await tool.call("add_commitment", {"summary": "overdue", "due_in_minutes": -5})
+    await tool.call("add_commitment", {"summary": "later", "due_in_minutes": 600})
+    text, _ = await tool.call("list_commitments", {"filter": "due"})
+    assert "overdue" in text
+    assert "later" not in text
+
+
+@pytest.mark.asyncio
+async def test_complete_commitment(tool):
+    add_text, _ = await tool.call("add_commitment", {"summary": "x"})
+    cid = tool.store.list_open()[0].id
+    text, _ = await tool.call("complete_commitment", {"id": cid})
+    assert "✓" in text or "done" in text.lower() or "完了" in text
+    assert tool.store.get(cid).status is CommitmentStatus.DONE
+
+
+@pytest.mark.asyncio
+async def test_snooze_commitment(tool):
+    await tool.call("add_commitment", {"summary": "ping", "due_in_minutes": -1})
+    cid = tool.store.list_open()[0].id
+    await tool.call("snooze_commitment", {"id": cid, "minutes": 60})
+    assert tool.store.get(cid).status is CommitmentStatus.SNOOZED
+    assert tool.store.list_due(now=FIXED_NOW) == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_returns_error_text(tool):
+    text, _ = await tool.call("nonexistent", {})
+    assert "unknown" in text.lower() or "error" in text.lower()
+
+
+def test_capability_exposes_four_tools(tmp_path):
+    store = SQLiteCommitmentStore(tmp_path / "c.db")
+    tool = CommitmentTool(store)
+    cap = CommitmentCapability(tool)
+    names = {spec.name for spec in cap.specs()}
+    assert names == {
+        "add_commitment",
+        "list_commitments",
+        "complete_commitment",
+        "snooze_commitment",
+    }
+    for spec in cap.specs():
+        assert spec.category == "commitment"
+        assert spec.input_schema.get("type") == "object"
+    store.close()
+
+
+def test_format_commitments_for_context():
+    store = SQLiteCommitmentStore(":memory:")
+    due = [store.create(summary="overdue ping", due_at=FIXED_NOW - 10, priority=2)]
+    upcoming = [store.create(summary="dentist at 3", due_at=FIXED_NOW + 3600)]
+    text = format_commitments_for_context(due=due, upcoming=upcoming)
+    assert "overdue ping" in text
+    assert "dentist at 3" in text
+    # empty input yields empty string
+    assert format_commitments_for_context(due=[], upcoming=[]) == ""
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_commitment_kind_defaults_to_reminder():
+    store = SQLiteCommitmentStore(":memory:")
+    tool = CommitmentTool(store)
+    await tool.call("add_commitment", {"summary": "no kind"})
+    assert store.list_open()[0].kind is CommitmentKind.REMINDER
+    store.close()
+
+
+def test_agent_commitments_context_surfaces_due(tmp_path):
+    """The EmbodiedAgent surface method renders due commitments without a full boot."""
+    import time
+    import types
+
+    from familiar_agent.agent import EmbodiedAgent
+
+    store = SQLiteCommitmentStore(tmp_path / "c.db")
+    store.create(summary="overdue thing", due_at=time.time() - 10, priority=2)
+    store.create(summary="far thing", due_at=time.time() + 10_000_000)
+    stub = types.SimpleNamespace(_commitment_store=store)
+
+    ctx = EmbodiedAgent._commitments_context(stub)
+    assert "overdue thing" in ctx
+    assert "Reminders due now" in ctx
+    assert "far thing" not in ctx  # outside the upcoming horizon
+    store.close()
+
+
+def test_agent_commitments_context_empty_without_store():
+    import types
+
+    from familiar_agent.agent import EmbodiedAgent
+
+    stub = types.SimpleNamespace(_commitment_store=None)
+    assert EmbodiedAgent._commitments_context(stub) == ""
+
+
+def test_build_tool_registry_includes_commitment_tools(tmp_path):
+    """When the commitment tool is present, its tools land in the registry."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from familiar_agent.agent import EmbodiedAgent
+
+    agent = EmbodiedAgent.__new__(EmbodiedAgent)
+    for attr in ("_camera", "_mobility", "_tts", "_mcp"):
+        setattr(agent, attr, None)
+    for attr in ("_memory_tool", "_tom_tool", "_coding"):
+        m = MagicMock()
+        m.call = AsyncMock(return_value=("ok", None))
+        setattr(agent, attr, m)
+    store = SQLiteCommitmentStore(tmp_path / "c.db")
+    agent._commitment_tool = CommitmentTool(store)
+
+    registry = agent._build_tool_registry()
+    names = {spec["name"] for spec in registry.tool_defs()}
+    assert "add_commitment" in names
+    assert "complete_commitment" in names
+    store.close()

--- a/tests/test_commitment_tool.py
+++ b/tests/test_commitment_tool.py
@@ -177,3 +177,46 @@ def test_build_tool_registry_includes_commitment_tools(tmp_path):
     assert "add_commitment" in names
     assert "complete_commitment" in names
     store.close()
+
+
+# ── today's agenda (morning secretary surface) ──
+
+
+def _agenda_stub(store):
+    import types
+
+    return types.SimpleNamespace(_commitment_store=store)
+
+
+def test_today_agenda_includes_due_and_today_only(tmp_path):
+    import time as _time
+
+    from familiar_agent.agent import EmbodiedAgent
+
+    store = SQLiteCommitmentStore(tmp_path / "c.db")
+    now = _time.time()
+    store.create(summary="overdue call", due_at=now - 600, priority=1)
+    store.create(summary="dentist 15:00", due_at=now + 3600)
+    store.create(summary="next week thing", due_at=now + 8 * 86400)
+    store.create(summary="no due note")
+
+    ctx = EmbodiedAgent._today_agenda_context(_agenda_stub(store))
+    assert "Today's agenda" in ctx
+    assert "overdue call" in ctx
+    assert "dentist 15:00" in ctx
+    assert "next week thing" not in ctx
+    assert "no due note" not in ctx
+    store.close()
+
+
+def test_today_agenda_empty_cases(tmp_path):
+    import types
+
+    from familiar_agent.agent import EmbodiedAgent
+
+    # no store at all
+    assert EmbodiedAgent._today_agenda_context(types.SimpleNamespace(_commitment_store=None)) == ""
+    # empty store
+    store = SQLiteCommitmentStore(tmp_path / "c.db")
+    assert EmbodiedAgent._today_agenda_context(_agenda_stub(store)) == ""
+    store.close()

--- a/tests/test_commitments.py
+++ b/tests/test_commitments.py
@@ -114,3 +114,139 @@ def test_is_due_helper():
     assert not c.is_due(now=50.0)
     assert c.is_upcoming(now=50.0, horizon=100.0)
     assert not c.is_upcoming(now=50.0, horizon=10.0)
+
+
+# ── proactive-reminder cadence (Phase 3) ──
+
+BASE = 600.0
+
+
+def test_reminder_columns_persist(tmp_path):
+    path = tmp_path / "commitments.db"
+    s1 = SQLiteCommitmentStore(path)
+    c = s1.create(summary="ping", due_at=10.0)
+    s1.mark_reminded([c.id], at=100.0)
+    s1.close()
+
+    s2 = SQLiteCommitmentStore(path)
+    got = s2.get(c.id)
+    assert got.last_reminded_at == 100.0
+    assert got.reminder_count == 1
+    s2.close()
+
+
+def test_mark_reminded_increments(store):
+    c = store.create(summary="ping", due_at=10.0)
+    store.mark_reminded([c.id], at=100.0)
+    store.mark_reminded([c.id], at=200.0)
+    got = store.get(c.id)
+    assert got.reminder_count == 2
+    assert got.last_reminded_at == 200.0
+
+
+def test_due_for_reminder_first_time_fires(store):
+    now = 10_000.0
+    store.create(summary="fresh", due_at=now - 5)
+    ready = store.list_due_for_reminder(now=now, base_cooldown=BASE)
+    assert [c.summary for c in ready] == ["fresh"]
+
+
+def test_due_for_reminder_respects_backoff(store):
+    now = 10_000.0
+    c = store.create(summary="ping", due_at=now - 5)
+    store.mark_reminded([c.id], at=now)
+    # within base cooldown → not yet
+    assert store.list_due_for_reminder(now=now + BASE / 2, base_cooldown=BASE) == []
+    # after base cooldown → fires again (2nd)
+    assert len(store.list_due_for_reminder(now=now + BASE + 1, base_cooldown=BASE)) == 1
+
+
+def test_due_for_reminder_escalates_and_caps(store):
+    now = 10_000.0
+    c = store.create(summary="ping", due_at=now - 5)
+    # 1st fire
+    store.mark_reminded([c.id], at=now)
+    # 2nd fire after 1x base
+    t2 = now + BASE + 1
+    assert store.list_due_for_reminder(now=t2, base_cooldown=BASE)
+    store.mark_reminded([c.id], at=t2)
+    # 3rd needs 3x base; 1x is not enough
+    assert store.list_due_for_reminder(now=t2 + BASE + 1, base_cooldown=BASE) == []
+    t3 = t2 + 3 * BASE + 1
+    assert store.list_due_for_reminder(now=t3, base_cooldown=BASE)
+    store.mark_reminded([c.id], at=t3)
+    # capped at 3 reminders → goes quiet forever
+    assert store.list_due_for_reminder(now=t3 + 100 * BASE, base_cooldown=BASE) == []
+    # but it is still surfaced for passive context
+    assert store.list_due(now=t3 + 100 * BASE)
+
+
+def test_due_for_reminder_clamps_inconsistent_zero_count():
+    """count=0 with last_reminded_at set (unreachable via the public API) must use
+    the base factor (1.0), not silently pick the longest backoff via idx=-1."""
+    now = 10_000.0
+    c = Commitment(
+        id="x",
+        summary="s",
+        kind=CommitmentKind.REMINDER,
+        status=CommitmentStatus.OPEN,
+        due_at=now - 5,
+        last_reminded_at=now - 1.5 * BASE,  # past 1.0*BASE, well short of 3.0*BASE
+        reminder_count=0,
+    )
+    assert c.due_for_reminder(now=now, base_cooldown=BASE)
+
+
+def test_snooze_resets_reminder_cadence(store):
+    now = 10_000.0
+    c = store.create(summary="ping", due_at=now - 5)
+    store.mark_reminded([c.id], at=now)
+    store.mark_reminded([c.id], at=now + BASE + 1)
+    store.snooze(c.id, until=now + 10)
+    got = store.get(c.id)
+    assert got.reminder_count == 0
+    assert got.last_reminded_at is None
+
+
+def test_legacy_db_without_reminder_columns_migrates(tmp_path):
+    import sqlite3
+
+    path = tmp_path / "old.db"
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE runtime_commitments (
+            id TEXT PRIMARY KEY,
+            summary TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            status TEXT NOT NULL,
+            due_at REAL,
+            priority INTEGER NOT NULL,
+            created_by TEXT NOT NULL,
+            person TEXT,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            completed_at REAL,
+            snooze_until REAL,
+            metadata_json TEXT NOT NULL
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO runtime_commitments VALUES "
+        "('commit_old', 'legacy', 'reminder', 'open', 5.0, 0, 'user', NULL, "
+        "1.0, 1.0, NULL, NULL, '{}')"
+    )
+    conn.commit()
+    conn.close()
+
+    store = SQLiteCommitmentStore(path)
+    got = store.get("commit_old")
+    assert got is not None
+    assert got.reminder_count == 0
+    assert got.last_reminded_at is None
+    # the migrated DB supports the new reminder query
+    assert [c.summary for c in store.list_due_for_reminder(now=100.0, base_cooldown=BASE)] == [
+        "legacy"
+    ]
+    store.close()

--- a/tests/test_commitments.py
+++ b/tests/test_commitments.py
@@ -1,0 +1,116 @@
+"""Tests for the generic Commitment store (secretary core)."""
+
+from __future__ import annotations
+
+import pytest
+
+from familiar_runtime.commitments import (
+    Commitment,
+    CommitmentKind,
+    CommitmentStatus,
+    SQLiteCommitmentStore,
+)
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = SQLiteCommitmentStore(tmp_path / "commitments.db")
+    yield s
+    s.close()
+
+
+def test_create_and_get(store):
+    c = store.create(summary="call dentist", kind=CommitmentKind.REMINDER)
+    assert c.id.startswith("commit_")
+    assert c.status is CommitmentStatus.OPEN
+    assert c.kind is CommitmentKind.REMINDER
+    got = store.get(c.id)
+    assert got is not None
+    assert got.summary == "call dentist"
+
+
+def test_reload_persists(tmp_path):
+    path = tmp_path / "commitments.db"
+    s1 = SQLiteCommitmentStore(path)
+    c = s1.create(summary="buy milk", due_at=1234.0, priority=2, person="kota")
+    s1.close()
+
+    s2 = SQLiteCommitmentStore(path)
+    got = s2.get(c.id)
+    assert got is not None
+    assert got.summary == "buy milk"
+    assert got.due_at == 1234.0
+    assert got.priority == 2
+    assert got.person == "kota"
+    s2.close()
+
+
+def test_list_open_excludes_done_and_cancelled(store):
+    a = store.create(summary="a")
+    b = store.create(summary="b")
+    store.complete(a.id)
+    store.cancel(b.id)
+    store.create(summary="c")
+    assert [x.summary for x in store.list_open()] == ["c"]
+
+
+def test_due_and_upcoming(store):
+    now = 1000.0
+    store.create(summary="overdue", due_at=now - 10)
+    store.create(summary="soon", due_at=now + 100)
+    store.create(summary="far", due_at=now + 10_000)
+    store.create(summary="no_due")
+
+    assert [x.summary for x in store.list_due(now=now)] == ["overdue"]
+    assert [x.summary for x in store.list_upcoming(now=now, horizon=3600)] == ["soon"]
+
+
+def test_open_ordering_due_first_then_priority(store):
+    now = 1000.0
+    store.create(summary="low_due", due_at=now + 50, priority=0)
+    store.create(summary="high_due", due_at=now + 10, priority=3)
+    store.create(summary="no_due_hi", priority=2)
+    store.create(summary="no_due_lo", priority=0)
+
+    ordered = [x.summary for x in store.list_open()]
+    # dated commitments first (earliest due), then undated by priority desc
+    assert ordered == ["high_due", "low_due", "no_due_hi", "no_due_lo"]
+
+
+def test_snooze_hides_until_window_then_reappears(store):
+    now = 1000.0
+    c = store.create(summary="ping", due_at=now - 5)
+    assert [x.summary for x in store.list_due(now=now)] == ["ping"]
+
+    store.snooze(c.id, until=now + 100)
+    assert store.list_due(now=now) == []
+    assert store.get(c.id).status is CommitmentStatus.SNOOZED
+
+    # once the snooze window passes it is due again
+    assert [x.summary for x in store.list_due(now=now + 200)] == ["ping"]
+
+
+def test_complete_sets_timestamp(store):
+    c = store.create(summary="done soon")
+    done = store.complete(c.id)
+    assert done.status is CommitmentStatus.DONE
+    assert done.completed_at is not None
+
+
+def test_update_unknown_id_raises(store):
+    with pytest.raises(KeyError):
+        store.complete("commit_does_not_exist")
+
+
+def test_is_due_helper():
+    c = Commitment(
+        id="x",
+        summary="s",
+        kind=CommitmentKind.REMINDER,
+        status=CommitmentStatus.OPEN,
+        due_at=100.0,
+    )
+    assert c.is_due(now=200.0)
+    assert not c.is_due(now=50.0)
+    assert c.is_upcoming(now=50.0, horizon=100.0)
+    assert not c.is_upcoming(now=50.0, horizon=10.0)

--- a/tests/test_gui_async_stability.py
+++ b/tests/test_gui_async_stability.py
@@ -214,6 +214,103 @@ async def test_gui_idle_desire_logs_localized_murmur(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_gui_proactive_reminder_fires_when_due(monkeypatch, tmp_path):
+    from types import SimpleNamespace
+
+    from familiar_runtime.commitments import SQLiteCommitmentStore
+
+    win = _make_window_stub()
+    store = SQLiteCommitmentStore(tmp_path / "c.db")
+    store.create(summary="take meds", due_at=1.0, priority=1)
+    win._agent = SimpleNamespace(
+        config=SimpleNamespace(proactive_reminders=True, auto_desire=False),
+        _commitment_store=store,
+        _heartbeat=None,
+    )
+    win._agent_ready = True
+
+    captured: dict[str, str] = {}
+
+    async def _fake_run_agent(text: str, inner_voice: str = "") -> None:
+        captured["text"] = text
+        captured["inner_voice"] = inner_voice
+
+    win._run_agent = _fake_run_agent  # type: ignore[method-assign]
+
+    call_count = {"n": 0}
+
+    async def _fake_wait_for(awaitable, timeout):
+        if hasattr(awaitable, "close"):
+            awaitable.close()
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise asyncio.TimeoutError
+        return None
+
+    monkeypatch.setattr("familiar_agent.gui.asyncio.wait_for", _fake_wait_for)
+    # Bypass the idle-gap/cooldown timing gate; we are testing the wiring here.
+    monkeypatch.setattr(
+        "familiar_agent.gui.should_fire_commitment_reminder",
+        lambda **kwargs: list(store.list_open()),
+    )
+
+    await FamiliarWindow._process_queue(win)
+
+    assert captured["text"] == ""
+    assert "take meds" in captured["inner_voice"]
+    # mark_reminded advanced the cadence so it won't immediately re-fire.
+    assert store.list_open()[0].reminder_count == 1
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_gui_mid_turn_snooze_survives_mark(monkeypatch, tmp_path):
+    """GUI marks BEFORE the turn, so an in-turn snooze cadence reset is final."""
+    import time as _time
+    from types import SimpleNamespace
+
+    from familiar_runtime.commitments import SQLiteCommitmentStore
+
+    win = _make_window_stub()
+    store = SQLiteCommitmentStore(tmp_path / "c.db")
+    c = store.create(summary="take meds", due_at=1.0, priority=1)
+    win._agent = SimpleNamespace(
+        config=SimpleNamespace(proactive_reminders=True, auto_desire=False),
+        _commitment_store=store,
+        _heartbeat=None,
+    )
+    win._agent_ready = True
+
+    async def _snoozes_during_turn(text: str, inner_voice: str = "") -> None:
+        store.snooze(c.id, until=_time.time() + 3600)
+
+    win._run_agent = _snoozes_during_turn  # type: ignore[method-assign]
+
+    call_count = {"n": 0}
+
+    async def _fake_wait_for(awaitable, timeout):
+        if hasattr(awaitable, "close"):
+            awaitable.close()
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise asyncio.TimeoutError
+        return None
+
+    monkeypatch.setattr("familiar_agent.gui.asyncio.wait_for", _fake_wait_for)
+    monkeypatch.setattr(
+        "familiar_agent.gui.should_fire_commitment_reminder",
+        lambda **kwargs: store.list_due(now=_time.time()),
+    )
+
+    await FamiliarWindow._process_queue(win)
+
+    got = store.get(c.id)
+    assert got.reminder_count == 0  # snooze reset not clobbered by post-run mark
+    assert got.last_reminded_at is None
+    store.close()
+
+
+@pytest.mark.asyncio
 async def test_gui_cancel_turn_cancels_running_task_and_logs():
     win = _make_window_stub()
     win._agent_running = True

--- a/tests/test_main_repl_reminder.py
+++ b/tests/test_main_repl_reminder.py
@@ -1,0 +1,156 @@
+"""Wiring tests for the REPL proactive-reminder branch in main.repl().
+
+The reminder branch must sit BEFORE the auto_desire guard so reminders fire
+even when desire-driven idle turns are disabled (independent toggle).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from familiar_agent.main import repl
+from familiar_runtime.commitments import SQLiteCommitmentStore
+
+
+@pytest.fixture
+def stdin_guard(monkeypatch):
+    """Block the repl's stdin reader thread until the test finishes.
+
+    repl() spawns a run_in_executor stdin reader; without this, pytest's
+    captured stdin returns EOF instantly and the loop exits before idle.
+    """
+    release = threading.Event()
+
+    def fake_readline() -> str:
+        release.wait(timeout=10)
+        return ""  # EOF once released
+
+    monkeypatch.setattr("sys.stdin", SimpleNamespace(readline=fake_readline))
+    yield
+    release.set()
+
+
+@pytest.fixture
+def no_process_exit(monkeypatch):
+    """repl()'s finally block calls os._exit(0); neuter it so pytest survives."""
+    calls: list[int] = []
+    monkeypatch.setattr("familiar_agent.main.os._exit", lambda code: calls.append(code))
+    return calls
+
+
+def _fake_agent(store, *, proactive: bool, auto_desire: bool = False):
+    agent = SimpleNamespace(
+        is_embedding_ready=True,
+        config=SimpleNamespace(proactive_reminders=proactive, auto_desire=auto_desire),
+        _commitment_store=store,
+        _heartbeat=None,
+        run=AsyncMock(),
+        close=AsyncMock(),
+    )
+    return agent
+
+
+def _fake_wait_for_factory(behaviors):
+    """Pop a behavior per call: 'timeout' raises TimeoutError, 'stop' raises KeyboardInterrupt.
+
+    Once behaviors are exhausted, delegate to the awaitable itself (covers the
+    cleanup wait_for calls in repl()'s finally block).
+    """
+    real_wait_for = asyncio.wait_for
+
+    async def _fake_wait_for(awaitable, timeout):
+        if not behaviors:
+            return await real_wait_for(awaitable, timeout)
+        if hasattr(awaitable, "close"):
+            awaitable.close()
+        action = behaviors.pop(0)
+        if action == "timeout":
+            raise asyncio.TimeoutError
+        raise KeyboardInterrupt
+
+    return _fake_wait_for
+
+
+@pytest.mark.asyncio
+async def test_repl_reminder_fires_with_auto_desire_off(
+    monkeypatch, tmp_path, stdin_guard, no_process_exit
+):
+    store = SQLiteCommitmentStore(tmp_path / "c.db")
+    store.create(summary="meds", due_at=time.time() - 60, priority=1)
+    agent = _fake_agent(store, proactive=True, auto_desire=False)
+
+    monkeypatch.setattr("familiar_agent.main.create_realtime_stt_session", lambda: None)
+    monkeypatch.setattr(
+        "familiar_agent.main.asyncio.wait_for", _fake_wait_for_factory(["timeout", "stop"])
+    )
+    # Bypass the wall-clock idle gap (last_interaction is set to now inside repl).
+    monkeypatch.setattr(
+        "familiar_agent.main.should_fire_commitment_reminder",
+        lambda **kw: kw["store"].list_due(now=time.time()),
+    )
+
+    await repl(agent, desires=SimpleNamespace(), debug=False)
+
+    agent.run.assert_awaited_once()
+    kwargs = agent.run.await_args.kwargs
+    assert agent.run.await_args.args[0] == ""
+    assert "meds" in kwargs["inner_voice"]
+    # mark_reminded advanced the cadence
+    assert store.list_open()[0].reminder_count == 1
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_repl_reminder_turn_error_does_not_kill_repl(
+    monkeypatch, tmp_path, stdin_guard, no_process_exit
+):
+    """A backend error during the reminder turn must not crash (and silently
+    os._exit) the REPL; the slot is still burned so a flapping backend
+    self-limits via the cadence cap."""
+    store = SQLiteCommitmentStore(tmp_path / "c.db")
+    store.create(summary="meds", due_at=time.time() - 60, priority=1)
+    agent = _fake_agent(store, proactive=True, auto_desire=False)
+    agent.run = AsyncMock(side_effect=RuntimeError("api down"))
+
+    monkeypatch.setattr("familiar_agent.main.create_realtime_stt_session", lambda: None)
+    monkeypatch.setattr(
+        "familiar_agent.main.asyncio.wait_for",
+        _fake_wait_for_factory(["timeout", "stop"]),
+    )
+    monkeypatch.setattr(
+        "familiar_agent.main.should_fire_commitment_reminder",
+        lambda **kw: kw["store"].list_due(now=time.time()),
+    )
+
+    # Must return normally (KeyboardInterrupt from 'stop' caught inside repl).
+    await repl(agent, desires=SimpleNamespace(), debug=False)
+
+    agent.run.assert_awaited_once()
+    assert store.list_open()[0].reminder_count == 1  # slot burned despite the error
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_repl_reminder_respects_toggle_off(
+    monkeypatch, tmp_path, stdin_guard, no_process_exit
+):
+    store = SQLiteCommitmentStore(tmp_path / "c.db")
+    store.create(summary="meds", due_at=time.time() - 60, priority=1)
+    agent = _fake_agent(store, proactive=False, auto_desire=False)
+
+    monkeypatch.setattr("familiar_agent.main.create_realtime_stt_session", lambda: None)
+    monkeypatch.setattr(
+        "familiar_agent.main.asyncio.wait_for", _fake_wait_for_factory(["timeout", "stop"])
+    )
+
+    await repl(agent, desires=SimpleNamespace(), debug=False)
+
+    agent.run.assert_not_awaited()
+    assert store.list_open()[0].reminder_count == 0
+    store.close()

--- a/tests/test_person_model.py
+++ b/tests/test_person_model.py
@@ -213,3 +213,24 @@ async def test_tom_canonicalizes_companion_case_variants(tmp_path):
 def test_recent_reads_case_insensitively(tracker):
     tracker.record_inference(person="Kota", states=[("calm", 0.5)], evidence=[], policy="")
     assert tracker.recent("kota", n=5)[0]["state"] == "calm"
+
+
+def test_context_for_prompt_excludes_stale_inferences(tracker):
+    """Inferences older than the max age must not steer the agent."""
+    from datetime import datetime, timedelta, timezone
+
+    tracker.record_inference(person="kota", states=[("fresh mood", 0.6)], evidence=[], policy="")
+    # Inject an old row directly (record_inference always stamps now).
+    old = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+    db = tracker._ensure_db()
+    db.execute(
+        "INSERT INTO person_inferences (id, person, state, confidence, evidence_json,"
+        " policy, source, created_at) VALUES ('pinf_old', 'kota', 'ancient mood', 0.9,"
+        " '[]', '', 'tom', ?)",
+        (old,),
+    )
+    db.commit()
+
+    ctx = tracker.context_for_prompt("kota")
+    assert "fresh mood" in ctx
+    assert "ancient mood" not in ctx

--- a/tests/test_person_model.py
+++ b/tests/test_person_model.py
@@ -234,3 +234,17 @@ def test_context_for_prompt_excludes_stale_inferences(tracker):
     ctx = tracker.context_for_prompt("kota")
     assert "fresh mood" in ctx
     assert "ancient mood" not in ctx
+
+
+def test_unparseable_created_at_treated_as_stale(tracker):
+    tracker.record_inference(person="kota", states=[("fresh", 0.5)], evidence=[], policy="")
+    db = tracker._ensure_db()
+    db.execute(
+        "INSERT INTO person_inferences (id, person, state, confidence, evidence_json,"
+        " policy, source, created_at) VALUES ('pinf_bad', 'kota', 'garbled', 0.9,"
+        " '[]', '', 'tom', 'not-a-timestamp')"
+    )
+    db.commit()
+    ctx = tracker.context_for_prompt("kota")
+    assert "fresh" in ctx
+    assert "garbled" not in ctx

--- a/tests/test_person_model.py
+++ b/tests/test_person_model.py
@@ -1,0 +1,215 @@
+"""Tests for the persistent person model (Phase 4: ToM accumulation).
+
+The PersonModelTracker stores per-person mental-state inferences produced by
+the ToM tool, so the agent accumulates a model of each person instead of
+re-inferring from scratch every turn.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from familiar_neighbor.mind.person_model import PersonModelTracker
+
+
+@pytest.fixture
+def tracker(tmp_path):
+    t = PersonModelTracker(db_path=tmp_path / "observations.db")
+    yield t
+    t.close()
+
+
+def test_record_and_recent_roundtrip(tracker):
+    tracker.record_inference(
+        person="kota",
+        states=[("tired but satisfied", 0.8), ("wants quiet company", 0.6)],
+        evidence=["said 'おつかれ'", "short replies"],
+        policy="keep it brief and warm",
+    )
+    rows = tracker.recent("kota", n=5)
+    assert len(rows) == 2
+    states = {r["state"] for r in rows}
+    assert states == {"tired but satisfied", "wants quiet company"}
+    assert rows[0]["policy"] == "keep it brief and warm"
+    assert rows[0]["confidence"] in (0.8, 0.6)
+
+
+def test_recent_returns_newest_first(tracker):
+    tracker.record_inference(person="kota", states=[("old", 0.5)], evidence=[], policy="")
+    tracker.record_inference(person="kota", states=[("new", 0.5)], evidence=[], policy="")
+    rows = tracker.recent("kota", n=2)
+    assert rows[0]["state"] == "new"
+
+
+def test_recent_filters_by_person(tracker):
+    tracker.record_inference(person="kota", states=[("a", 0.5)], evidence=[], policy="")
+    tracker.record_inference(person="akari", states=[("b", 0.5)], evidence=[], policy="")
+    assert {r["state"] for r in tracker.recent("kota", n=10)} == {"a"}
+
+
+def test_context_for_prompt_renders_states_and_policy(tracker):
+    tracker.record_inference(
+        person="kota",
+        states=[("worried about deadline", 0.7)],
+        evidence=[],
+        policy="validate first, no advice",
+    )
+    ctx = tracker.context_for_prompt("kota")
+    assert "Person model" in ctx
+    assert "kota" in ctx
+    assert "worried about deadline" in ctx
+    assert "validate first, no advice" in ctx
+
+
+def test_context_for_prompt_empty_for_unknown_person(tracker):
+    assert tracker.context_for_prompt("nobody") == ""
+
+
+def test_persists_across_reopen(tmp_path):
+    path = tmp_path / "observations.db"
+    t1 = PersonModelTracker(db_path=path)
+    t1.record_inference(person="kota", states=[("calm", 0.9)], evidence=["tone"], policy="p")
+    t1.close()
+
+    t2 = PersonModelTracker(db_path=path)
+    assert t2.recent("kota", n=1)[0]["state"] == "calm"
+    t2.close()
+
+
+def test_migration_creates_table(tmp_path):
+    path = tmp_path / "observations.db"
+    t = PersonModelTracker(db_path=path)
+    t.record_inference(person="x", states=[("s", 0.1)], evidence=[], policy="")
+    t.close()
+    conn = sqlite3.connect(path)
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    conn.close()
+    assert "person_inferences" in tables
+
+
+# ── ToM writeback ──
+
+
+class _JSONBackend:
+    """Fake utility backend returning a fixed ToM JSON payload."""
+
+    def __init__(self, payload: str) -> None:
+        self._payload = payload
+
+    async def complete(self, prompt: str, max_tokens: int) -> str:
+        return self._payload
+
+
+class _FakeMemory:
+    async def recall_async(self, query: str, n: int = 5) -> list[dict]:
+        return []
+
+
+@pytest.mark.asyncio
+async def test_tom_tool_writes_back_to_person_model(tmp_path):
+    from familiar_agent.tools.tom import ToMTool
+
+    tracker = PersonModelTracker(db_path=tmp_path / "observations.db")
+    backend = _JSONBackend(
+        '{"evidence": ["short reply"], '
+        '"inference": [{"state": "exhausted", "confidence": 0.85}], '
+        '"policy": "let him rest"}'
+    )
+    tool = ToMTool(_FakeMemory(), default_person="kota", backend=backend, person_model=tracker)
+
+    text, image = await tool.call("tom", {"situation": "「もう寝るわ」とだけ言った"})
+
+    assert image is None
+    assert "exhausted" in text
+    rows = tracker.recent("kota", n=5)
+    assert len(rows) == 1
+    assert rows[0]["state"] == "exhausted"
+    assert rows[0]["confidence"] == pytest.approx(0.85)
+    assert rows[0]["policy"] == "let him rest"
+    tracker.close()
+
+
+@pytest.mark.asyncio
+async def test_tom_tool_without_person_model_still_works(tmp_path):
+    from familiar_agent.tools.tom import ToMTool
+
+    backend = _JSONBackend('{"evidence": [], "inference": [], "policy": "p"}')
+    tool = ToMTool(_FakeMemory(), default_person="kota", backend=backend)
+    text, _ = await tool.call("tom", {"situation": "hello"})
+    assert "kota" in text
+
+
+@pytest.mark.asyncio
+async def test_tom_writeback_failure_does_not_break_tool(tmp_path):
+    from familiar_agent.tools.tom import ToMTool
+
+    class _BrokenTracker:
+        def record_inference(self, **kwargs):
+            raise RuntimeError("db locked")
+
+    backend = _JSONBackend(
+        '{"evidence": [], "inference": [{"state": "ok", "confidence": 0.5}], "policy": "p"}'
+    )
+    tool = ToMTool(
+        _FakeMemory(), default_person="kota", backend=backend, person_model=_BrokenTracker()
+    )
+    text, _ = await tool.call("tom", {"situation": "hello"})
+    assert "ok" in text  # tool output unaffected by writeback failure
+
+
+# ── agent surface ──
+
+
+def test_agent_person_model_context_surfaces(tmp_path):
+    import types
+
+    from familiar_agent.agent import EmbodiedAgent
+
+    tracker = PersonModelTracker(db_path=tmp_path / "observations.db")
+    tracker.record_inference(
+        person="kota", states=[("misses conversation", 0.7)], evidence=[], policy="reach out"
+    )
+    stub = types.SimpleNamespace(
+        _person_model=tracker,
+        config=types.SimpleNamespace(companion_name="kota"),
+    )
+    ctx = EmbodiedAgent._person_model_context(stub)
+    assert "misses conversation" in ctx
+    tracker.close()
+
+
+def test_agent_person_model_context_empty_without_tracker():
+    import types
+
+    from familiar_agent.agent import EmbodiedAgent
+
+    stub = types.SimpleNamespace(
+        _person_model=None,
+        config=types.SimpleNamespace(companion_name="kota"),
+    )
+    assert EmbodiedAgent._person_model_context(stub) == ""
+
+
+@pytest.mark.asyncio
+async def test_tom_canonicalizes_companion_case_variants(tmp_path):
+    """'Kota' must be stored under the canonical companion key 'kota' so the
+    accumulated model actually surfaces (person-key fragmentation guard)."""
+    from familiar_agent.tools.tom import ToMTool
+
+    tracker = PersonModelTracker(db_path=tmp_path / "observations.db")
+    backend = _JSONBackend(
+        '{"evidence": [], "inference": [{"state": "cheerful", "confidence": 0.6}], "policy": ""}'
+    )
+    tool = ToMTool(_FakeMemory(), default_person="kota", backend=backend, person_model=tracker)
+
+    await tool.call("tom", {"situation": "smiled", "person": "Kota"})
+
+    assert tracker.recent("kota", n=5)[0]["state"] == "cheerful"
+    tracker.close()
+
+
+def test_recent_reads_case_insensitively(tracker):
+    tracker.record_inference(person="Kota", states=[("calm", 0.5)], evidence=[], policy="")
+    assert tracker.recent("kota", n=5)[0]["state"] == "calm"

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -27,6 +27,20 @@ def test_setup_config_to_env_values_serializes_auto_flags() -> None:
     assert values["FAMILIAR_AUTO_SAY"] == "false"
 
 
+def test_setup_config_serializes_proactive_reminders() -> None:
+    on = setup_config_to_env_values(SetupConfig(proactive_reminders=True))
+    off = setup_config_to_env_values(SetupConfig(proactive_reminders=False))
+    assert on["FAMILIAR_PROACTIVE_REMINDERS"] == "true"
+    assert off["FAMILIAR_PROACTIVE_REMINDERS"] == "false"
+
+
+def test_proactive_reminders_field_present_and_advanced() -> None:
+    fields = {f.attr: f for f in iter_setting_fields(setup_mode=False)}
+    assert "proactive_reminders" in fields
+    assert fields["proactive_reminders"].section == "advanced"
+    assert fields["proactive_reminders"].widget == "bool"
+
+
 def test_validate_setup_config_requires_api_key_only_in_setup_mode() -> None:
     config = SetupConfig(api_key="", camera_onvif_port="not-a-port")
 

--- a/tests/test_social_policy.py
+++ b/tests/test_social_policy.py
@@ -149,3 +149,160 @@ def test_user_correction_prefers_plain_clarification_without_extra_inference() -
     assert decision.response_mode == "clarify"
     assert decision.should_use_tom is False
     assert decision.avoid_problem_solving is True
+
+
+# ── Phase 5: relationship-learned policy adjustment ────────────────────────
+#
+# Recorded support failures / preferences must actually change future policy
+# decisions — closing the social learning loop.
+
+
+def _decide(text: str, *, mood: str = "engaged", **kwargs):
+    appraisal = AppraisalEngine()
+    policy_engine = SocialPolicyEngine()
+    affect = appraisal.appraise(
+        AppraisalContext(user_text=text, companion_mood=mood, interoception=_pressure())
+    )
+    return policy_engine.decide(
+        user_text=text,
+        affect=affect,
+        trust=0.4,
+        intimacy=0.4,
+        interoception=_pressure(),
+        **kwargs,
+    )
+
+
+def test_no_history_leaves_decision_unchanged() -> None:
+    baseline = _decide("むかつくわ、最悪や")
+    same = _decide("むかつくわ、最悪や", support_styles=[], failed_patterns=[])
+    assert same == baseline
+
+
+def test_failed_advice_pattern_surfaces_relational_memory_on_venting() -> None:
+    text = "むかつくわ、最悪や"
+    baseline = _decide(text, mood="frustrated")
+    assert baseline.primary_act == "venting"
+    assert baseline.should_recall_relational_memory is False  # trust 0.4 < 0.5
+
+    learned = _decide(
+        text,
+        mood="frustrated",
+        failed_patterns=["went straight to advice, felt lectured"],
+    )
+    assert learned.should_recall_relational_memory is True
+    assert learned.softness > baseline.softness
+
+
+def test_failed_advice_pattern_japanese_markers_match() -> None:
+    learned = _decide(
+        "むかつくわ、最悪や",
+        mood="frustrated",
+        failed_patterns=["正論で返してしまって逆効果だった"],
+    )
+    assert learned.should_recall_relational_memory is True
+
+
+def test_advice_request_with_learned_aversion_softens_and_uses_tom() -> None:
+    text = "これどうしたらいいかな"
+    baseline = _decide(text)
+    assert baseline.primary_act == "request_for_advice"
+    assert baseline.should_use_tom is False  # low threat
+
+    learned = _decide(text, failed_patterns=["unsolicited solution dump"])
+    assert learned.primary_act == "request_for_advice"  # still advises — they asked
+    assert learned.should_use_tom is True
+    assert learned.should_recall_relational_memory is True
+    assert learned.directness < baseline.directness
+    assert learned.softness > baseline.softness
+    assert learned.avoid_problem_solving is False  # explicit ask still honored
+
+
+def test_validate_first_support_style_triggers_learning_too() -> None:
+    learned = _decide(
+        "もう疲れたわ、しんどい",
+        mood="tired",
+        support_styles=["validate_first"],
+    )
+    assert learned.primary_act == "fatigue_signal"
+    assert learned.should_recall_relational_memory is True
+
+
+def test_unrelated_failed_pattern_does_not_adjust() -> None:
+    text = "むかつくわ、最悪や"
+    baseline = _decide(text, mood="frustrated")
+    same = _decide(text, mood="frustrated", failed_patterns=["forgot a promised reminder"])
+    assert same == baseline
+
+
+def test_relationship_learning_inputs_contract(tmp_path) -> None:
+    """The extraction helper must match RelationshipTracker's stored item shapes."""
+    from familiar_agent.relationship import RelationshipTracker
+    from familiar_agent.social_policy import relationship_learning_inputs
+
+    tracker = RelationshipTracker(
+        state_path=tmp_path / "relationship.json",
+        db_path=tmp_path / "observations.db",
+    )
+    tracker.record_support_preference("listen before fixing", style="validate_first")
+    tracker.record_failed_support_pattern("went straight to advice", consequence="felt lectured")
+
+    styles, patterns = relationship_learning_inputs(tracker)
+    assert "validate_first" in styles
+    assert any("advice" in p for p in patterns)
+    tracker.close()
+
+
+def test_conflict_signal_gets_learning_softening() -> None:
+    from familiar_agent.mental_state import AffectiveState
+
+    policy_engine = SocialPolicyEngine()
+    hot_affect = AffectiveState(
+        valence=-0.4,
+        arousal=0.7,
+        dominance=-0.2,
+        attachment_pull=0.2,
+        tenderness=0.2,
+        threat=0.7,
+        uncertainty=0.4,
+        frustration=0.6,
+        loneliness=0.2,
+        summary="",
+    )
+    base = policy_engine.decide(
+        user_text="そうきたか",
+        affect=hot_affect,
+        trust=0.4,
+        intimacy=0.4,
+        interoception=_pressure(),
+    )
+    assert base.primary_act == "conflict_signal"
+
+    learned = policy_engine.decide(
+        user_text="そうきたか",
+        affect=hot_affect,
+        trust=0.4,
+        intimacy=0.4,
+        interoception=_pressure(),
+        failed_patterns=["jumped to advice mid-conflict"],
+    )
+    assert learned.softness > base.softness
+
+
+def test_action_request_is_not_adjusted_by_advice_aversion() -> None:
+    text = "これ直しといて、頼むわ"
+    baseline = _decide(text)
+    assert baseline.primary_act == "request_for_action"
+    learned = _decide(text, failed_patterns=["unsolicited advice dump"])
+    assert learned == baseline  # acting on explicit asks is not advice-giving
+
+
+def test_positive_pattern_with_resolved_does_not_trigger() -> None:
+    text = "むかつくわ、最悪や"
+    baseline = _decide(text, mood="frustrated")
+    same = _decide(
+        text,
+        mood="frustrated",
+        failed_patterns=["they resolved things alone, I was not needed"],
+    )
+    assert same == baseline  # "resolved" must not match the "solve" marker

--- a/tests/test_tui_reminder_tick.py
+++ b/tests/test_tui_reminder_tick.py
@@ -1,0 +1,117 @@
+"""Wiring tests for FamiliarApp._reminder_tick (TUI proactive reminders)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from familiar_agent.tui import FamiliarApp
+from familiar_runtime.commitments import SQLiteCommitmentStore
+
+
+def _stub(store, *, proactive: bool = True, agent_running: bool = False):
+    app = SimpleNamespace(
+        agent=SimpleNamespace(
+            config=SimpleNamespace(proactive_reminders=proactive, auto_desire=False),
+            _commitment_store=store,
+            _heartbeat=None,
+        ),
+        _agent_running=agent_running,
+        _input_queue=asyncio.Queue(),
+        _last_interaction=time.time() - 3600,
+        _run_agent=AsyncMock(),
+    )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_tui_reminder_tick_fires_and_marks(tmp_path):
+    store = SQLiteCommitmentStore(tmp_path / "c.db")
+    store.create(summary="stretch break", due_at=time.time() - 60)
+    app = _stub(store)
+
+    await FamiliarApp._reminder_tick(app)
+
+    app._run_agent.assert_awaited_once()
+    assert "stretch break" in app._run_agent.await_args.kwargs["inner_voice"]
+    assert store.list_open()[0].reminder_count == 1
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_tui_reminder_tick_respects_toggle(tmp_path):
+    store = SQLiteCommitmentStore(tmp_path / "c.db")
+    store.create(summary="stretch break", due_at=time.time() - 60)
+    app = _stub(store, proactive=False)
+
+    await FamiliarApp._reminder_tick(app)
+
+    app._run_agent.assert_not_awaited()
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_tui_reminder_tick_skips_while_running(tmp_path):
+    store = SQLiteCommitmentStore(tmp_path / "c.db")
+    store.create(summary="stretch break", due_at=time.time() - 60)
+    app = _stub(store, agent_running=True)
+
+    await FamiliarApp._reminder_tick(app)
+
+    app._run_agent.assert_not_awaited()
+    assert store.list_open()[0].reminder_count == 0
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_tui_mid_turn_snooze_survives_mark(tmp_path):
+    """mark_reminded fires BEFORE the turn, so an in-turn snooze reset is final."""
+    store = SQLiteCommitmentStore(tmp_path / "c.db")
+    c = store.create(summary="stretch break", due_at=time.time() - 60)
+    app = _stub(store)
+
+    async def _snoozes_during_turn(text, inner_voice=""):
+        # The model responds to the reminder by snoozing the commitment.
+        store.snooze(c.id, until=time.time() + 3600)
+
+    app._run_agent = _snoozes_during_turn
+
+    await FamiliarApp._reminder_tick(app)
+
+    got = store.get(c.id)
+    assert got.reminder_count == 0  # snooze reset not clobbered
+    assert got.last_reminded_at is None
+    store.close()
+
+
+@pytest.mark.asyncio
+async def test_tui_process_queue_requeues_input_during_autonomous_turn(tmp_path):
+    """Input dequeued while an autonomous turn runs is re-queued, not run concurrently."""
+    queue: asyncio.Queue = asyncio.Queue()
+    run_calls: list[str] = []
+
+    app = SimpleNamespace(_agent_running=False, _input_queue=queue)
+
+    async def _run_agent(text):
+        run_calls.append(text)
+
+    app._run_agent = _run_agent
+
+    task = asyncio.create_task(FamiliarApp._process_queue(app))
+    await asyncio.sleep(0.01)  # parked in get()
+
+    app._agent_running = True  # an autonomous turn (reminder tick) starts
+    await queue.put("hello")  # user speaks during the turn
+    await asyncio.sleep(0.12)  # woken consumer must re-queue, not run
+
+    assert run_calls == []
+    app._agent_running = False  # autonomous turn finishes
+    await asyncio.sleep(0.2)
+
+    assert run_calls == ["hello"]
+    await queue.put(None)
+    await asyncio.wait_for(task, timeout=2)

--- a/tests/test_ui_helpers.py
+++ b/tests/test_ui_helpers.py
@@ -9,10 +9,14 @@ from __future__ import annotations
 
 from familiar_agent._ui_helpers import (
     ACTION_ICONS,
+    commitment_reminder_prompt,
+    decide_idle_action,
     desire_tick_prompt,
     format_action,
+    should_fire_commitment_reminder,
     should_fire_idle_desire,
 )
+from familiar_runtime.commitments import SQLiteCommitmentStore
 
 
 # ---------------------------------------------------------------------------
@@ -217,4 +221,162 @@ class TestShouldFireIdleDesire:
             last_interaction=100.0,
             now=190.0,
             cooldown=90.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Proactive commitment reminders (Phase 3)
+# ---------------------------------------------------------------------------
+
+BASE = 600.0
+NOW = 10_000.0
+
+
+def _store(tmp_path):
+    return SQLiteCommitmentStore(tmp_path / "commitments.db")
+
+
+class TestShouldFireCommitmentReminder:
+    def test_fires_for_due_commitment_when_idle(self, tmp_path):
+        store = _store(tmp_path)
+        store.create(summary="ping", due_at=NOW - 5)
+        ready = should_fire_commitment_reminder(
+            agent_running=False,
+            has_pending_input=False,
+            last_interaction=NOW - 1000,
+            now=NOW,
+            store=store,
+            base_cooldown=BASE,
+        )
+        assert [c.summary for c in ready] == ["ping"]
+        store.close()
+
+    def test_suppressed_while_agent_running(self, tmp_path):
+        store = _store(tmp_path)
+        store.create(summary="ping", due_at=NOW - 5)
+        assert (
+            should_fire_commitment_reminder(
+                agent_running=True,
+                has_pending_input=False,
+                last_interaction=NOW - 1000,
+                now=NOW,
+                store=store,
+                base_cooldown=BASE,
+            )
+            == []
+        )
+        store.close()
+
+    def test_suppressed_with_pending_input(self, tmp_path):
+        store = _store(tmp_path)
+        store.create(summary="ping", due_at=NOW - 5)
+        assert (
+            should_fire_commitment_reminder(
+                agent_running=False,
+                has_pending_input=True,
+                last_interaction=NOW - 1000,
+                now=NOW,
+                store=store,
+                base_cooldown=BASE,
+            )
+            == []
+        )
+        store.close()
+
+    def test_suppressed_within_min_idle_gap(self, tmp_path):
+        store = _store(tmp_path)
+        store.create(summary="ping", due_at=NOW - 5)
+        assert (
+            should_fire_commitment_reminder(
+                agent_running=False,
+                has_pending_input=False,
+                last_interaction=NOW - 5,  # only 5s since last interaction
+                now=NOW,
+                store=store,
+                base_cooldown=BASE,
+                min_idle_gap=30.0,
+            )
+            == []
+        )
+        store.close()
+
+    def test_quiet_hours_blocks_low_priority(self, tmp_path):
+        store = _store(tmp_path)
+        store.create(summary="trivial", due_at=NOW - 5, priority=1)
+        ready = should_fire_commitment_reminder(
+            agent_running=False,
+            has_pending_input=False,
+            last_interaction=NOW - 1000,
+            now=NOW,
+            store=store,
+            base_cooldown=BASE,
+            quiet_hours=True,
+        )
+        assert ready == []
+        store.close()
+
+    def test_quiet_hours_allows_urgent(self, tmp_path):
+        store = _store(tmp_path)
+        store.create(summary="urgent", due_at=NOW - 5, priority=2)
+        ready = should_fire_commitment_reminder(
+            agent_running=False,
+            has_pending_input=False,
+            last_interaction=NOW - 1000,
+            now=NOW,
+            store=store,
+            base_cooldown=BASE,
+            quiet_hours=True,
+        )
+        assert [c.summary for c in ready] == ["urgent"]
+        store.close()
+
+    def test_empty_store(self, tmp_path):
+        store = _store(tmp_path)
+        assert (
+            should_fire_commitment_reminder(
+                agent_running=False,
+                has_pending_input=False,
+                last_interaction=NOW - 1000,
+                now=NOW,
+                store=store,
+                base_cooldown=BASE,
+            )
+            == []
+        )
+        store.close()
+
+
+def test_commitment_reminder_prompt_includes_summaries(tmp_path):
+    store = _store(tmp_path)
+    a = store.create(summary="call dentist", due_at=NOW - 5)
+    b = store.create(summary="water plants", due_at=NOW - 5)
+    text = commitment_reminder_prompt([a, b])
+    assert "call dentist" in text
+    assert "water plants" in text
+    store.close()
+
+
+class TestDecideIdleAction:
+    def test_user_input_wins(self):
+        assert (
+            decide_idle_action(has_pending_input=True, reminder_ready=True, desire_ready=True)
+            == "user"
+        )
+
+    def test_reminder_beats_desire(self):
+        assert (
+            decide_idle_action(has_pending_input=False, reminder_ready=True, desire_ready=True)
+            == "reminder"
+        )
+
+    def test_desire_when_no_reminder(self):
+        assert (
+            decide_idle_action(has_pending_input=False, reminder_ready=False, desire_ready=True)
+            == "desire"
+        )
+
+    def test_idle_when_nothing(self):
+        assert (
+            decide_idle_action(has_pending_input=False, reminder_ready=False, desire_ready=False)
+            == "idle"
         )


### PR DESCRIPTION
## Summary

Two pillars toward "more human, more socially capable":

**Secretary layer** — the agent can now hold commitments (reminders,
appointments, promises, follow-ups) with due times and priorities, surface
them passively in every turn, proactively speak up when they come due
(independent of auto_desire, `FAMILIAR_PROACTIVE_REMINDERS` default ON,
quiet-hours aware, escalating backoff capped at 3 reminders), and open the
day with a `[Today's agenda]` block on the first turn.

**Social accumulation** — ToM inferences now persist per person
(`person_inferences`, migration 010) and surface as an accumulated
`[Person model]` block (7-day staleness cutoff); recorded support failures
and preferences now feed back into `SocialPolicyEngine.decide()` so the same
support misstep is not repeated.

## Hardening

All three idle loops were wired through multi-agent adversarial review;
11 confirmed findings fixed and re-verified, including: mark-before-run
(mid-turn snooze survives), TUI concurrent agent.run race (re-queue for
interrupt drain), REPL silent-death via `os._exit(0)` on backend errors,
person-key fragmentation (canonicalization + COLLATE NOCASE).

## Tests

+87 tests across store cadence/backoff, legacy-DB migration, idle-loop
wiring (REPL/TUI/GUI), config independence, person-model roundtrip and
writeback isolation, social-policy learning invariance. Full suite
1070 passed; ruff/format/mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)