### PR TITLE
feat: deterministic perspective-taking, honest capacity boundary, and delight misclassification fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Secretary layer: commitments (reminders, appointments, promises, follow-ups) with due times, priorities, and snooze in a dedicated store; add/list/complete/snooze tools; due and upcoming items surface in every turn and a `[Today's agenda]` block opens the day
+- Proactive reminders: due commitments fire self-initiated turns from REPL/TUI/GUI idle loops, independent of `auto_desire` (`FAMILIAR_PROACTIVE_REMINDERS`, default on), quiet-hours aware (urgent-only at night), with escalating backoff capped at 3 reminders
+- Persistent person model: ToM inferences accumulate per person (`person_inferences`) and surface as an accumulated `[Person model]` prompt block with a 7-day staleness cutoff
+- Social learning loop: recorded failed support patterns and support preferences now adjust `SocialPolicyEngine.decide()` (surface relational memory and soften on distress; force perspective-taking on advice requests)
+- Deterministic perspective-taking: `should_use_tom` turns now actually run the ToM inference (bounded, cooldown-protected) and inject the result instead of relying on the model to call the tool
+- Agency boundary: when the agent itself is running low and is asked for work, advice, or repair, the policy instructs honest capacity acknowledgement instead of overpromising
 - GitHub Actions-based release automation for the new `develop -> main -> tag` flow, including a manual release PR workflow and an automatic tag/release workflow on `main`
 - Bootstrap-based startup recovery for missing or legacy `.env` files, including shared setup persistence and `ANTHROPIC_* -> PLATFORM/API_KEY/MODEL` migration support
 - Schema-driven settings metadata that powers both the GUI settings dialog and the first-run setup wizard from one definition
@@ -50,6 +56,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Embodied tool routing now goes through the generic ToolRegistry while preserving existing camera, voice, memory, coding, and MCP behavior
 
 ### Fixed
+- Kansai past-tense "〜やった" (e.g. 「散々やった」) no longer classifies as delight; only exclamatory forms (やったー/やった！/やったぜ) celebrate
 - `scripts/new_migration.sh` now accepts Windows-style `--dir` paths in Git Bash so cross-platform CI migration tests pass on `windows-latest`
 - The app no longer exits before opening setup when `API_KEY` is missing; GUI users are routed into first-run setup and non-GUI users get a clear fallback path
 - Realtime STT no longer re-ingests the agent's own speech during or immediately after TTS playback, and repeated echo loops now trigger an automatic reconnect

--- a/docs/adr/0004-llm-speech-act-fallback.md
+++ b/docs/adr/0004-llm-speech-act-fallback.md
@@ -1,0 +1,78 @@
+# ADR 0004: LLM fallback for speech-act classification
+
+## Status
+
+Proposed
+
+## Context
+
+`SocialPolicyEngine._base_decision` classifies the companion's utterance into
+one of ~17 speech acts using ordered regex pattern lists. A four-round,
+reproduction-required audit (2026-06) found and fixed **51 wrong-register
+misfires** — including inverted registers such as celebrating a tumor
+diagnosis (腫瘍ができた → delight), comforting joy slang (最高すぎて死んだ →
+grief), apologizing when thanked (この前の返事ありがとうな → repair), and
+treating the most common workplace greeting as an exhaustion complaint
+(お疲れ様です → fatigue). All 51 are pinned by regression tests in
+`tests/test_social_policy.py`.
+
+The audit did **not** run dry. The rounds converged on failure classes that
+regular expressions cannot close:
+
+1. **Unbounded lexicons** — ailment formations (虫歯/ものもらい/できもの…)
+   can be netted by a locative frame (体部位+に…できた) but never enumerated.
+2. **Reported speech** — やめろって言われた is a disclosure, やめろ is a
+   boundary; the same surface token inverts meaning by quotation.
+3. **Transitivity / direction** — 傷ついた (I was hurt) vs 友達を傷つけた
+   (I hurt someone) vs 主人公が傷つくシーン (fiction).
+4. **Concession and scope** — 疲れたけど最高の一日やった！ is joy;
+   最高の誕生日になるはずやったのに is lament. Regex sees both tokens in both.
+5. **Sarcasm** — 最高かよ is regex-detectable; "yay, another outage" is not.
+
+Each class was patched for its reproduced instances, but the tail is
+structural: these distinctions require parsing, not matching.
+
+## Decision (proposed)
+
+Keep the regex layer as the deterministic fast path, and add an **LLM
+fallback** via the existing utility backend for exactly two situations:
+
+1. **Fallthrough** — when no pattern matches and the turn lands in the
+   `attuned`/`bid_for_connection` fallback *and* the utterance is substantive
+   (length above a threshold, not a desire turn), ask the utility backend to
+   pick the speech act from the fixed 17-act vocabulary (single completion,
+   ~50 output tokens, strict JSON, 2s timeout, fallback to `attuned` on any
+   failure).
+2. **Conflict** — when two or more of {delight, venting/grief, repair,
+   boundary} pattern groups match the same utterance (the mixed-sentiment /
+   inversion-risk zone), let the LLM arbitrate instead of branch order.
+
+The deterministic layer remains authoritative for everything else, so
+existing tests and latency characteristics are unchanged for the common case.
+The 51-case regression suite doubles as the evaluation set for the fallback
+prompt.
+
+Costs: one extra utility call on a minority of turns (estimated <15%; the
+auto-ToM cooldown pattern from `embodied_hook._should_auto_tom` can rate-limit
+identically). Risks: nondeterminism in the arbitration zone — mitigated by
+keeping the regex verdict when the LLM call fails or returns an act outside
+the vocabulary.
+
+## Alternatives considered
+
+- **Keep auditing regexes** — rounds produced 16 → 12 → 12 → 10 findings;
+  the marginal round cost is constant while severity declines. Reasonable as
+  maintenance, insufficient as a fix for classes 1–5.
+- **Replace the classifier with the LLM entirely** — loses determinism,
+  testability, and the zero-latency common path; the appraisal/policy layers
+  were deliberately designed deterministic (see project development rules).
+- **A small local classifier model** — attractive long-term, but adds a
+  deployment dependency the utility backend already covers.
+
+## Consequences
+
+- `SocialPolicyEngine.decide()` would gain an optional async variant or a
+  pre-computed `llm_act_hint` input (computed in `prepare_turn` alongside
+  auto-ToM) so the engine itself stays synchronous and testable.
+- The fallback prompt and act vocabulary become versioned artifacts pinned by
+  the existing regression suite.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,6 +66,13 @@ JSONL append-only logging with replay support remains available.
 - Preferences (likes/dislikes)
 - Boundaries (things to avoid)
 - Session/conversation counting, days-together tracking
+- Support preferences and failed support patterns feed back into social
+  policy decisions (learned validate-first, advice aversion)
+
+**Person model** — `familiar_neighbor/mind/person_model.py`:
+- ToM inferences accumulate per person (states + confidence + chosen policy)
+- Surfaced as an accumulated-impressions prompt block (7-day staleness cutoff)
+- Written deterministically: flagged turns run the ToM inference themselves
 
 **Working memory** — Recent context + workspace coalitions
 
@@ -95,6 +102,12 @@ JSONL append-only logging with replay support remains available.
 - Score = activation × (0.4×urgency + 0.3×novelty + 0.3)
 - Ignition threshold modulated by prediction error
 - Winner's context injected into LLM prompt
+
+**Commitments / proactive reminders** — `familiar_runtime/commitments` + idle-loop wiring:
+- Due-time promises (reminders, appointments, follow-ups) with priority and snooze
+- Fire self-initiated turns from REPL/TUI/GUI idle loops, independent of desires
+- Quiet hours pass urgent-only; escalating backoff goes quiet after 3 reminders
+- Passive surface every turn + `[Today's agenda]` on the first turn of the day
 
 ### Layer E: Expression → `agent.py` ReAct loop + `tools/tts.py`
 

--- a/plans/secretary-and-social-foundation.md
+++ b/plans/secretary-and-social-foundation.md
@@ -1,127 +1,134 @@
-# familiar-ai 基盤強化 — 秘書能力 + 社会性フィードバックループ
+# familiar-ai foundation work — secretary capability + social feedback loops
 
-## ゴール（ユーザ設定）
+## Goal (user-set)
 
-> より人間らしく、あるいは社会性高く振る舞えるような基盤にしたい。
-> それにあたって、タスク遂行エージェントとしての能力も欲しい。特に秘書的な振る舞い。
+> Make the foundation behave more human-like and socially capable, and add
+> task-execution agent capability — especially secretary-like behavior.
 
-## 現状分析（調査済み）
+## Baseline analysis
 
-### 既にあるもの
-- **社会性（`familiar_neighbor/mind/`）**: appraisal（PAD感情）/ social_policy（17発話行為×13応答モード）/ relationship（trust/intimacy + 傾向/境界/儀式）/ meta_monitor（応答ゲート）/ workspace（GWT競争）/ tom（ToM tool）/ scene（世界モデル）。豊富だが **一方向フロー**（入力→appraise→decide→出力）。
-- **タスク**: `familiar_runtime/tasks/`（Task + checkpoint, 独自 `runtime_tasks.db`, self-init schema）。task-mode CLI 専用。
-- **やり残し**: `ConcernEngine`（感情的テーマ, 自動decay, JSON）/ `unfinished_business`（memory DB, prompt に最大3件 surface）。
+### What already existed
+- **Sociality (`familiar_neighbor/mind/`)**: appraisal (PAD affect) / social_policy
+  (17 speech acts × 13 response modes) / relationship (trust/intimacy +
+  tendencies/boundaries/rituals) / meta_monitor (response gate) / workspace (GWT
+  competition) / tom (ToM tool) / scene (world model). Rich, but a **one-way flow**
+  (input → appraise → decide → output).
+- **Tasks**: `familiar_runtime/tasks/` (Task + checkpoints, own `runtime_tasks.db`,
+  self-init schema). Task-mode CLI only.
+- **Unfinished threads**: `ConcernEngine` (affective topics, auto-decay, JSON) and
+  `unfinished_business` (memory DB, up to 3 surfaced per turn).
 
-### 欠けているギャップ
-1. **秘書の核がない**: 期日・優先度を持ち、due になったら**自発的に思い出す**「約束・予定・リマインダ」レイヤが無い。Task は期日/優先度/リマインダを持たず、プロンプトにも出ない。
-2. **社会的学習ループが閉じてない**: `relationship.failed_support_patterns` を記録しても `social_policy.decide()` が参照せず、過去の失敗/成功が応答選択に反映されない。
-3. **相手モデルが蓄積されない**: ToM は毎回 recall して推論するだけ。persistent な person model が無い。
+### Gaps
+1. **No secretary core**: nothing held due-dated, prioritized commitments and
+   *proactively* spoke up when they came due. Tasks have no due/priority and never
+   reach the prompt.
+2. **The social learning loop never closed**: `relationship.failed_support_patterns`
+   was recorded but `social_policy.decide()` never consulted it.
+3. **No accumulated person model**: ToM re-inferred from scratch every call.
 
-## 設計方針
+## Approach
 
-- 秘書能力は **persona非依存の汎用基盤** → `familiar_runtime/commitments/`（`tasks/` の先例に倣い独自DB self-init）。
-- 社会性強化は **既存 mind/ レイヤの結線追加**（決定論ロジック優先、プロンプト肥大を避ける）。
-- 各 Phase は独立 PR 相当、テスト緑を維持。TDD（RED→GREEN）。
-
----
-
-## Phase 1 — Commitment ストア（秘書の核, 汎用基盤）✅
-
-**新規** `src/familiar_runtime/commitments/`:
-- `model.py`:
-  - `CommitmentKind(str, Enum)`: REMINDER / APPOINTMENT / PROMISE / FOLLOWUP / TASK
-  - `CommitmentStatus(str, Enum)`: OPEN / DONE / CANCELLED / SNOOZED
-  - `@dataclass Commitment`: id, summary, kind, status, due_at(float|None), priority(int 0-3),
-    created_by(str), person(str|None), created_at, updated_at, completed_at(float|None),
-    snooze_until(float|None), metadata
-  - helper: `is_due(now)`, `is_upcoming(now, horizon)`, `effective_due()`
-- `store.py` `SQLiteCommitmentStore`（独自 `commitments.db`, self-init）:
-  - create / save / get / update_status / complete / snooze / cancel
-  - list_open / list_due(now) / list_upcoming(now, horizon)
-  - 並び順: due_at（NULL は後ろ）, priority 降順, created_at
-- `__init__.py` で re-export
-
-**テスト** `tests/test_commitments.py`: create/reload, due 判定, upcoming 判定, snooze 復活,
-complete, priority+due 並び順, cancelled 除外。
+- Secretary capability lives in the **persona-neutral substrate** →
+  `familiar_runtime/commitments/` (own self-init DB, following the `tasks/` pattern).
+- Sociality work is **wiring inside the existing mind/ layer** (deterministic logic
+  first; avoid growing the prompt).
+- Each phase ships PR-sized with the full gate green. TDD (RED → GREEN).
 
 ---
 
-## Phase 2 — ツール + capability + 配線 + surface（秘書をエージェントに繋ぐ）✅
+## Phase 1 — Commitment store (secretary core) ✅
 
-- **新規** `src/familiar_agent/tools/commitments.py` `CommitmentTool`（legacy tool 形式: `get_tool_definitions()` + async `call()`）:
-  - `add_commitment`（summary, kind?, due_in_minutes?|due_at_iso?, priority?, person?）
-  - `list_commitments`（filter: open/due/upcoming/all）
-  - `complete_commitment`（id）
-  - `snooze_commitment`（id, minutes）
-- **新規** `src/familiar_capabilities/commitments.py` `CommitmentCapability(LegacyToolProvider)`
-- **配線** `agent.py`: store/tool を `__init__` で構築、`_build_tool_registry()` で register
-- **surface** `embodied_hook.py`: due + upcoming を continuity_ctx に注入（`unfinished_business` と同パターン、`[Reminders due]` / `[Upcoming]`）
-- **テスト**: tool 単体 + capability spec + surface 文字列。
+`src/familiar_runtime/commitments/`: `Commitment`
+(reminder/appointment/promise/followup/task; due_at, priority 0-3, snooze, person)
++ `SQLiteCommitmentStore` (list_due / list_upcoming / list_open, due+priority
+ordering, snooze). 9 tests.
 
----
+## Phase 2 — Tool + capability + wiring + surface ✅
 
-## Phase 3 — 自発的リマインド（実装済 ✅）
+`CommitmentTool` (add/list/complete/snooze; relative-minutes and ISO due times) +
+`CommitmentCapability`; constructed and registered in `agent.py`; due + upcoming
+items surface into the turn continuity context in `embodied_hook.py`. 13 tests.
 
-ユーザ確定: トグル独立・既定ON / quiet hours は priority>=2 のみ / だんだん間隔を空けて止まる。
+## Phase 3 — Proactive reminders ✅
 
-- model: `last_reminded_at` / `reminder_count` / `due_for_reminder()`（backoff base×{1,3}, REMINDER_CAP=3 で沈黙。passive surface は継続）
-- store: `_ensure_columns()` idempotent ALTER / `list_due_for_reminder` / `mark_reminded`（targeted UPDATE）/ `snooze` で cadence リセット
-- config: `AgentConfig.proactive_reminders`（`FAMILIAR_PROACTIVE_REMINDERS`、既定 True、auto_desire 独立）+ settings_schema（advanced/bool）
-- i18n: `reminder_impulse`（en/ja、他言語 en フォールバック）。complete/snooze ツール呼び出しまで指示
-- `_ui_helpers`: `should_fire_commitment_reminder`（純粋ゲート: running/pending/idle-gap/quiet-priority）/ `commitment_reminder_prompt` / `decide_idle_action`
-- 3ループ配線: main repl / tui `_reminder_tick` / gui `_process_queue` — いずれも **auto_desire ガードの前**
-- テスト +33（store cadence・legacy DB 移行・ゲート全分岐・config 独立性・3ループ配線統合・mark-before-run 固定）
+User-locked decisions: independent toggle (`FAMILIAR_PROACTIVE_REMINDERS`, default
+ON) / quiet hours pass only priority>=2 / escalating backoff (base 600s × {1,3})
+capped at 3 reminders, then quiet while still surfacing passively.
 
-**多角レビュー（4次元×敵対検証）→ 確定 10 findings を全修正:**
-- `mark_reminded` を**ターン前**に移動（3ループ）— ターン中の snooze による cadence リセットを保護、
-  失敗時セマンティクス統一（エラーでもスロット消費 → flapping backend が cap で自己制限）
-- TUI 二重 `agent.run` レース: `_process_queue` が `get()` 後に `_agent_running` ならキューへ差し戻し
-  （実行中ターンが interrupt_queue 経由で吸収）
-- REPL: reminder turn とゲート＋mark を try/except 保護（裸だと finally の `os._exit(0)` で silent death）、
-  ターン後に `last_interaction_time` 更新（desire の連続発火防止）
-- GUI/TUI: tick 本体（heartbeat/store 呼び出し）を例外ガード — sqlite エラーで idle ループが恒久死しない
-- `due_for_reminder` の idx を `max(0, ...)` でクランプ + 不整合状態のテスト
-- `decide_idle_action` docstring を実態（contract の参照実装）に修正
-- 修正後に per-fix 敵対検証 7/7 resolved + completeness 残渣（mark ガード/GUI mark-before-run pin/clamp テスト）も解消
+- model: `last_reminded_at` / `reminder_count` / `due_for_reminder()` (backoff+cap)
+- store: idempotent `_ensure_columns()` ALTER migration / `list_due_for_reminder` /
+  `mark_reminded` (targeted UPDATE) / snooze resets the cadence
+- config: `AgentConfig.proactive_reminders` + settings schema (advanced/bool)
+- i18n: `reminder_impulse` (en/ja; other locales fall back to en); instructs the
+  model to call complete/snooze after delivering
+- `_ui_helpers`: `should_fire_commitment_reminder` (pure gate:
+  running/pending/idle-gap/quiet-priority) / `commitment_reminder_prompt` /
+  `decide_idle_action` (reference implementation of the idle precedence)
+- wired into all three idle loops (REPL / TUI `_reminder_tick` / GUI) — each
+  **before** the `auto_desire` guard
+- tests +33 (store cadence, legacy-DB migration, all gate branches, config
+  independence, per-loop wiring integration, mark-before-run pinned)
 
----
-
-## Phase 4 — Person Model 永続化（社会性: ToM 蓄積）
-
-**問題**: ToMTool の LLM 推論は構造化 JSON `{evidence, inference[{state,confidence}], policy}` を生成するのに
-markdown に平坦化して捨てている（`_last_policy` のみ揮発保持）。相手の心的モデルが蓄積されない。
-
-**設計**（RelationshipTracker の永続パターン踏襲: lazy conn + WAL + apply_migrations）:
-- migration `2026-06-XX-010_person_models.py`: `person_inferences` テーブル
-  （id TEXT PK, person TEXT, state TEXT, confidence REAL, evidence_json TEXT, policy TEXT,
-  source TEXT default 'tom', created_at TEXT ISO）+ person/created_at index。observations.db に同居。
-- **新規** `src/familiar_neighbor/mind/person_model.py` `PersonModelTracker`:
-  `record_inference(person, states, evidence, policy)` / `recent(person, n)` /
-  `context_for_prompt(person)` → `[Person model: X]` ブロック（最近の推定＋確信度＋最後に効いた方針、recency 順）
-- `ToMTool`: `_llm_inference` で JSON parse 成功時に tracker へ書き戻し（optional 依存、None なら従来挙動）
-- `agent.py`: tracker 構築 → ToMTool へ注入。`embodied_hook.prepare_turn` で companion の
-  `context_for_prompt` を relationship ctx の隣に注入
-- テスト: tracker CRUD/プロンプト整形/migration 適用（test_memory_migrations.py パターン）/
-  ToM 書き戻し（fake backend が JSON 返却）/ hook surface
+**Multi-agent adversarial review (4 dimensions × verification) → 10 confirmed
+findings, all fixed:**
+- `mark_reminded` moved **before** the turn (a mid-turn snooze cadence reset
+  survives; error turns still burn a capped slot → flapping backends self-limit)
+- TUI double-`agent.run` race: `_process_queue` re-queues input dequeued while an
+  autonomous turn runs (absorbed via interrupt_queue)
+- REPL: reminder gate + turn wrapped in try/except (a bare error used to die
+  silently via the finally `os._exit(0)`); `last_interaction_time` updated after
+  reminder turns (no back-to-back desire fires)
+- GUI/TUI tick bodies exception-guarded (a sqlite error can't kill the idle loop)
+- `due_for_reminder` index clamped + inconsistent-state test
+- `decide_idle_action` docstring corrected to reality
+- post-fix adversarial verification 7/7 resolved; completeness residuals
+  (mark guard / GUI mark-before-run pin / clamp test) also closed
 
 ---
 
-## Phase 5 — 社会的学習ループを閉じる（実装済 ✅）
+## Phase 4 — Persistent person model (ToM accumulation) ✅
 
-記録するだけで参照されなかった `failed_support_patterns` / `support_preferences` を
-`SocialPolicyEngine.decide()` に接続。決定論補正 `_apply_relationship_learning`:
-- アドバイス系失敗履歴（advice/solution/正論/説教 等のマーカー）or validate-first 系 style を検知したら:
-  - distress 系 act（venting/fatigue/grief/conflict）→ `should_recall_relational_memory=True`
-    （relational ctx に失敗パターンが描画されるのでモデルが「前に失敗したこと」を見る）+ softness 微増
-  - 明示的依頼（request_for_advice/action）→ 依頼は尊重しつつ `should_use_tom=True` +
-    directness 減・softness 増（validate-first な伝え方へ）
-- `relationship_learning_inputs()` が Tracker のアイテム形状（style / pattern|evidence）を吸収（契約テスト付き）
-- `embodied_hook.prepare_turn` の decide() 呼び出しに配線
-- テスト +7（無履歴で不変・和文マーカー・無関係パターン不発・契約）
+**Problem**: the ToM tool produced structured JSON
+`{evidence, inference[{state,confidence}], policy}` and threw it away after
+formatting (only `_last_policy` kept, in-memory).
+
+**Design** (follows RelationshipTracker persistence: lazy conn + WAL +
+apply_migrations):
+- migration 010: `person_inferences` table (id, person, state, confidence,
+  evidence_json, policy, source, created_at ISO) in the shared observations.db
+- **new** `familiar_neighbor/mind/person_model.py` `PersonModelTracker`:
+  `record_inference` / `recent(person, n)` / `context_for_prompt(person)` →
+  `[Person model]` block (recent states + confidence + last chosen approach;
+  7-day staleness cutoff)
+- `ToMTool`: writes back successful parsed inferences (optional dependency; a
+  writeback failure never affects tool output); person keys canonicalized to the
+  companion name (case-insensitive) + COLLATE NOCASE reads
+- `agent.py`: constructs the tracker, injects the block next to the relationship
+  context; `close()` also closes the person-model and commitment stores
+- tests: tracker CRUD / prompt rendering / migration / writeback isolation /
+  canonicalization / agent surface
+
+## Phase 5 — Closing the social learning loop ✅
+
+`failed_support_patterns` / `support_preferences` (recorded but never consulted)
+now feed `SocialPolicyEngine.decide()`. Deterministic adjustment
+`_apply_relationship_learning`:
+- on advice-failure history (advice/solution/正論/説教 markers) or a
+  validate-first support style:
+  - distress acts (venting/fatigue/grief/conflict) →
+    `should_recall_relational_memory=True` (the relational context renders the
+    failed patterns, so the model actually sees what failed before) + softness up
+  - explicit advice requests → still honored, but `should_use_tom=True` with
+    gentler delivery (action requests deliberately NOT adjusted)
+- `relationship_learning_inputs()` absorbs the tracker's stored item shapes
+  (style / pattern|evidence), pinned by a contract test
+- wired into `embodied_hook.prepare_turn`
+- tests +7 (no-history invariance, JP/EN markers, non-firing on unrelated
+  patterns, contract)
 
 ---
 
-## Validation（各 Phase 末）
+## Validation (end of every phase)
 
 ```bash
 uv run ruff check .
@@ -130,56 +137,18 @@ uv run --group dev mypy src/familiar_agent src/familiar_runtime src/familiar_cap
 uv run pytest -q
 ```
 
-## 進行ステータス
+## Status
 
-- [x] Phase 1: Commitment ストア + tests（9件）
-- [x] Phase 2: tool + capability + 配線 + surface + tests（13件）
-- [x] Phase 3: 自発的リマインド（独立トグル・quiet hours・escalating backoff+cap、3ループ配線、レビュー10件全修正）
-- [x] Phase 4: Person Model（person_inferences + PersonModelTracker + ToM 書き戻し + prompt surface）
-- [x] Phase 5: 社会的学習ループ（failed patterns → decide() 補正、契約テスト付き）
+- [x] Phase 1: commitment store + tests
+- [x] Phase 2: tool + capability + wiring + surface + tests
+- [x] Phase 3: proactive reminders (independent toggle, quiet hours, escalating
+  backoff+cap, three-loop wiring, all 10 review findings fixed)
+- [x] Phase 4: person model (person_inferences + PersonModelTracker + ToM
+  writeback + prompt surface)
+- [x] Phase 5: social learning loop (failed patterns → decide() adjustment,
+  contract-tested)
 
-**PR #175 作成済み**（https://github.com/lifemate-ai/familiar-ai/pull/175、develop 向け）。
-CI 全緑（lint + test macos/ubuntu/windows）。**merge はコウタ判断。**
-全5フェーズ完了 + アジェンダ + staleness カットオフ + CLAUDE.md 更新 + レビュー指摘全消化。
-
----
-
-## PR ドラフト（コウタ用 — push 後にそのまま使える）
-
-**タイトル:** `feat: secretary layer (commitments + proactive reminders) and social accumulation (person model + learned policy)`
-
-**本文:**
-
-```markdown
-## Summary
-
-Two pillars toward "more human, more socially capable":
-
-**Secretary layer** — the agent can now hold commitments (reminders,
-appointments, promises, follow-ups) with due times and priorities, surface
-them passively in every turn, proactively speak up when they come due
-(independent of auto_desire, FAMILIAR_PROACTIVE_REMINDERS, default ON,
-quiet-hours aware, escalating backoff capped at 3), and open the day with a
-[Today's agenda] block on the first turn.
-
-**Social accumulation** — ToM inferences now persist per person
-(person_inferences, migration 010) and surface as an accumulated
-[Person model] block (7-day staleness cutoff); recorded support failures
-and preferences now feed back into SocialPolicyEngine.decide() so the same
-support misstep is not repeated.
-
-## Hardening
-
-All three idle loops were wired through multi-agent adversarial review;
-11 confirmed findings fixed and re-verified, including: mark-before-run
-(mid-turn snooze survives), TUI concurrent agent.run race (re-queue for
-interrupt drain), REPL silent-death via os._exit(0) on backend errors,
-person-key fragmentation (canonicalization + COLLATE NOCASE).
-
-## Tests
-
-+87 tests across store cadence/backoff, legacy-DB migration, idle-loop
-wiring (REPL/TUI/GUI), config independence, person-model roundtrip and
-writeback isolation, social-policy learning invariance. Full suite
-1070 passed; ruff/format/mypy green.
-```
+Shipped as **PR #175** (merged) with the agenda block, staleness cutoff, and
+CLAUDE.md updates. Follow-up round (deterministic ToM, agency boundary,
+deferred-topic capture, 4-round classifier audit, ADR 0004) shipped as **PR #176**;
+the dangling memory-link fix as **PR #177**.

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -853,7 +853,12 @@ class EmbodiedAgent:
             registry.register(MobilityCapability(self._mobility))
         if self._tts:
             registry.register(VoiceCapability(self._tts))
-        registry.register(MemoryCapability(self._memory_tool, names={"remember", "recall"}))
+        registry.register(
+            MemoryCapability(
+                self._memory_tool,
+                names={"remember", "recall", "resolve_unfinished_business"},
+            )
+        )
         registry.register(ToMCapability(self._tom_tool))
         registry.register(CodingCapability(self._coding))
         commitment_tool = getattr(self, "_commitment_tool", None)

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -1294,6 +1294,11 @@ class EmbodiedAgent:
             lines.append("- a memory mention is allowed only if it fits naturally")
         if policy.avoid_raw_interoception_numbers:
             lines.append("- never mention raw internal/body metrics")
+        if policy.acknowledge_capacity:
+            lines.append(
+                "- you are running low right now; be honest about your current "
+                "capacity instead of overpromising — offer a smaller step or a deferral"
+            )
         return "\n".join(lines)
 
     def _build_mental_snapshot(

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -1182,6 +1182,28 @@ class EmbodiedAgent:
         lines.extend(format_commitment_line(c, now=now) for c in items)
         return "\n".join(lines)
 
+    async def _run_auto_tom(self, user_input: str, *, timeout: float = 12.0) -> str:
+        """Run the ToM tool deterministically when social policy demands it.
+
+        The model is not relied on to call the tool itself; this guarantees
+        perspective-taking happens on emotionally loaded turns (and the result
+        feeds the persistent person model as a side effect). Failures and
+        timeouts degrade to an empty string — never break the turn.
+        """
+        tom_tool = getattr(self, "_tom_tool", None)
+        if tom_tool is None:
+            return ""
+        try:
+            text, _image = await asyncio.wait_for(
+                tom_tool.call("tom", {"situation": user_input[:500]}),
+                timeout=timeout,
+            )
+        except (asyncio.TimeoutError, Exception):
+            logger.debug("auto ToM failed", exc_info=True)
+            return ""
+        text = str(text).strip()
+        return text[:1200] if text else ""
+
     def _person_model_context(self) -> str:
         """Surface the accumulated ToM model of the companion, if any."""
         tracker = getattr(self, "_person_model", None)

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -532,6 +532,9 @@ class EmbodiedAgent:
         )
         self._last_tool_error: str | None = None
         self._tool_failure_streak: int = 0
+        # Deterministic ToM cooldown bookkeeping (see embodied_hook._should_auto_tom)
+        self._last_auto_tom_turn: int | None = None
+        self._last_auto_tom_act: str | None = None
 
         # Mood persistence (Phase 2 companion-likeness)
         self._mood: str = "neutral"
@@ -1194,11 +1197,13 @@ class EmbodiedAgent:
         if tom_tool is None:
             return ""
         try:
+            # 12s default is deliberately tighter than _TOOL_TIMEOUTS["tom"] (20s):
+            # this runs serially before the main loop, so it caps time-to-first-token.
             text, _image = await asyncio.wait_for(
                 tom_tool.call("tom", {"situation": user_input[:500]}),
                 timeout=timeout,
             )
-        except (asyncio.TimeoutError, Exception):
+        except Exception:
             logger.debug("auto ToM failed", exc_info=True)
             return ""
         text = str(text).strip()

--- a/src/familiar_agent/tools/memory.py
+++ b/src/familiar_agent/tools/memory.py
@@ -1923,6 +1923,14 @@ class ObservationMemory:
             return []
 
     def resolve_unfinished_business(self, business_id: str) -> bool:
+        """Resolve by full id, or by a unique prefix of an open item.
+
+        The prompt surfaces ids truncated to 8 chars, so the model passes a
+        prefix; resolve it as long as it is unambiguous among open items.
+        """
+        business_id = str(business_id).strip()
+        if len(business_id) < 4:
+            return False
         try:
             with self._db_lock:
                 db = self._ensure_connected()
@@ -1930,6 +1938,23 @@ class ObservationMemory:
                     "UPDATE unfinished_business SET status = 'resolved', resolved_at = ? WHERE id = ?",
                     (self._now_iso(), business_id),
                 )
+                if updated.rowcount != 1:
+                    escaped = (
+                        business_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+                    )
+                    rows = db.execute(
+                        "SELECT id FROM unfinished_business "
+                        "WHERE id LIKE ? ESCAPE '\\' AND status = 'open'",
+                        (escaped + "%",),
+                    ).fetchall()
+                    if len(rows) != 1:
+                        db.commit()
+                        return False
+                    updated = db.execute(
+                        "UPDATE unfinished_business SET status = 'resolved', resolved_at = ? "
+                        "WHERE id = ?",
+                        (self._now_iso(), rows[0]["id"]),
+                    )
                 db.commit()
             return updated.rowcount == 1
         except Exception as e:

--- a/src/familiar_agent/tools/memory.py
+++ b/src/familiar_agent/tools/memory.py
@@ -2233,6 +2233,21 @@ class MemoryTool:
                     },
                 },
             },
+            {
+                "name": "resolve_unfinished_business",
+                "description": (
+                    "Mark an open unfinished-business item (shown in your context "
+                    "as [Open unfinished business] with its id) as resolved once "
+                    "the conversation has actually addressed it."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string", "description": "The item's id."},
+                    },
+                    "required": ["id"],
+                },
+            },
         ]
 
     async def call(self, tool_name: str, tool_input: dict) -> tuple[str, str | None]:
@@ -2326,5 +2341,12 @@ class MemoryTool:
                 for item in items
             ]
             return "\n".join(lines), None
+
+        if tool_name == "resolve_unfinished_business":
+            business_id = str(tool_input.get("id", "")).strip()
+            resolved = await self._store.resolve_unfinished_business_async(business_id)
+            if resolved:
+                return f"✓ Resolved unfinished business [{business_id[:8]}]", None
+            return f"Error: unfinished business not found: {business_id[:8]}", None
 
         return f"Unknown memory tool: {tool_name}", None

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -44,6 +44,22 @@ from familiar_neighbor.mind.social_policy import (
 )
 from familiar_runtime.runtime import RuntimeHookBase
 
+
+def _should_auto_tom(
+    social_policy: "SocialPolicyDecision",
+    *,
+    brief_reply_turn: bool,
+    is_desire_turn: bool,
+    user_input: str,
+) -> bool:
+    """Gate for deterministic ToM: only flagged, full, companion-driven turns."""
+    if not social_policy.should_use_tom:
+        return False
+    if brief_reply_turn or is_desire_turn:
+        return False
+    return bool(user_input.strip())
+
+
 if TYPE_CHECKING:
     from familiar_agent.agent import EmbodiedAgent
 
@@ -367,6 +383,18 @@ class EmbodiedAgentHook(RuntimeHookBase):
             is_desire_turn=is_desire_turn,
         )
 
+        # ── Deterministic perspective-taking ──
+        # should_use_tom used to be advisory only; now the inference actually
+        # runs (and accumulates into the person model) on flagged turns.
+        auto_tom_ctx = ""
+        if _should_auto_tom(
+            social_policy,
+            brief_reply_turn=brief_reply_turn,
+            is_desire_turn=is_desire_turn,
+            user_input=user_input,
+        ):
+            auto_tom_ctx = await agent._run_auto_tom(user_input)
+
         # ── Append user message to history ──
         agent.messages.append(agent.backend.make_user_message(user_input_with_ctx))
 
@@ -436,6 +464,7 @@ class EmbodiedAgentHook(RuntimeHookBase):
                     agent._mental_state_bus.summarize_recent_for_prompt(2),
                     mental_snapshot.prompt_summary(),
                     agent._format_social_policy_prompt(social_policy),
+                    auto_tom_ctx,
                 )
                 if part
             )

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -367,8 +367,19 @@ class EmbodiedAgentHook(RuntimeHookBase):
         )
 
         # ── Social policy + provisional relationship update ──
+        # Relational-hurt tokens only — bare "hurt" turned "My back hurts"
+        # into a repair turn.
         previous_response_hurt = any(
-            token in user_input.lower() for token in ("hurt", "傷つ", "前の返事", "嫌だった")
+            token in user_input.lower()
+            for token in (
+                "hurt me",
+                "hurt my feelings",
+                "you hurt",
+                "that hurt",
+                "傷つ",
+                "前の返事",
+                "嫌だった",
+            )
         )
         learned_styles, learned_failures = relationship_learning_inputs(agent._relationship)
         social_policy = agent._social_policy.decide(

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -35,6 +35,7 @@ from familiar_agent._runtime_helpers import (
 from familiar_agent.heartbeat import HeartbeatRuntime
 from familiar_agent.routines import parse_schedule_config
 from familiar_neighbor.mind.appraisal import AppraisalContext, AppraisalEngine
+from familiar_neighbor.mind.deferral import DEFERRAL_PREFIX, detect_deferral
 from familiar_neighbor.mind.desires import DesireSystem
 from familiar_neighbor.mind.mental_state import MentalStateBus, MentalStateSnapshot
 from familiar_neighbor.mind.social_policy import (
@@ -262,6 +263,20 @@ class EmbodiedAgentHook(RuntimeHookBase):
                 limit=3,
                 fallback=[],
             )
+            # ── Deferred-topic capture ──
+            # "後で話すわ" must not be lost: record it as unfinished business so
+            # it stays surfaced until the model resolves it.
+            deferral = detect_deferral(user_input) if not is_desire_turn else None
+            if deferral:
+                summary = f"{DEFERRAL_PREFIX}{deferral}"
+                if not any(item.get("summary") == summary for item in unfinished_business):
+                    open_unfinished = getattr(agent._memory, "open_unfinished_business_async", None)
+                    await _call_optional_async(
+                        open_unfinished,
+                        summary,
+                        source="deferral",
+                        fallback=None,
+                    )
         companion_mood = "engaged"
         working_memory: list[dict] = []
         semantic_facts: list[dict] = []
@@ -452,8 +467,11 @@ class EmbodiedAgentHook(RuntimeHookBase):
                 continuity_ctx = (
                     continuity_ctx
                     + ("\n\n" if continuity_ctx else "")
-                    + "[Open unfinished business]\n"
-                    + "\n".join(f"- {item['summary'][:160]}" for item in unfinished_business[:3])
+                    + "[Open unfinished business — resolve_unfinished_business(id) once addressed]\n"
+                    + "\n".join(
+                        f"- [{str(item.get('id', ''))[:8]}] {item['summary'][:160]}"
+                        for item in unfinished_business[:3]
+                    )
                 )
             # First turn already carries [Today's agenda] in morning_ctx; skip the
             # per-turn reminders block there to avoid listing the same items twice.

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -258,18 +258,21 @@ class EmbodiedAgentHook(RuntimeHookBase):
             list_unfinished_business = getattr(
                 agent._memory, "list_unfinished_business_async", None
             )
-            unfinished_business = await _call_optional_async(
+            # Fetch a wider window than the surfaced top-3 so deferral dedup
+            # doesn't re-insert an item that merely fell off the visible slice.
+            unfinished_open = await _call_optional_async(
                 list_unfinished_business,
-                limit=3,
+                limit=20,
                 fallback=[],
             )
+            unfinished_business = unfinished_open[:3]
             # ── Deferred-topic capture ──
             # "後で話すわ" must not be lost: record it as unfinished business so
             # it stays surfaced until the model resolves it.
             deferral = detect_deferral(user_input) if not is_desire_turn else None
             if deferral:
                 summary = f"{DEFERRAL_PREFIX}{deferral}"
-                if not any(item.get("summary") == summary for item in unfinished_business):
+                if not any(item.get("summary") == summary for item in unfinished_open):
                     open_unfinished = getattr(agent._memory, "open_unfinished_business_async", None)
                     await _call_optional_async(
                         open_unfinished,

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -376,7 +376,8 @@ class EmbodiedAgentHook(RuntimeHookBase):
                 "hurt my feelings",
                 "you hurt",
                 "that hurt",
-                "傷つ",
+                "傷つい",
+                "傷つけられ",
                 "前の返事",
                 "嫌だった",
             )

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -45,19 +45,35 @@ from familiar_neighbor.mind.social_policy import (
 from familiar_runtime.runtime import RuntimeHookBase
 
 
+# Within a sustained distress conversation, re-running ToM every turn adds a
+# serial utility call to time-to-first-token and writes near-duplicate person
+# model rows. Re-run only after this many turns unless the speech act changed.
+_AUTO_TOM_COOLDOWN_TURNS = 3
+
+
 def _should_auto_tom(
     social_policy: "SocialPolicyDecision",
     *,
     brief_reply_turn: bool,
     is_desire_turn: bool,
     user_input: str,
+    turns_since_last: int | None = None,
+    last_act: str | None = None,
 ) -> bool:
     """Gate for deterministic ToM: only flagged, full, companion-driven turns."""
     if not social_policy.should_use_tom:
         return False
     if brief_reply_turn or is_desire_turn:
         return False
-    return bool(user_input.strip())
+    if not user_input.strip():
+        return False
+    if (
+        turns_since_last is not None
+        and turns_since_last < _AUTO_TOM_COOLDOWN_TURNS
+        and last_act == social_policy.primary_act
+    ):
+        return False
+    return True
 
 
 if TYPE_CHECKING:
@@ -387,13 +403,25 @@ class EmbodiedAgentHook(RuntimeHookBase):
         # should_use_tom used to be advisory only; now the inference actually
         # runs (and accumulates into the person model) on flagged turns.
         auto_tom_ctx = ""
+        last_auto_tom_turn = getattr(agent, "_last_auto_tom_turn", None)
         if _should_auto_tom(
             social_policy,
             brief_reply_turn=brief_reply_turn,
             is_desire_turn=is_desire_turn,
             user_input=user_input,
+            turns_since_last=(
+                agent._turn_count - last_auto_tom_turn if last_auto_tom_turn is not None else None
+            ),
+            last_act=getattr(agent, "_last_auto_tom_act", None),
         ):
+            agent._last_auto_tom_turn = agent._turn_count
+            agent._last_auto_tom_act = social_policy.primary_act
             auto_tom_ctx = await agent._run_auto_tom(user_input)
+            if auto_tom_ctx:
+                auto_tom_ctx = (
+                    "[Perspective-taking already done this turn — do not call the "
+                    "tom tool again]\n" + auto_tom_ctx
+                )
 
         # ── Append user message to history ──
         agent.messages.append(agent.backend.make_user_message(user_input_with_ctx))

--- a/src/familiar_neighbor/mind/deferral.py
+++ b/src/familiar_neighbor/mind/deferral.py
@@ -15,13 +15,24 @@ import re
 
 _DEFERRAL_PATTERNS = [
     r"(?:あとで|後で)(?:ゆっくり)?(?:話|説明|教え|言う|聞かせ|相談)",
-    r"また今度",
+    # また今度 is verb-anchored too: a bare また今度ね is a polite decline,
+    # not a topic the agent should keep raising.
+    r"また今度(?:ゆっくり)?(?:話|説明|聞かせ|相談|教え)",
     r"その(?:話|件)は(?:また|あとで|後で)",
     r"後日(?:話|説明|相談|連絡|改めて)",
     r"\btell you later\b",
     r"\btalk (?:about (?:it|this) )?(?:later|another time)\b",
     r"\banother time\b",
 ]
+
+# "後で教えてくれる？" is the companion asking the AGENT to do something later —
+# that is the commitments/reminder domain, not a topic the companion deferred.
+# Request forms (てくれ/てもらえ/てほしい/てください, or a bare て-imperative not
+# followed by あげ/やる) are excluded.
+_REQUEST_TO_AGENT = re.compile(
+    r"て(?:くれ|もらえ|ほしい|ちょうだい|頂戴|ください|下さい)"
+    r"|(?:教え|聞かせ|話し)て(?!あげ|やる)"
+)
 
 _COMPILED = [re.compile(p) for p in _DEFERRAL_PATTERNS]
 
@@ -35,6 +46,8 @@ def detect_deferral(user_input: str) -> str | None:
     if not text:
         return None
     lower = text.lower()
-    if any(p.search(lower) for p in _COMPILED):
-        return text[:120]
-    return None
+    if not any(p.search(lower) for p in _COMPILED):
+        return None
+    if _REQUEST_TO_AGENT.search(lower):
+        return None
+    return text[:120]

--- a/src/familiar_neighbor/mind/deferral.py
+++ b/src/familiar_neighbor/mind/deferral.py
@@ -1,0 +1,40 @@
+"""Deferred-topic detection — "後で話す" must not be lost.
+
+A deterministic detector for the companion deferring a conversation topic
+("その話はあとで", "また今度説明する"). Detected deferrals are recorded as
+unfinished business so the surface/resolve machinery the agent already has
+keeps the topic alive until the conversation returns to it.
+
+Patterns require a communication verb after あとで/後で so that doing
+something later ("あとでお風呂入る") is not mistaken for deferring a topic.
+"""
+
+from __future__ import annotations
+
+import re
+
+_DEFERRAL_PATTERNS = [
+    r"(?:あとで|後で)(?:ゆっくり)?(?:話|説明|教え|言う|聞かせ|相談)",
+    r"また今度",
+    r"その(?:話|件)は(?:また|あとで|後で)",
+    r"後日(?:話|説明|相談|連絡|改めて)",
+    r"\btell you later\b",
+    r"\btalk (?:about (?:it|this) )?(?:later|another time)\b",
+    r"\banother time\b",
+]
+
+_COMPILED = [re.compile(p) for p in _DEFERRAL_PATTERNS]
+
+# Prompt-block prefix used when recording; also used for dedup matching.
+DEFERRAL_PREFIX = "deferred topic: "
+
+
+def detect_deferral(user_input: str) -> str | None:
+    """Return a bounded snippet when the input defers a topic, else None."""
+    text = user_input.strip()
+    if not text:
+        return None
+    lower = text.lower()
+    if any(p.search(lower) for p in _COMPILED):
+        return text[:120]
+    return None

--- a/src/familiar_neighbor/mind/social_policy.py
+++ b/src/familiar_neighbor/mind/social_policy.py
@@ -35,16 +35,19 @@ _ACTION_PATTERNS = [
     r"please do",
     r"頼む",
 ]
-# Relational hurt only — repair is the FIRST branch, so bare "hurt" turned
-# "My back hurts" into an apology, and bare つらかった made ordinary past-tense
-# vents (会議きつかったわ) read as relational repair.
+# Relational hurt only — repair is the FIRST branch, so it must never fire on
+# physical pain ("my back hurts" / "stubbed my toe, that hurt"), third-party
+# guilt (友達を傷つけてしまった), or benign references (この前の返事ありがとう).
 _REPAIR_PATTERNS = [
     r"hurt (?:me|my feelings)",
     r"feel(?:ing)?s? hurt",
     r"you hurt",
-    r"that hurt\b",
-    r"傷つ",
-    r"前の返事",
+    r"(?:^|[\"”」]\s*)that (?:really )?hurt\b",
+    # self-directed hurt only: intransitive 傷つい, passive 傷つけられ, or an
+    # explicit first-person object
+    r"(?<!を)傷つい",
+    r"傷つけられ",
+    r"(?:私|ウチ|うち|俺|僕)を?傷つけ",
     r"(?:返事|言葉|言い方|あの一言|さっきの(?:返事|言葉|言い方|発言|あれ|やつ)).{0,10}(?:つらかった|きつかった)",
 ]
 # "やった" only as an exclamation: utterance-initial (but not やったら/やったん
@@ -74,10 +77,19 @@ _NEGATED_POSITIVE_RE = re.compile(
 # sarcasm (最高かよ), and ailment formations (しこりができた must not celebrate).
 _DELIGHT_VETO_JA_RE = re.compile(
     r"(?:嬉し|うれし)く(?:も|は)?な(?:い|かった|さそう)"
+    r"|(?:嬉し|うれし)い?(?:わけ|はず)(?:が|も|は)?な(?:い|かった)"
     r"|最高(?:じゃ|では|や)?な(?:い|かった)"
     r"|最高ちゃう"
     r"|(?:最高|嬉し)(?:すぎ)?かよ"
-    r"|(?:しこり|腫瘍|口内炎|ニキビ|湿疹|あざ|肩こり|クマ)(?:まで|が)?できた"
+    # ailment formations never celebrate: a lexicon net plus the locative
+    # frame 体部位+に…できた (the lexicon alone can't enumerate every ailment)
+    r"|(?:しこり|腫瘍|口内炎|ニキビ|湿疹|あざ|肩こり|クマ|虫歯|ものもらい|たんこぶ|まめ|ヘルペス|結石|できもの|吹き出物|イボ|蕁麻疹|血豆|水ぶくれ)(?:まで|が|も)?できた"
+    r"|(?:首|肩|足|腰|口|目|歯|顔|背中|腕|手|肌|喉|おでこ|まぶた)(?:の[^、。]{0,4})?に[^、。]{0,8}できた"
+)
+# Concessive joy: 疲れたけど最高の一日やった！ — the distress token concedes to
+# the delight that follows, so the distress-precedence veto must not fire.
+_CONCESSIVE_JOY_RE = re.compile(
+    r"(?:けど|けれど|のに|\bbut\b)[^、。!！]{0,12}(?:最高|嬉し|うれし|\bhappy\b)"
 )
 # bare "ugh" matched laughed/daughter/thought/enough; うんざり and the past
 # forms つらかった/きつかった live here so ordinary vents validate instead of
@@ -91,7 +103,8 @@ _VENTING_PATTERNS = [
     r"しんど",
     r"(?<!お)疲れ",
     r"うんざり",
-    r"泣きそう",
+    # 嬉しくて泣きそう is joy, not distress
+    r"(?<!くて)泣きそう(?!なくらい)",
     r"落ち込",
     r"へこむ",
     r"\bugh+\b",
@@ -107,7 +120,8 @@ _GRIEF_PATTERNS = [
     r"\b(?:we|i|she|he|they) (?:just )?lost (?:him|her|them)\b",
     r"passed away",
     r"亡くな",
-    r"死ん(?:だ|でしまっ|でしも|でもう|じゃっ)",
+    # すぎて死んだ is hyperbolic joy slang (最高すぎて死んだ), not bereavement
+    r"(?<!すぎて)(?<!過ぎて)死ん(?:だ|でしまっ|でしも|でもう|じゃっ)",
     r"死にました",
     r"死別",
     r"つらい",
@@ -148,10 +162,11 @@ _PLAYFUL_PATTERNS = [
 # an opener ("No more bugs! We shipped!") is usually celebration, not protest.
 _BOUNDARY_PATTERNS = [
     # imperative/request form only — やめてん is "I quit" (a disclosure),
-    # やめてって言われた is reported speech, neither is a boundary at the agent
-    r"やめて(?:[よやな]|くれ|ください|ほしい|[ー〜!！。…]|$)",
-    r"やめろ",
-    r"それは嫌",
+    # やめてって言われた / やめろって言われた are reported speech, それは嫌やった
+    # is a past-tense disclosure: none of them is a boundary at the agent
+    r"やめて(?:[よやな]|くれ|ください|ほしい|もらえ|もらって|[ー〜!！。…]|$)",
+    r"やめろ(?!って|と(?:言|の|か))",
+    r"それは嫌(?:や|だ|です)?[ー〜!！。…]*$",
     r"\bno more[.!！]*$",
     r"no more of (?:this|that)",
     r"\bstop that\b",
@@ -435,13 +450,16 @@ class SocialPolicyEngine:
             )
 
         # Delight must lose to explicit distress in the same utterance
-        # (「最悪や、最高の誕生日になるはずやったのに」 is a lament, not a share).
+        # (「最悪や、最高の誕生日になるはずやったのに」 is a lament, not a share)
+        # — unless the distress is concessive (疲れたけど最高の一日やった！).
+        distress_overrides_delight = (
+            _matches(text, _VENTING_PATTERNS) or _matches(text, _GRIEF_PATTERNS)
+        ) and not _CONCESSIVE_JOY_RE.search(text)
         if (
             _matches(text, _DELIGHT_PATTERNS)
             and not _NEGATED_POSITIVE_RE.search(text.lower())
             and not _DELIGHT_VETO_JA_RE.search(text)
-            and not _matches(text, _VENTING_PATTERNS)
-            and not _matches(text, _GRIEF_PATTERNS)
+            and not distress_overrides_delight
             and affect.valence >= -0.1
         ):
             return SocialPolicyDecision(

--- a/src/familiar_neighbor/mind/social_policy.py
+++ b/src/familiar_neighbor/mind/social_policy.py
@@ -8,9 +8,43 @@ import re
 from .interoception import InteroceptivePressure
 from .mental_state import AffectiveState
 
-_ADVICE_PATTERNS = [r"どう", r"教えて", r"advice", r"should i", r"どうしたら"]
-_ACTION_PATTERNS = [r"して", r"やって", r"run", r"fix", r"please do", r"頼む"]
-_REPAIR_PATTERNS = [r"hurt", r"傷つ", r"前の返事", r"つらかった", r"きつかった"]
+# Pattern hygiene (2026-06 audit): every short pattern below was once a bare
+# substring and misfired on common speech (めっちゃ→ちゃう, laughed→ugh,
+# 死ぬほど笑った→grief, retired→tired, brunch→run, …). Keep new entries
+# anchored / word-bounded / morphology-aware, and reproduce-by-running before
+# loosening anything.
+
+# Interrogative advice forms only — bare どう also matched どうも/どうぞ/どうでもいい.
+_ADVICE_PATTERNS = [
+    r"どう(?:したら|すれば|しよう|思う|やったら|かな)",
+    r"教えて",
+    r"\badvice\b",
+    r"\bshould i\b",
+]
+# Request morphology only — bare して/やって matched past-progressives (してた)
+# and dismay (やってもうた).
+_ACTION_PATTERNS = [
+    r"して(?:くれ|ください|もらえ|ほしい|頂|いただ)",
+    r"して[よなや]?[!！。]?$",
+    r"やって(?:くれ|ください|もらえ|ほしい)",
+    r"やって[よなや]?[!！。]?$",
+    r"\brun\b",
+    r"\bfix\b",
+    r"please do",
+    r"頼む",
+]
+# Relational hurt only — repair is the FIRST branch, so bare "hurt" turned
+# "My back hurts" into an apology.
+_REPAIR_PATTERNS = [
+    r"hurt (?:me|my feelings)",
+    r"feel(?:ing)?s? hurt",
+    r"you hurt",
+    r"that hurt\b",
+    r"傷つ",
+    r"前の返事",
+    r"つらかった",
+    r"きつかった",
+]
 # "やった" only as an exclamation: utterance-initial (but not やったら/やったん
 # conditionals/questions) or followed by an exclamatory mark. Kansai past tense
 # "〜やった" ("散々やった") must NOT read as delight.
@@ -21,13 +55,36 @@ _DELIGHT_PATTERNS = [
     r"うれし",
     r"最高",
     r"できた",
-    r"happy",
-    r"yay",
+    # negated happy must not celebrate ("I'm not happy with…")
+    r"(?<!not )(?<!n't )(?<!never )\bhappy\b",
+    r"\byay\b",
 ]
-_VENTING_PATTERNS = [r"むかつ", r"最悪", r"つらい", r"しんど", r"疲れ", r"ugh"]
-_GRIEF_PATTERNS = [r"寂し", r"悲し", r"grief", r"lost", r"死", r"つらい"]
-_FATIGUE_PATTERNS = [r"疲れ", r"眠い", r"しんど", r"だるい", r"exhausted", r"tired"]
-_META_PATTERNS = [r"君", r"あなた", r"この会話", r"meta", r"how do you", r"あなたは"]
+# bare "ugh" matched laughed/daughter/thought/enough; うんざり added here so the
+# fed-up reading is caught positively (it used to read as silence via うん).
+_VENTING_PATTERNS = [r"むかつ", r"最悪", r"つらい", r"しんど", r"疲れ", r"うんざり", r"\bugh+\b"]
+# bereavement forms only — bare 死 matched 死ぬほど笑った/必死, bare "lost"
+# matched "lost track of time".
+_GRIEF_PATTERNS = [
+    r"寂し",
+    r"悲し",
+    r"\bgrief\b",
+    r"\blost (?:a |my |our |her |his )?(?:someone|mom|dad|mother|father|grand\w+|friend|husband|wife|partner|dog|cat|pet|baby)\b",
+    r"passed away",
+    r"亡くな",
+    r"死ん(?:だ|でしまっ|じゃっ)",
+    r"死別",
+    r"つらい",
+]
+_FATIGUE_PATTERNS = [r"疲れ", r"眠い", r"しんど", r"だるい", r"\bexhausted\b", r"\btired\b"]
+# 君 only as a standalone second-person pronoun (not 田中君/君津); "how do you"
+# only for introspective targets (not "how do you make carbonara").
+_META_PATTERNS = [
+    r"(?<![一-龯ァ-ヶぁ-んー])君(?=[はがのにをもと]|って|$)",
+    r"あなた",
+    r"この会話",
+    r"\bmeta\b",
+    r"how do you (?:feel|think|remember|decide|work|see|experience|know)\b",
+]
 # "w" is the Japanese laugh marker only when not embedded in an ASCII word
 # ("we went..." must not classify as playful); "play" needs word boundaries
 # ("display" is not playful).
@@ -39,8 +96,26 @@ _PLAYFUL_PATTERNS = [
     r"\bteas(?:e|ing)\b",
     r"冗談",
 ]
-_BOUNDARY_PATTERNS = [r"やめて", r"やめろ", r"それは嫌", r"no more", r"stop that"]
-_SILENCE_PATTERNS = [r"…", r"\.\.\.", r"うん", r"ok$", r"おけ$", r"寝る"]
+# "no more" as protest only (not "no more milk"); \b kills "nonstop that".
+_BOUNDARY_PATTERNS = [
+    r"やめて",
+    r"やめろ",
+    r"それは嫌",
+    r"^no more\b",
+    r"\bno more[.!！]*$",
+    r"no more of (?:this|that)",
+    r"\bstop that\b",
+]
+# うん only as a standalone acknowledgement (not うんざり/ううん); 寝る only as
+# an utterance-final sign-off (not 寝る前に…).
+_SILENCE_PATTERNS = [
+    r"…",
+    r"\.\.\.",
+    r"^うん(?:うん)?[。…〜ー]?$",
+    r"ok$",
+    r"おけ$",
+    r"寝る(?:わ|ね|で|ぞ)?[ー〜。…!！]*$",
+]
 _GREETING_PATTERNS = [
     r"^おはよ",
     r"^こんにちは",
@@ -66,8 +141,14 @@ _CORRECTION_PATTERNS = [
     r"食い違",
     r"そういう意味じゃ",
     r"そうじゃない",
-    r"違う",
-    r"ちゃう",
+    # 間違う is the mistake-verb, not a correction of the agent
+    r"(?<!間)違う",
+    # Kansai ちゃう as a correction needs a clause boundary or demonstrative —
+    # bare ちゃう hijacked めっちゃ (めっ「ちゃう」れしい) and the 〜ちゃう
+    # contraction (食べちゃう).
+    r"(?:^|[\s、。!！?？])ちゃう",
+    r"(?:それ|これ)(?:は)?ちゃう",
+    r"ちゃうちゃう",
     r"^いや[、, ]",
 ]
 

--- a/src/familiar_neighbor/mind/social_policy.py
+++ b/src/familiar_neighbor/mind/social_policy.py
@@ -68,6 +68,31 @@ _ADVICE_FAILURE_RE = re.compile(r"\b(advice|advise|solution|solve|lecture)\b")
 _ADVICE_FAILURE_MARKERS_JA = ("正論", "アドバイス", "解決", "説教")
 _VALIDATE_FIRST_STYLES = {"validate_first", "listen_first", "listen_only"}
 
+# Agency boundary: above this need_rest, demanding turns trigger an honest
+# capacity acknowledgement instead of silently degraded effort.
+_CAPACITY_HONESTY_THRESHOLD = 0.7
+_CAPACITY_SENSITIVE_ACTS = {"request_for_action", "request_for_advice", "repair_attempt"}
+
+
+def _apply_capacity_honesty(
+    decision: "SocialPolicyDecision",
+    interoception: InteroceptivePressure,
+) -> "SocialPolicyDecision":
+    """Never fake being fine: flag demanding turns when the agent runs low.
+
+    Only acts the companion *initiated* (work, advice, repair) get the flag —
+    a greeting must not volunteer fatigue. The response mode is unchanged
+    (repair still repairs); the model is just told to be honest about capacity
+    and offer a smaller step instead of overpromising.
+    """
+    if interoception.need_rest < _CAPACITY_HONESTY_THRESHOLD:
+        return decision
+    if decision.primary_act not in _CAPACITY_SENSITIVE_ACTS:
+        return decision
+    decision.acknowledge_capacity = True
+    decision.initiative = max(0.0, decision.initiative - 0.15)
+    return decision
+
 
 def relationship_learning_inputs(relationship) -> tuple[list[str], list[str]]:
     """Extract decide() learning inputs from a RelationshipTracker-like object."""
@@ -135,6 +160,9 @@ class SocialPolicyDecision:
     avoid_problem_solving: bool
     mention_memory: bool
     avoid_raw_interoception_numbers: bool = True
+    # Agency boundary: when the agent itself is running low and is asked for
+    # work or repair, be honest about capacity instead of overpromising.
+    acknowledge_capacity: bool = False
 
 
 class SocialPolicyEngine:
@@ -160,11 +188,12 @@ class SocialPolicyEngine:
             interoception=interoception,
             previous_response_hurt=previous_response_hurt,
         )
-        return _apply_relationship_learning(
+        decision = _apply_relationship_learning(
             decision,
             support_styles=support_styles,
             failed_patterns=failed_patterns,
         )
+        return _apply_capacity_honesty(decision, interoception)
 
     def _base_decision(
         self,

--- a/src/familiar_neighbor/mind/social_policy.py
+++ b/src/familiar_neighbor/mind/social_policy.py
@@ -11,7 +11,19 @@ from .mental_state import AffectiveState
 _ADVICE_PATTERNS = [r"どう", r"教えて", r"advice", r"should i", r"どうしたら"]
 _ACTION_PATTERNS = [r"して", r"やって", r"run", r"fix", r"please do", r"頼む"]
 _REPAIR_PATTERNS = [r"hurt", r"傷つ", r"前の返事", r"つらかった", r"きつかった"]
-_DELIGHT_PATTERNS = [r"やった", r"嬉し", r"うれし", r"最高", r"できた", r"happy", r"yay"]
+# "やった" only as an exclamation: utterance-initial (but not やったら/やったん
+# conditionals/questions) or followed by an exclamatory mark. Kansai past tense
+# "〜やった" ("散々やった") must NOT read as delight.
+_DELIGHT_PATTERNS = [
+    r"^やった(?![らん])",
+    r"やった[ー〜!！ぜ]",
+    r"嬉し",
+    r"うれし",
+    r"最高",
+    r"できた",
+    r"happy",
+    r"yay",
+]
 _VENTING_PATTERNS = [r"むかつ", r"最悪", r"つらい", r"しんど", r"疲れ", r"ugh"]
 _GRIEF_PATTERNS = [r"寂し", r"悲し", r"grief", r"lost", r"死", r"つらい"]
 _FATIGUE_PATTERNS = [r"疲れ", r"眠い", r"しんど", r"だるい", r"exhausted", r"tired"]

--- a/src/familiar_neighbor/mind/social_policy.py
+++ b/src/familiar_neighbor/mind/social_policy.py
@@ -45,7 +45,7 @@ _REPAIR_PATTERNS = [
     r"that hurt\b",
     r"傷つ",
     r"前の返事",
-    r"(?:返事|言葉|言い方|さっきの|あの一言).{0,10}(?:つらかった|きつかった)",
+    r"(?:返事|言葉|言い方|あの一言|さっきの(?:返事|言葉|言い方|発言|あれ|やつ)).{0,10}(?:つらかった|きつかった)",
 ]
 # "やった" only as an exclamation: utterance-initial (but not やったら/やったん
 # conditionals/questions) or followed by an exclamatory mark. Kansai past tense
@@ -63,9 +63,21 @@ _DELIGHT_PATTERNS = [
     r"\byay\b",
 ]
 # Negation veto for the delight branch — fixed-width lookbehinds can't catch
-# "I'm not VERY happy with…", so the branch checks this window separately.
+# "I'm not VERY happy with…". \w+n't covers every contraction (a bare \bn't\b
+# can never match inside one); the 32-char window absorbs multi-word hedges
+# ("not really all that happy").
 _NEGATED_POSITIVE_RE = re.compile(
-    r"\b(?:not|never|n't|isn't|wasn't|don't|ain't)\b[\w\s']{0,16}\b(?:happy|glad)\b"
+    r"\b(?:not|never|cannot|hardly|barely|far from|anything but|\w+n't)\b"
+    r"[\w\s']{0,32}\b(?:happy|glad|thrilled)\b"
+)
+# Japanese delight vetoes: negated positives (嬉しくない/最高やない), かよ
+# sarcasm (最高かよ), and ailment formations (しこりができた must not celebrate).
+_DELIGHT_VETO_JA_RE = re.compile(
+    r"(?:嬉し|うれし)く(?:も|は)?な(?:い|かった|さそう)"
+    r"|最高(?:じゃ|では|や)?な(?:い|かった)"
+    r"|最高ちゃう"
+    r"|(?:最高|嬉し)(?:すぎ)?かよ"
+    r"|(?:しこり|腫瘍|口内炎|ニキビ|湿疹|あざ|肩こり|クマ)(?:まで|が)?できた"
 )
 # bare "ugh" matched laughed/daughter/thought/enough; うんざり and the past
 # forms つらかった/きつかった live here so ordinary vents validate instead of
@@ -79,6 +91,9 @@ _VENTING_PATTERNS = [
     r"しんど",
     r"(?<!お)疲れ",
     r"うんざり",
+    r"泣きそう",
+    r"落ち込",
+    r"へこむ",
     r"\bugh+\b",
 ]
 # bereavement forms only — bare 死 matched 死ぬほど笑った/必死, bare "lost"
@@ -113,6 +128,9 @@ _META_PATTERNS = [
     r"この会話",
     r"\bmeta\b",
     r"how do you (?:feel|think|remember|decide|work|see|experience|know)\b",
+    # reciprocal social questions target the agent itself
+    r"\bhow (?:was|is|'s) your\b",
+    r"\bwhat (?:did|have) you\b",
 ]
 # "w" is the Japanese laugh marker only when not embedded in an ASCII word
 # ("we went..." must not classify as playful); "play" needs word boundaries
@@ -129,7 +147,9 @@ _PLAYFUL_PATTERNS = [
 # "no more" as protest only — utterance-final or "no more of this/that";
 # an opener ("No more bugs! We shipped!") is usually celebration, not protest.
 _BOUNDARY_PATTERNS = [
-    r"やめて",
+    # imperative/request form only — やめてん is "I quit" (a disclosure),
+    # やめてって言われた is reported speech, neither is a boundary at the agent
+    r"やめて(?:[よやな]|くれ|ください|ほしい|[ー〜!！。…]|$)",
     r"やめろ",
     r"それは嫌",
     r"\bno more[.!！]*$",
@@ -158,11 +178,13 @@ _GREETING_PATTERNS = [
     r"^おーい$",
     r"^もしもし$",
 ]
+# Whole-utterance anchors (same treatment as greetings): a thanks that merely
+# OPENS a longer message (ありがとう。実は昨日ばあちゃんが亡くなってん) must not
+# short-circuit the grief/venting branches.
 _ACK_PATTERNS = [
-    r"^ありがとう",
-    r"^ありがと",
-    r"^助か",
-    r"^よかった",
+    r"^ありがとう?(?:な|ね|やで|ございます|ございました)?[ー〜!！。\s]*$",
+    r"^助か(?:った|る|ります|りました)?(?:わ|で)?[ー〜!！。\s]*$",
+    r"^よかった[ー〜!！。\s]*$",
     r"^了解$",
     r"^ok$",
     r"^okay$",
@@ -412,9 +434,14 @@ class SocialPolicyEngine:
                 mention_memory=False,
             )
 
+        # Delight must lose to explicit distress in the same utterance
+        # (「最悪や、最高の誕生日になるはずやったのに」 is a lament, not a share).
         if (
             _matches(text, _DELIGHT_PATTERNS)
             and not _NEGATED_POSITIVE_RE.search(text.lower())
+            and not _DELIGHT_VETO_JA_RE.search(text)
+            and not _matches(text, _VENTING_PATTERNS)
+            and not _matches(text, _GRIEF_PATTERNS)
             and affect.valence >= -0.1
         ):
             return SocialPolicyDecision(

--- a/src/familiar_neighbor/mind/social_policy.py
+++ b/src/familiar_neighbor/mind/social_policy.py
@@ -14,27 +14,30 @@ from .mental_state import AffectiveState
 # anchored / word-bounded / morphology-aware, and reproduce-by-running before
 # loosening anything.
 
-# Interrogative advice forms only — bare どう also matched どうも/どうぞ/どうでもいい.
+# Interrogative advice forms only — bare どう also matched どうも/どうぞ/
+# どうでもいい; どうしようもない is resignation, not an advice ask.
 _ADVICE_PATTERNS = [
-    r"どう(?:したら|すれば|しよう|思う|やったら|かな)",
+    r"どう(?:したら|すれば|しよう(?!もな)|思う|やったら|かな)",
     r"教えて",
     r"\badvice\b",
     r"\bshould i\b",
 ]
 # Request morphology only — bare して/やって matched past-progressives (してた)
-# and dismay (やってもうた).
+# and dismay (やってもうた); bare \brun\b matched "went for a run".
 _ACTION_PATTERNS = [
     r"して(?:くれ|ください|もらえ|ほしい|頂|いただ)",
     r"して[よなや]?[!！。]?$",
     r"やって(?:くれ|ください|もらえ|ほしい)",
     r"やって[よなや]?[!！。]?$",
-    r"\brun\b",
+    r"\b(?:can|could|would|will|please)\s+(?:you\s+)?run\b",
+    r"^run\b",
     r"\bfix\b",
     r"please do",
     r"頼む",
 ]
 # Relational hurt only — repair is the FIRST branch, so bare "hurt" turned
-# "My back hurts" into an apology.
+# "My back hurts" into an apology, and bare つらかった made ordinary past-tense
+# vents (会議きつかったわ) read as relational repair.
 _REPAIR_PATTERNS = [
     r"hurt (?:me|my feelings)",
     r"feel(?:ing)?s? hurt",
@@ -42,8 +45,7 @@ _REPAIR_PATTERNS = [
     r"that hurt\b",
     r"傷つ",
     r"前の返事",
-    r"つらかった",
-    r"きつかった",
+    r"(?:返事|言葉|言い方|さっきの|あの一言).{0,10}(?:つらかった|きつかった)",
 ]
 # "やった" only as an exclamation: utterance-initial (but not やったら/やったん
 # conditionals/questions) or followed by an exclamatory mark. Kansai past tense
@@ -54,28 +56,55 @@ _DELIGHT_PATTERNS = [
     r"嬉し",
     r"うれし",
     r"最高",
-    r"できた",
-    # negated happy must not celebrate ("I'm not happy with…")
-    r"(?<!not )(?<!n't )(?<!never )\bhappy\b",
+    # できた only as clause-final/exclamatory accomplishment — the formation
+    # sense (腫瘍ができたって言われた) must not celebrate.
+    r"できた(?:[!！ー〜♪]|で|ぞ|やん|わ|$)",
+    r"\bhappy\b",
     r"\byay\b",
 ]
-# bare "ugh" matched laughed/daughter/thought/enough; うんざり added here so the
-# fed-up reading is caught positively (it used to read as silence via うん).
-_VENTING_PATTERNS = [r"むかつ", r"最悪", r"つらい", r"しんど", r"疲れ", r"うんざり", r"\bugh+\b"]
+# Negation veto for the delight branch — fixed-width lookbehinds can't catch
+# "I'm not VERY happy with…", so the branch checks this window separately.
+_NEGATED_POSITIVE_RE = re.compile(
+    r"\b(?:not|never|n't|isn't|wasn't|don't|ain't)\b[\w\s']{0,16}\b(?:happy|glad)\b"
+)
+# bare "ugh" matched laughed/daughter/thought/enough; うんざり and the past
+# forms つらかった/きつかった live here so ordinary vents validate instead of
+# repairing; 疲れ excludes the お疲れ greeting.
+_VENTING_PATTERNS = [
+    r"むかつ",
+    r"最悪",
+    r"つらい",
+    r"つらかった",
+    r"きつかった",
+    r"しんど",
+    r"(?<!お)疲れ",
+    r"うんざり",
+    r"\bugh+\b",
+]
 # bereavement forms only — bare 死 matched 死ぬほど笑った/必死, bare "lost"
-# matched "lost track of time".
+# matched "lost track of time"; polite/Kansai death forms and pronoun objects
+# ("we lost him") must still reach the comfort register.
 _GRIEF_PATTERNS = [
     r"寂し",
     r"悲し",
     r"\bgrief\b",
-    r"\blost (?:a |my |our |her |his )?(?:someone|mom|dad|mother|father|grand\w+|friend|husband|wife|partner|dog|cat|pet|baby)\b",
+    r"\blost (?:a |my |our |her |his )?(?:\w+ )?(?:someone|mom|dad|mother|father|grand\w+|friend|husband|wife|partner|dog|cat|pet|baby)\b",
+    r"\b(?:we|i|she|he|they) (?:just )?lost (?:him|her|them)\b",
     r"passed away",
     r"亡くな",
-    r"死ん(?:だ|でしまっ|じゃっ)",
+    r"死ん(?:だ|でしまっ|でしも|でもう|じゃっ)",
+    r"死にました",
     r"死別",
     r"つらい",
 ]
-_FATIGUE_PATTERNS = [r"疲れ", r"眠い", r"しんど", r"だるい", r"\bexhausted\b", r"\btired\b"]
+_FATIGUE_PATTERNS = [
+    r"(?<!お)疲れ",
+    r"眠い",
+    r"しんど",
+    r"だるい",
+    r"\bexhausted\b",
+    r"\btired\b",
+]
 # 君 only as a standalone second-person pronoun (not 田中君/君津); "how do you"
 # only for introspective targets (not "how do you make carbonara").
 _META_PATTERNS = [
@@ -89,19 +118,20 @@ _META_PATTERNS = [
 # ("we went..." must not classify as playful); "play" needs word boundaries
 # ("display" is not playful).
 _PLAYFUL_PATTERNS = [
-    r"(?<![a-z])[wｗ]+(?![a-z])",
+    # laugh-w must not match URLs (www.) or kaomoji eyes (;w;)
+    r"(?<![a-z./:;])[wｗ]+(?![a-z./;])",
     r"笑",
     r"ふふ",
     r"\bplay(?:ful|ing)?\b",
     r"\bteas(?:e|ing)\b",
     r"冗談",
 ]
-# "no more" as protest only (not "no more milk"); \b kills "nonstop that".
+# "no more" as protest only — utterance-final or "no more of this/that";
+# an opener ("No more bugs! We shipped!") is usually celebration, not protest.
 _BOUNDARY_PATTERNS = [
     r"やめて",
     r"やめろ",
     r"それは嫌",
-    r"^no more\b",
     r"\bno more[.!！]*$",
     r"no more of (?:this|that)",
     r"\bstop that\b",
@@ -116,10 +146,15 @@ _SILENCE_PATTERNS = [
     r"おけ$",
     r"寝る(?:わ|ね|で|ぞ)?[ー〜。…!！]*$",
 ]
+# Whole-utterance anchors: a greeting that merely OPENS a longer message
+# ("おはよう。昨日じいちゃんが亡くなった") must not short-circuit the branches
+# that follow (grief/venting/…). お疲れ様 is a greeting, not a fatigue signal.
 _GREETING_PATTERNS = [
-    r"^おはよ",
-    r"^こんにちは",
-    r"^こんばんは",
+    r"^おはよ(?:う|うございます)?[ー〜!！。\s]*$",
+    r"^こんにちは[ー〜!！。\s]*$",
+    r"^こんばんは[ー〜!！。\s]*$",
+    r"^お疲れ(?:様|さま)?(?:です|でした)?[ー〜!！。\s]*$",
+    r"^おつかれ(?:さま)?(?:です|でした)?[ー〜!！。\s]*$",
     r"^おーい$",
     r"^もしもし$",
 ]
@@ -141,8 +176,9 @@ _CORRECTION_PATTERNS = [
     r"食い違",
     r"そういう意味じゃ",
     r"そうじゃない",
-    # 間違う is the mistake-verb, not a correction of the agent
-    r"(?<!間)違う",
+    # 間違う is the mistake-verb; prenominal 違う+noun (違う話なんやけど…) is a
+    # topic shift, not a correction — only predicate-final 違う corrects.
+    r"(?<!間)違う(?:[よでわぞ]|って|ねん|やん|と思)?\s*(?:[、。!！?？…]|$)",
     # Kansai ちゃう as a correction needs a clause boundary or demonstrative —
     # bare ちゃう hijacked めっちゃ (めっ「ちゃう」れしい) and the 〜ちゃう
     # contraction (食べちゃう).
@@ -376,7 +412,11 @@ class SocialPolicyEngine:
                 mention_memory=False,
             )
 
-        if _matches(text, _DELIGHT_PATTERNS) and affect.valence >= -0.1:
+        if (
+            _matches(text, _DELIGHT_PATTERNS)
+            and not _NEGATED_POSITIVE_RE.search(text.lower())
+            and affect.valence >= -0.1
+        ):
             return SocialPolicyDecision(
                 primary_act="delight_share",
                 response_mode="celebrate",

--- a/src/familiar_neighbor/mind/social_policy.py
+++ b/src/familiar_neighbor/mind/social_policy.py
@@ -28,7 +28,17 @@ _VENTING_PATTERNS = [r"むかつ", r"最悪", r"つらい", r"しんど", r"疲�
 _GRIEF_PATTERNS = [r"寂し", r"悲し", r"grief", r"lost", r"死", r"つらい"]
 _FATIGUE_PATTERNS = [r"疲れ", r"眠い", r"しんど", r"だるい", r"exhausted", r"tired"]
 _META_PATTERNS = [r"君", r"あなた", r"この会話", r"meta", r"how do you", r"あなたは"]
-_PLAYFUL_PATTERNS = [r"w", r"笑", r"ふふ", r"play", r"tease", r"冗談"]
+# "w" is the Japanese laugh marker only when not embedded in an ASCII word
+# ("we went..." must not classify as playful); "play" needs word boundaries
+# ("display" is not playful).
+_PLAYFUL_PATTERNS = [
+    r"(?<![a-z])[wｗ]+(?![a-z])",
+    r"笑",
+    r"ふふ",
+    r"\bplay(?:ful|ing)?\b",
+    r"\bteas(?:e|ing)\b",
+    r"冗談",
+]
 _BOUNDARY_PATTERNS = [r"やめて", r"やめろ", r"それは嫌", r"no more", r"stop that"]
 _SILENCE_PATTERNS = [r"…", r"\.\.\.", r"うん", r"ok$", r"おけ$", r"寝る"]
 _GREETING_PATTERNS = [

--- a/tests/test_agent_react_loop.py
+++ b/tests/test_agent_react_loop.py
@@ -881,3 +881,73 @@ async def test_brief_greeting_turn_skips_auto_tom():
             p.stop()
 
     auto_tom.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Tests: deferred-topic capture (user says "後で話す" -> unfinished business)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deferral_is_recorded_as_unfinished_business():
+    agent = _make_agent()
+    agent.backend.stream_turn = AsyncMock(return_value=(_turn("end_turn", text="ええよ"), "ええよ"))
+    agent._memory.list_unfinished_business_async = AsyncMock(return_value=[])
+    open_mock = AsyncMock(return_value="biz-1")
+    agent._memory.open_unfinished_business_async = open_mock
+
+    ps = _patch_heavy()
+    for p in ps:
+        p.start()
+    try:
+        await agent.run("その話はあとで話すわ、ごめんな")
+    finally:
+        for p in ps:
+            p.stop()
+
+    open_mock.assert_awaited_once()
+    summary = open_mock.await_args.args[0]
+    assert summary.startswith("deferred topic: ")
+    assert "あとで話す" in summary
+    assert open_mock.await_args.kwargs.get("source") == "deferral"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_deferral_not_recorded_twice():
+    agent = _make_agent()
+    agent.backend.stream_turn = AsyncMock(return_value=(_turn("end_turn", text="ええよ"), "ええよ"))
+    existing = {"id": "biz-1", "summary": "deferred topic: その話はあとで話すわ、ごめんな"}
+    agent._memory.list_unfinished_business_async = AsyncMock(return_value=[existing])
+    open_mock = AsyncMock(return_value="biz-2")
+    agent._memory.open_unfinished_business_async = open_mock
+
+    ps = _patch_heavy()
+    for p in ps:
+        p.start()
+    try:
+        await agent.run("その話はあとで話すわ、ごめんな")
+    finally:
+        for p in ps:
+            p.stop()
+
+    open_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_normal_input_records_no_deferral():
+    agent = _make_agent()
+    agent.backend.stream_turn = AsyncMock(return_value=(_turn("end_turn", text="ん"), "ん"))
+    agent._memory.list_unfinished_business_async = AsyncMock(return_value=[])
+    open_mock = AsyncMock(return_value="biz-1")
+    agent._memory.open_unfinished_business_async = open_mock
+
+    ps = _patch_heavy()
+    for p in ps:
+        p.start()
+    try:
+        await agent.run("今日は新しいカメラの設定をいじっててんけど、なかなか難しいわ")
+    finally:
+        for p in ps:
+            p.stop()
+
+    open_mock.assert_not_awaited()

--- a/tests/test_agent_react_loop.py
+++ b/tests/test_agent_react_loop.py
@@ -951,3 +951,26 @@ async def test_normal_input_records_no_deferral():
             p.stop()
 
     open_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_deferral_dedup_sees_beyond_surfaced_top3():
+    """A duplicate whose twin sits at position >=4 must still be deduped."""
+    agent = _make_agent()
+    agent.backend.stream_turn = AsyncMock(return_value=(_turn("end_turn", text="ええよ"), "ええよ"))
+    dup = {"id": "biz-4", "summary": "deferred topic: その話はあとで話すわ、ごめんな"}
+    fresher = [{"id": f"biz-{i}", "summary": f"other {i}"} for i in range(3)]
+    agent._memory.list_unfinished_business_async = AsyncMock(return_value=fresher + [dup])
+    open_mock = AsyncMock(return_value="biz-5")
+    agent._memory.open_unfinished_business_async = open_mock
+
+    ps = _patch_heavy()
+    for p in ps:
+        p.start()
+    try:
+        await agent.run("その話はあとで話すわ、ごめんな")
+    finally:
+        for p in ps:
+            p.stop()
+
+    open_mock.assert_not_awaited()

--- a/tests/test_agent_react_loop.py
+++ b/tests/test_agent_react_loop.py
@@ -825,3 +825,59 @@ async def test_post_response_pipeline_updates_self_continuity_state():
 
     agent._concerns.update_from_turn.assert_called_once()
     agent._self_state.apply_turn_context.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: deterministic ToM wiring (auto_tom_ctx -> mental_ctx -> system prompt)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flagged_turn_runs_auto_tom_and_injects_result():
+    """A venting turn (should_use_tom=True) runs ToM deterministically and the
+    result reaches the system prompt via mental_ctx."""
+    agent = _make_agent()
+    agent.backend.stream_turn = AsyncMock(return_value=(_turn("end_turn", text="うん"), "うん"))
+
+    auto_tom = AsyncMock(return_value="TOM-SENTINEL-XYZ")
+    patches = dict(_HEAVY_PATCHES)
+    patches["familiar_agent.agent.EmbodiedAgent._run_auto_tom"] = auto_tom
+
+    ps = [patch(t, n) for t, n in patches.items()]
+    for p in ps:
+        p.start()
+    try:
+        await agent.run("むかつくわ、ほんまに最悪な一日や")
+    finally:
+        for p in ps:
+            p.stop()
+
+    auto_tom.assert_awaited_once()
+    system = agent.backend.stream_turn.await_args.kwargs.get("system")
+    if system is None:
+        system = agent.backend.stream_turn.await_args.args[0]
+    joined = "\n".join(system) if isinstance(system, tuple) else str(system)
+    assert "TOM-SENTINEL-XYZ" in joined
+
+
+@pytest.mark.asyncio
+async def test_brief_greeting_turn_skips_auto_tom():
+    agent = _make_agent(with_tts=True)
+    agent.backend.stream_turn = AsyncMock(
+        return_value=(_turn("end_turn", text="おはよう。"), "おはよう。")
+    )
+
+    auto_tom = AsyncMock(return_value="TOM-SENTINEL-XYZ")
+    patches = dict(_HEAVY_PATCHES)
+    patches["familiar_agent.agent.EmbodiedAgent._run_auto_tom"] = auto_tom
+
+    ps = [patch(t, n) for t, n in patches.items()]
+    for p in ps:
+        p.start()
+    try:
+        await agent.run("おはよう")
+    finally:
+        for p in ps:
+            p.stop()
+
+    auto_tom.assert_not_awaited()

--- a/tests/test_auto_tom.py
+++ b/tests/test_auto_tom.py
@@ -95,3 +95,45 @@ class TestRunAutoTom:
         tom = types.SimpleNamespace(call=AsyncMock(return_value=("x" * 5000, None)))
         out = await EmbodiedAgent._run_auto_tom(_agent_stub(tom), "y")
         assert len(out) <= 1300
+
+
+class TestAutoTomCooldown:
+    def test_same_act_within_cooldown_blocked(self):
+        assert not _should_auto_tom(
+            types.SimpleNamespace(should_use_tom=True, primary_act="venting"),
+            brief_reply_turn=False,
+            is_desire_turn=False,
+            user_input="まだむかつくわ",
+            turns_since_last=1,
+            last_act="venting",
+        )
+
+    def test_act_change_bypasses_cooldown(self):
+        assert _should_auto_tom(
+            types.SimpleNamespace(should_use_tom=True, primary_act="grief_signal"),
+            brief_reply_turn=False,
+            is_desire_turn=False,
+            user_input="ほんまは悲しいんよ",
+            turns_since_last=1,
+            last_act="venting",
+        )
+
+    def test_cooldown_expires_after_enough_turns(self):
+        assert _should_auto_tom(
+            types.SimpleNamespace(should_use_tom=True, primary_act="venting"),
+            brief_reply_turn=False,
+            is_desire_turn=False,
+            user_input="まだむかつくわ",
+            turns_since_last=3,
+            last_act="venting",
+        )
+
+    def test_no_history_fires(self):
+        assert _should_auto_tom(
+            types.SimpleNamespace(should_use_tom=True, primary_act="venting"),
+            brief_reply_turn=False,
+            is_desire_turn=False,
+            user_input="むかつく",
+            turns_since_last=None,
+            last_act=None,
+        )

--- a/tests/test_auto_tom.py
+++ b/tests/test_auto_tom.py
@@ -1,0 +1,97 @@
+"""Deterministic perspective-taking: should_use_tom actually runs the ToM tool.
+
+SocialPolicyEngine sets should_use_tom on emotionally loaded turns, but the
+flag used to be consumed by nobody — perspective-taking only happened if the
+model spontaneously called the tool. These tests pin the new deterministic
+path: flag → ToM inference → prompt injection → person-model accumulation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+from familiar_agent.agent import EmbodiedAgent
+from familiar_neighbor.embodied_hook import _should_auto_tom
+
+
+def _policy(should_use_tom: bool):
+    return types.SimpleNamespace(should_use_tom=should_use_tom)
+
+
+class TestShouldAutoTom:
+    def test_fires_when_flagged_normal_turn(self):
+        assert _should_auto_tom(
+            _policy(True), brief_reply_turn=False, is_desire_turn=False, user_input="つらいわ"
+        )
+
+    def test_skips_when_not_flagged(self):
+        assert not _should_auto_tom(
+            _policy(False), brief_reply_turn=False, is_desire_turn=False, user_input="つらいわ"
+        )
+
+    def test_skips_brief_reply_turn(self):
+        assert not _should_auto_tom(
+            _policy(True), brief_reply_turn=True, is_desire_turn=False, user_input="つらいわ"
+        )
+
+    def test_skips_desire_turn(self):
+        assert not _should_auto_tom(
+            _policy(True), brief_reply_turn=False, is_desire_turn=True, user_input=""
+        )
+
+    def test_skips_empty_input(self):
+        assert not _should_auto_tom(
+            _policy(True), brief_reply_turn=False, is_desire_turn=False, user_input="  "
+        )
+
+
+def _agent_stub(tom_tool):
+    return types.SimpleNamespace(_tom_tool=tom_tool)
+
+
+class TestRunAutoTom:
+    @pytest.mark.asyncio
+    async def test_returns_tool_output(self):
+        tom = types.SimpleNamespace(call=AsyncMock(return_value=("# ToM: analysis", None)))
+        out = await EmbodiedAgent._run_auto_tom(_agent_stub(tom), "しんどいわ")
+        assert "analysis" in out
+        situation = tom.call.await_args.args[1]["situation"]
+        assert "しんどいわ" in situation
+
+    @pytest.mark.asyncio
+    async def test_empty_when_tool_missing(self):
+        out = await EmbodiedAgent._run_auto_tom(types.SimpleNamespace(_tom_tool=None), "x")
+        assert out == ""
+
+    @pytest.mark.asyncio
+    async def test_empty_when_tool_raises(self):
+        tom = types.SimpleNamespace(call=AsyncMock(side_effect=RuntimeError("backend down")))
+        out = await EmbodiedAgent._run_auto_tom(_agent_stub(tom), "x")
+        assert out == ""
+
+    @pytest.mark.asyncio
+    async def test_empty_on_timeout(self):
+        async def _slow(name, payload):
+            await asyncio.sleep(5)
+            return "late", None
+
+        tom = types.SimpleNamespace(call=_slow)
+        out = await EmbodiedAgent._run_auto_tom(_agent_stub(tom), "x", timeout=0.05)
+        assert out == ""
+
+    @pytest.mark.asyncio
+    async def test_long_situation_is_truncated(self):
+        tom = types.SimpleNamespace(call=AsyncMock(return_value=("ok", None)))
+        await EmbodiedAgent._run_auto_tom(_agent_stub(tom), "あ" * 2000)
+        situation = tom.call.await_args.args[1]["situation"]
+        assert len(situation) <= 600
+
+    @pytest.mark.asyncio
+    async def test_long_output_is_trimmed(self):
+        tom = types.SimpleNamespace(call=AsyncMock(return_value=("x" * 5000, None)))
+        out = await EmbodiedAgent._run_auto_tom(_agent_stub(tom), "y")
+        assert len(out) <= 1300

--- a/tests/test_deferral.py
+++ b/tests/test_deferral.py
@@ -41,11 +41,26 @@ class TestDetectDeferral:
             "あとでお風呂入る",  # doing something later, not deferring a topic
             "これ直しといて",
             "やったー！うまくいった",
+            "また今度ね",  # polite decline, not a topic to keep raising
+            "また今度にしよう",
+            "後で教えてくれる？",  # a request TO the agent — commitments domain
+            "あとで話してくれへん",
+            "あとで聞かせてほしい",
             "",
         ],
     )
     def test_non_deferrals_ignored(self, text):
         assert detect_deferral(text) is None
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "あとで教えてあげるわ",  # user WILL tell — genuine deferral
+            "また今度ゆっくり話そう",
+        ],
+    )
+    def test_user_offering_to_tell_later_is_deferral(self, text):
+        assert detect_deferral(text) is not None
 
     def test_snippet_is_bounded(self):
         long = "また今度話すわ。" + "あ" * 300
@@ -89,3 +104,42 @@ async def test_resolve_tool_unknown_id(memory_tool):
     tool, _store = memory_tool
     text, _ = await tool.call("resolve_unfinished_business", {"id": "nope"})
     assert "not" in text.lower() or "error" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_resolve_tool_accepts_surfaced_8char_prefix(memory_tool):
+    """The prompt shows ids truncated to 8 chars — that prefix MUST resolve.
+
+    Regression for the review-critical bug where exact-match resolve made the
+    surfaced id useless.
+    """
+    tool, store = memory_tool
+    business_id = store.open_unfinished_business(summary="deferred: 旅行の話")
+    short = business_id[:8]
+
+    text, _ = await tool.call("resolve_unfinished_business", {"id": short})
+    assert "✓" in text or "resolved" in text.lower()
+    assert not any(b["id"] == business_id for b in store.list_unfinished_business())
+
+
+def test_resolve_ambiguous_prefix_fails(memory_tool):
+    _tool, store = memory_tool
+    # Craft two open items sharing a prefix (uuid4 collisions are improbable;
+    # insert directly to force the case).
+    with store._db_lock:
+        db = store._ensure_connected()
+        for suffix in ("one", "two"):
+            db.execute(
+                "INSERT INTO unfinished_business "
+                "(id, summary, status, source, related_memory_id, metadata_json, created_at, resolved_at) "
+                "VALUES (?, ?, 'open', 'test', NULL, '{}', '2026-06-11T00:00:00', NULL)",
+                (f"aaaaaaaa-{suffix}", f"item {suffix}"),
+            )
+        db.commit()
+    assert store.resolve_unfinished_business("aaaaaaaa") is False
+
+
+def test_resolve_too_short_prefix_fails(memory_tool):
+    _tool, store = memory_tool
+    store.open_unfinished_business(summary="x")
+    assert store.resolve_unfinished_business("a") is False

--- a/tests/test_deferral.py
+++ b/tests/test_deferral.py
@@ -1,0 +1,91 @@
+"""Deferred-topic detection: "あとで話す" must not be lost.
+
+When the companion defers a topic ("後で話すわ", "また今度説明する"), the agent
+records it as unfinished business so it can naturally bring the topic back up
+later — and the model can resolve it via the new resolve_unfinished_business
+tool once the conversation returns to it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from familiar_agent.tools.memory import MemoryTool, ObservationMemory, _EmbeddingModel
+from familiar_neighbor.mind.deferral import detect_deferral
+
+
+class TestDetectDeferral:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "その話はあとで話すわ",
+            "詳しくは後で説明するから",
+            "また今度ゆっくり話そう",
+            "その件は後日相談させて",
+            "I'll tell you later, promise",
+            "let's talk about it another time",
+        ],
+    )
+    def test_deferrals_detected(self, text):
+        snippet = detect_deferral(text)
+        assert snippet is not None
+        assert snippet in text or len(snippet) <= 120
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "おはよう",
+            "今日は疲れたわ",
+            "あとでお風呂入る",  # doing something later, not deferring a topic
+            "これ直しといて",
+            "やったー！うまくいった",
+            "",
+        ],
+    )
+    def test_non_deferrals_ignored(self, text):
+        assert detect_deferral(text) is None
+
+    def test_snippet_is_bounded(self):
+        long = "また今度話すわ。" + "あ" * 300
+        snippet = detect_deferral(long)
+        assert snippet is not None
+        assert len(snippet) <= 120
+
+
+# ── resolve_unfinished_business tool ──
+
+
+@pytest.fixture
+def memory_tool(tmp_path):
+    with patch.object(_EmbeddingModel, "pre_warm"):
+        store = ObservationMemory(db_path=str(tmp_path / "obs.db"))
+    tool = MemoryTool(store)
+    yield tool, store
+    store.close()
+
+
+def test_resolve_tool_is_defined(memory_tool):
+    tool, _store = memory_tool
+    names = {d["name"] for d in tool.get_tool_definitions()}
+    assert "resolve_unfinished_business" in names
+
+
+@pytest.mark.asyncio
+async def test_resolve_tool_resolves_entry(memory_tool):
+    tool, store = memory_tool
+    business_id = store.open_unfinished_business(summary="deferred: 旅行の話")
+    assert any(b["id"] == business_id for b in store.list_unfinished_business())
+
+    text, image = await tool.call("resolve_unfinished_business", {"id": business_id})
+    assert image is None
+    assert "resolved" in text.lower() or "✓" in text
+    assert not any(b["id"] == business_id for b in store.list_unfinished_business())
+
+
+@pytest.mark.asyncio
+async def test_resolve_tool_unknown_id(memory_tool):
+    tool, _store = memory_tool
+    text, _ = await tool.call("resolve_unfinished_business", {"id": "nope"})
+    assert "not" in text.lower() or "error" in text.lower()

--- a/tests/test_social_policy.py
+++ b/tests/test_social_policy.py
@@ -524,3 +524,42 @@ def test_audit_round2_intended_positives_still_classify() -> None:
     assert _decide("どうしよう、財布なくしたかも").primary_act == "request_for_advice"
     assert _decide("I'm so happy for you!").primary_act == "delight_share"
     assert _decide("それなwww").primary_act == "playful_probe"
+
+
+# ── classifier audit round 3: systematic vetoes ──────────────────────────────
+
+
+def test_audit_round3_misfires_fixed() -> None:
+    cases = [
+        ("さっきの会議、ほんまきつかったわ", "repair_attempt"),
+        ("首にしこりができたで、ちょっと怖い", "delight_share"),
+        ("全然嬉しくないわ", "delight_share"),  # JP negated positive
+        ("最高じゃないわ、これ", "delight_share"),
+        ("I can't say I'm happy about the layoffs", "delight_share"),
+        ("I'm not really all that happy with how it turned out", "delight_share"),
+        ("far from happy with the result", "delight_share"),
+        ("ありがとう、ほんま助かった。実は昨日ばあちゃんが亡くなってん", "acknowledgement"),
+        ("思い切って会社やめてん", "boundary_assertion"),
+        ("最悪や、最高の誕生日になるはずやったのに", "delight_share"),  # mixed sentiment
+        ("最高かよ、ほんま", "delight_share"),  # かよ sarcasm
+        ("泣きそうや…", "silence_or_low_presence"),
+    ]
+    for text, wrong_act in cases:
+        decision = _decide(text)
+        assert decision.primary_act != wrong_act, f"{text!r} still {wrong_act}"
+
+
+def test_audit_round3_mixed_sentiment_vents() -> None:
+    decision = _decide("最悪や、最高の誕生日になるはずやったのに", mood="frustrated")
+    assert decision.primary_act == "venting"
+    assert _decide("泣きそうや…", mood="sad").primary_act == "venting"
+
+
+def test_audit_round3_intended_positives_still_classify() -> None:
+    assert _decide("ありがとうな！").primary_act == "acknowledgement"
+    assert _decide("助かったわ").primary_act == "acknowledgement"
+    assert _decide("それやめてほしい").primary_act == "boundary_assertion"
+    assert _decide("やめてや！").primary_act == "boundary_assertion"
+    assert _decide("さっきの返事、ちょっとつらかった").primary_act == "repair_attempt"
+    assert _decide("やっとアプリできたで！").primary_act == "delight_share"
+    assert _decide("How was your day?").primary_act == "meta_conversation"

--- a/tests/test_social_policy.py
+++ b/tests/test_social_policy.py
@@ -374,3 +374,18 @@ def test_capacity_prompt_line_rendered() -> None:
     rested = _decide_pressured("これ直してくれへん", need_rest=0.2)
     text2 = EmbodiedAgent._format_social_policy_prompt(rested)
     assert "capacity" not in text2.lower()
+
+
+# ── Kansai past-tense "〜やった" must not read as delight ───────────────────
+
+
+def test_kansai_past_tense_yatta_is_not_delight() -> None:
+    for text in ("今日ほんま散々やった", "えらい目にあって大変やった", "最悪の一日やった"):
+        decision = _decide(text, mood="frustrated")
+        assert decision.primary_act != "delight_share", text
+
+
+def test_exclamatory_yatta_still_delight() -> None:
+    for text in ("やったー、うまくいった！", "やった！受かった！", "やったぜ"):
+        decision = _decide(text)
+        assert decision.primary_act == "delight_share", text

--- a/tests/test_social_policy.py
+++ b/tests/test_social_policy.py
@@ -389,3 +389,22 @@ def test_exclamatory_yatta_still_delight() -> None:
     for text in ("やったー、うまくいった！", "やった！受かった！", "やったぜ"):
         decision = _decide(text)
         assert decision.primary_act == "delight_share", text
+
+
+# ── playful "w" must be the laugh marker, not the letter w ──────────────────
+
+
+def test_english_sentences_with_w_are_not_playful() -> None:
+    for text in (
+        "we went to the new bakery today",
+        "I was reading a book about whales",
+        "the display is broken again",
+    ):
+        decision = _decide(text)
+        assert decision.primary_act != "playful_probe", text
+
+
+def test_laugh_markers_still_playful() -> None:
+    for text in ("それなwww", "おもろすぎるw", "なんでやねん笑", "let's play a game"):
+        decision = _decide(text)
+        assert decision.primary_act == "playful_probe", text

--- a/tests/test_social_policy.py
+++ b/tests/test_social_policy.py
@@ -478,3 +478,49 @@ def test_audit_intended_positives_still_classify() -> None:
     assert act_of("もう寝るわ") == "silence_or_low_presence"
     assert act_of("君はどう思う？") in ("meta_conversation", "request_for_advice")
     assert act_of("I'm so happy for you!") == "delight_share"
+
+
+# ── classifier audit round 2: variation + tail misfires must stay fixed ──
+
+
+def test_audit_round2_misfires_fixed() -> None:
+    cases = [
+        ("I'm not very happy with how the demo went", "delight_share"),  # adverb-negation
+        ("I am not at all happy about this", "delight_share"),
+        ("もうどうしようもないわ", "request_for_advice"),  # どうしようもない resignation
+        ("No more bugs! We finally shipped it!", "boundary_assertion"),
+        ("Went for a run this morning, it was great", "request_for_action"),
+        ("お疲れ様です！", "fatigue_signal"),  # workplace greeting
+        ("今日の会議ほんまきつかったわ", "repair_attempt"),  # ordinary vent
+        ("健康診断で腫瘍ができたって言われた", "delight_share"),  # medical bad news
+        ("これ見てや https://www.example.com/news/2026", "playful_probe"),  # URL www
+        ("迷子の猫がまだ見つからへん ;w;", "playful_probe"),  # crying kaomoji
+        ("違う話なんやけど、ばあちゃんが死んでしまった", "clarification"),  # prenominal 違う
+        ("おはよう。昨日じいちゃんが亡くなったんや", "greeting"),  # multi-clause opener
+    ]
+    for text, wrong_act in cases:
+        decision = _decide(text)
+        assert decision.primary_act != wrong_act, f"{text!r} still {wrong_act}"
+
+
+def test_audit_round2_fix_regressions_restored() -> None:
+    """Round-1 narrowing dropped real grief forms — they must classify again."""
+    for text in ("祖父が死にました", "じいちゃんが死んでもうた", "We lost him last night"):
+        decision = _decide(text, mood="sad")
+        assert decision.primary_act == "grief_signal", text
+
+
+def test_audit_round2_intended_positives_still_classify() -> None:
+    assert _decide("お疲れ様です！").primary_act == "greeting"
+    assert (
+        _decide("おはよう。昨日じいちゃんが亡くなったんや", mood="sad").primary_act
+        == "grief_signal"
+    )
+    assert _decide("今日の会議ほんまきつかったわ", mood="frustrated").primary_act == "venting"
+    assert _decide("やっとアプリできたで！").primary_act == "delight_share"
+    assert _decide("can you run the tests?").primary_act == "request_for_action"
+    assert _decide("no more of this, please").primary_act == "boundary_assertion"
+    assert _decide("それ違うで").primary_act == "clarification"
+    assert _decide("どうしよう、財布なくしたかも").primary_act == "request_for_advice"
+    assert _decide("I'm so happy for you!").primary_act == "delight_share"
+    assert _decide("それなwww").primary_act == "playful_probe"

--- a/tests/test_social_policy.py
+++ b/tests/test_social_policy.py
@@ -408,3 +408,73 @@ def test_laugh_markers_still_playful() -> None:
     for text in ("それなwww", "おもろすぎるw", "なんでやねん笑", "let's play a game"):
         decision = _decide(text)
         assert decision.primary_act == "playful_probe", text
+
+
+# ── classifier pattern audit (2026-06): reproduced misfires must stay fixed ──
+#
+# Every utterance below was REPRODUCED misclassifying before the pattern
+# hygiene pass. The wrong register is noted; we assert the misfire is gone.
+
+
+def test_audit_jp_misfires_fixed() -> None:
+    cases = [
+        ("めっちゃうれしい！", "clarification"),  # ちゃう inside めっちゃ
+        ("めっちゃうまかったで", "clarification"),
+        ("笑っちゃうくらい晴れてる", "clarification"),
+        ("死ぬほど笑った", "grief_signal"),  # hyperbolic 死
+        ("必死で頑張ってん", "grief_signal"),
+        ("昨日は一日ゲームしてた", "request_for_action"),  # past progressive してた
+        ("さっきまでコウタと電話してた", "request_for_action"),
+        ("もうどうでもええわ", "request_for_advice"),  # どうでもいい
+        ("どうもありがとうな", "request_for_advice"),
+        ("田中君が遊びに来てくれた", "meta_conversation"),  # name+君
+        ("君津まで出張やった", "meta_conversation"),
+        ("あー、やってもうたわ", "request_for_action"),  # やってもうた dismay
+        ("うんざりやわ", "silence_or_low_presence"),  # うん inside うんざり
+        ("寝る前にちょっとだけ話聞いてや", "silence_or_low_presence"),
+    ]
+    for text, wrong_act in cases:
+        decision = _decide(text)
+        assert decision.primary_act != wrong_act, f"{text!r} still {wrong_act}"
+
+
+def test_audit_en_misfires_fixed() -> None:
+    cases = [
+        ("We laughed so hard at the comedy show last night", "venting"),  # ugh in laughed
+        ("My daughter drew me a picture today, it made my day", "venting"),
+        ("I'm not happy with how the demo went", "delight_share"),  # negated happy
+        ("My back hurts from sitting all day", "repair_attempt"),  # physical hurt
+        ("We totally lost track of time, what a fun night", "grief_signal"),  # lost track
+        ("My dad finally retired last week, we threw him a party", "fatigue_signal"),
+        ("We have no more milk in the fridge", "boundary_assertion"),
+        ("Had brunch with Sarah this morning, it was lovely", "request_for_action"),
+        ("How do you make carbonara?", "meta_conversation"),
+    ]
+    for text, wrong_act in cases:
+        decision = _decide(text)
+        assert decision.primary_act != wrong_act, f"{text!r} still {wrong_act}"
+
+
+def test_audit_intended_positives_still_classify() -> None:
+    appraisal = AppraisalEngine()
+    engine = SocialPolicyEngine()
+
+    def act_of(text: str, mood: str = "engaged") -> str:
+        affect = appraisal.appraise(
+            AppraisalContext(user_text=text, companion_mood=mood, interoception=_pressure())
+        )
+        return engine.decide(
+            user_text=text, affect=affect, trust=0.5, intimacy=0.5, interoception=_pressure()
+        ).primary_act
+
+    assert act_of("これどうしたらいいかな") == "request_for_advice"
+    assert act_of("これ直してくれへん") == "request_for_action"
+    assert act_of("翻訳して") == "request_for_action"
+    assert act_of("おばあちゃんが死んでしまった", mood="sad") == "grief_signal"
+    assert act_of("I'm so tired today", mood="tired") == "fatigue_signal"
+    assert act_of("ちゃうちゃう、そういう意味やない") == "clarification"
+    assert act_of("それはちゃうやろ") == "clarification"
+    assert act_of("うん") == "silence_or_low_presence"
+    assert act_of("もう寝るわ") == "silence_or_low_presence"
+    assert act_of("君はどう思う？") in ("meta_conversation", "request_for_advice")
+    assert act_of("I'm so happy for you!") == "delight_share"

--- a/tests/test_social_policy.py
+++ b/tests/test_social_policy.py
@@ -306,3 +306,71 @@ def test_positive_pattern_with_resolved_does_not_trigger() -> None:
         failed_patterns=["they resolved things alone, I was not needed"],
     )
     assert same == baseline  # "resolved" must not match the "solve" marker
+
+
+# ── Agency boundary: honest capacity acknowledgement ────────────────────────
+#
+# When the agent itself is running low (need_rest high) and the companion asks
+# for work or repair, the policy should tell the model to be honest about
+# capacity instead of overpromising — never to fake being fine.
+
+
+def _decide_pressured(text: str, *, need_rest: float, mood: str = "engaged", **kwargs):
+    appraisal = AppraisalEngine()
+    policy_engine = SocialPolicyEngine()
+    pressure = _pressure(need_rest=need_rest)
+    affect = appraisal.appraise(
+        AppraisalContext(user_text=text, companion_mood=mood, interoception=pressure)
+    )
+    return policy_engine.decide(
+        user_text=text,
+        affect=affect,
+        trust=0.5,
+        intimacy=0.5,
+        interoception=pressure,
+        **kwargs,
+    )
+
+
+def test_exhausted_action_request_acknowledges_capacity() -> None:
+    rested = _decide_pressured("これ全部直しといて、頼むわ", need_rest=0.2)
+    assert rested.primary_act == "request_for_action"
+    assert rested.acknowledge_capacity is False
+
+    exhausted = _decide_pressured("これ全部直しといて、頼むわ", need_rest=0.85)
+    assert exhausted.primary_act == "request_for_action"
+    assert exhausted.acknowledge_capacity is True
+    assert exhausted.initiative < rested.initiative
+
+
+def test_exhausted_repair_request_acknowledges_capacity_but_keeps_repair() -> None:
+    decision = _decide_pressured(
+        "さっきの返事ちょっと傷ついた", need_rest=0.85, previous_response_hurt=True
+    )
+    assert decision.primary_act == "repair_attempt"
+    assert decision.response_mode == "repair"  # repair still happens
+    assert decision.acknowledge_capacity is True
+
+
+def test_exhausted_greeting_does_not_volunteer_fatigue() -> None:
+    decision = _decide_pressured("おはよう", need_rest=0.85)
+    assert decision.primary_act == "greeting"
+    assert decision.acknowledge_capacity is False
+
+
+def test_rested_default_is_false_everywhere() -> None:
+    decision = _decide_pressured("これどうしたらいいかな", need_rest=0.2)
+    assert decision.acknowledge_capacity is False
+
+
+def test_capacity_prompt_line_rendered() -> None:
+    from familiar_agent.agent import EmbodiedAgent
+
+    decision = _decide_pressured("これ直してくれへん", need_rest=0.85)
+    assert decision.primary_act == "request_for_action"
+    text = EmbodiedAgent._format_social_policy_prompt(decision)
+    assert "capacity" in text.lower()
+
+    rested = _decide_pressured("これ直してくれへん", need_rest=0.2)
+    text2 = EmbodiedAgent._format_social_policy_prompt(rested)
+    assert "capacity" not in text2.lower()

--- a/tests/test_social_policy.py
+++ b/tests/test_social_policy.py
@@ -563,3 +563,43 @@ def test_audit_round3_intended_positives_still_classify() -> None:
     assert _decide("さっきの返事、ちょっとつらかった").primary_act == "repair_attempt"
     assert _decide("やっとアプリできたで！").primary_act == "delight_share"
     assert _decide("How was your day?").primary_act == "meta_conversation"
+
+
+# ── classifier audit round 4: lexicon frames and reported speech ─────────────
+
+
+def test_audit_round4_misfires_fixed() -> None:
+    cases = [
+        ("虫歯ができた", "delight_share"),  # off-list ailment
+        ("ものもらいができたわ、痛い", "delight_share"),
+        ("足にまめができた", "delight_share"),  # locative formation frame
+        ("上司に嫌味言われてん。それは嫌やったわ", "boundary_assertion"),
+        ("この前の返事ありがとうな", "repair_attempt"),
+        ("I stubbed my toe this morning, wow that hurt", "repair_attempt"),
+        ("昨日のライブ最高すぎて死んだ", "grief_signal"),  # hyperbolic joy slang
+        ("笑いすぎて死んだわ", "grief_signal"),
+        ("昨日友達を傷つけてしまったかもしれん", "repair_attempt"),  # third-party guilt
+        ("医者に酒やめろって言われてん", "boundary_assertion"),  # reported speech
+        ("嬉しいわけないやろ、こんなん", "delight_share"),
+    ]
+    for text, wrong_act in cases:
+        decision = _decide(text)
+        assert decision.primary_act != wrong_act, f"{text!r} still {wrong_act}"
+
+
+def test_audit_round4_concessive_joy_celebrates() -> None:
+    assert _decide("疲れたけど最高の一日やった！", mood="happy").primary_act == "delight_share"
+    assert _decide("嬉しくて泣きそうや", mood="happy").primary_act == "delight_share"
+
+
+def test_audit_round4_intended_positives_still_classify() -> None:
+    assert _decide("彼女ができた！").primary_act == "delight_share"
+    assert _decide("新しい友達ができたわ").primary_act == "delight_share"
+    assert _decide("それは嫌や").primary_act == "boundary_assertion"
+    assert _decide("やめろ！").primary_act == "boundary_assertion"
+    assert _decide("さっきの返事、ちょっと傷ついた").primary_act == "repair_attempt"
+    assert _decide("おばあちゃんが死んでしまった", mood="sad").primary_act == "grief_signal"
+    assert (
+        _decide("最悪や、最高の誕生日になるはずやったのに", mood="frustrated").primary_act
+        == "venting"
+    )


### PR DESCRIPTION
## Summary

Sociality round 2, building on #175:

**Deterministic ToM** — `should_use_tom` was set by SocialPolicyEngine on
emotionally loaded turns but consumed by nobody. Now `prepare_turn` runs the
ToM inference itself on flagged full turns and injects the result into the
mental context; every flagged turn also accumulates into the persistent
person model. Bounded (500-char input, 1200-char output, 12s cap), degrades
to empty on failure, with a 3-turn cooldown (reset on speech-act change) so
sustained venting doesn't pay a serial utility call per turn.

**Agency boundary** — when the agent's own need_rest is high and the
companion asks for work, advice, or repair, the policy sets
`acknowledge_capacity`: be honest about current capacity, offer a smaller
step or deferral, never fake being fine. Greetings don't volunteer fatigue;
repair still repairs.

**Deferred-topic capture** — "後で話すわ" / "また今度説明する" used to be
lost when the turn ended. A deterministic detector records deferred topics
as unfinished business (same-summary dedup), and the new
`resolve_unfinished_business` tool plus id-bearing context block lets the
model close an item once the conversation actually returns to it.

**Empathy-miss fixes** — two classifier bugs that produced wrong-register
responses: (1) Kansai past-tense "〜やった" ("散々やった") matched
the bare やった delight pattern and produced a celebrate response. Delight
now requires an exclamatory form (やったー/やった！/やったぜ/utterance-initial).
(2) The playful pattern `r"w"` matched the letter w anywhere, so nearly every
English sentence ("we went to the bakery") classified as playful_probe; the
laugh marker now requires w not embedded in an ASCII word, and play/tease get
word boundaries. (3) A two-lens reproduction-required audit then swept ALL
classifier patterns and fixed 16 more reproduced misfires — including
めっちゃうれしい！→clarification (ちゃう inside めっちゃ), 死ぬほど笑った→grief
comfort, 〜してた past-progressives→request_for_action, "I'm not happy"→celebrate,
"My back hurts"→repair apology, laughed/daughter→venting via embedded "ugh",
retired→tired, brunch→run. 23 misfires pinned by regression tests plus 11
intended positives. A round-2 pass (fix variations + unprobed areas:
keigo, emoji/kaomoji, multi-clause, URLs) fixed 12 more — including restoring
three round-1 over-narrowings (死にました/死んでもうた/"we lost him" must
still reach grief-comfort), お疲れ様です→greeting (was fatigue complaint),
腫瘍ができた no longer celebrated, negation-window veto for "not very happy",
and whole-utterance greeting anchors so おはよう。…亡くなった reaches the
grief branch. 28 misfires + 21 intended positives now pinned by regression
tests. Rounds 3-4 continued until convergence: Japanese negation vetoes
(全然嬉しくないわ no longer celebrates), distress-precedence with a concessive
exemption (最悪や、…はずやったのに vents; 疲れたけど最高！ celebrates),
hyperbole guards (最高すぎて死んだ is joy slang, not bereavement),
self-directed-hurt narrowing (友達を傷つけてしまった is a guilt disclosure,
not the agent's fault), reported-speech guards, and a locative formation
frame so 虫歯ができた never celebrates while 彼女ができた still does.
**51 reproduced misfires fixed and pinned across 4 audit rounds** plus ~35
intended positives held. The audit did not run dry — the remaining failure
classes (unbounded lexicons, reported speech/transitivity) are structural
regex limits; an LLM-based act-classification fallback is left as a
deliberate future decision.

Also: changelog entries for #175 + this round, and the architecture guide
now maps the secretary layer and person model.

## Tests

+43 over develop (gate matrices incl. ToM cooldown, run/timeout/truncation
bounds, wiring seams through agent.run for auto-ToM and deferral capture,
capacity-honesty matrix, delight classification, resolve-tool roundtrip).
Full suite 1113 passed; ruff/format/mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







