### PR TITLE
fix(memory): resolve surfaced 8-char memory ids when linking

### DIFF
--- a/src/familiar_agent/tools/memory.py
+++ b/src/familiar_agent/tools/memory.py
@@ -2036,6 +2036,27 @@ class ObservationMemory:
     # Associative links
     # ------------------------------------------------------------------
 
+    def _resolve_observation_id(self, db: sqlite3.Connection, candidate: str) -> str | None:
+        """Resolve a full or surfaced-prefix memory id to the stored full id.
+
+        Tool outputs show ids truncated to 8 chars, so the model passes
+        prefixes; accept them when unambiguous, reject unknown/ambiguous ids.
+        """
+        candidate = str(candidate).strip()
+        if len(candidate) < 4:
+            return None
+        row = db.execute("SELECT id FROM observations WHERE id = ?", (candidate,)).fetchone()
+        if row:
+            return str(row["id"])
+        escaped = candidate.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        rows = db.execute(
+            "SELECT id FROM observations WHERE id LIKE ? ESCAPE '\\' LIMIT 2",
+            (escaped + "%",),
+        ).fetchall()
+        if len(rows) == 1:
+            return str(rows[0]["id"])
+        return None
+
     def link_memories(
         self,
         source_id: str,
@@ -2045,6 +2066,9 @@ class ObservationMemory:
     ) -> bool:
         """Create a typed link between two memories. Returns True on success.
 
+        Accepts full ids or the surfaced 8-char prefixes; unknown or ambiguous
+        ids are rejected instead of silently inserting a dangling link.
+
         link_type: "related" | "similar" | "caused_by" | "leads_to"
         """
         link_id = str(uuid.uuid4())
@@ -2052,11 +2076,20 @@ class ObservationMemory:
         try:
             with self._db_lock:
                 db = self._ensure_connected()
+                resolved_source = self._resolve_observation_id(db, source_id)
+                resolved_target = self._resolve_observation_id(db, target_id)
+                if resolved_source is None or resolved_target is None:
+                    logger.debug(
+                        "link_memories rejected: unresolved id(s) %r -> %r",
+                        source_id,
+                        target_id,
+                    )
+                    return False
                 db.execute(
                     "INSERT OR IGNORE INTO memory_links "
                     "(id, source_id, target_id, link_type, note, created_at) "
                     "VALUES (?, ?, ?, ?, ?, ?)",
-                    (link_id, source_id, target_id, link_type, note, now),
+                    (link_id, resolved_source, resolved_target, link_type, note, now),
                 )
                 db.commit()
             return True

--- a/tests/test_memory_graph.py
+++ b/tests/test_memory_graph.py
@@ -52,3 +52,26 @@ def test_conflicting_semantic_facts_create_revisions(tmp_path: Path) -> None:
     assert revisions[0]["previous_text"] == "Coffee is the favorite"
     assert revisions[0]["new_text"] == "Tea is the favorite"
     mem.close()
+
+
+def test_link_memories_accepts_surfaced_8char_prefixes(tmp_path: Path) -> None:
+    """remember/recall surface ids truncated to 8 chars; linking with those
+    prefixes must create a REAL link (regression: dangling links were silently
+    inserted for unknown ids)."""
+    mem = _memory(tmp_path)
+    first_id, ok1 = mem.save_with_id("青いカメラが届いた", kind="observation")
+    second_id, ok2 = mem.save_with_id("カメラの設定を終えた", kind="observation")
+    assert ok1 and ok2
+
+    assert mem.link_memories(first_id[:8], second_id[:8], link_type="leads_to") is True
+    linked = mem.get_linked_memories(first_id)
+    assert any(item.get("id") == second_id for item in linked)
+    mem.close()
+
+
+def test_link_memories_rejects_unknown_target(tmp_path: Path) -> None:
+    mem = _memory(tmp_path)
+    first_id, _ = mem.save_with_id("孤立した記憶", kind="observation")
+    assert mem.link_memories(first_id, "deadbeef") is False
+    assert mem.get_linked_memories(first_id) == []
+    mem.close()


### PR DESCRIPTION
## Summary

`remember`/`recall` outputs show memory ids truncated to 8 chars, but
`link_memories` inserted whatever ids it was given with **no existence
check** — every model-created link (`remember`'s `link_to`) was silently
dangling: the INSERT "succeeded" while `get_linked_memories`' JOIN could
never match it.

`link_memories` now resolves both endpoints to stored full ids (exact match,
then unique-prefix LIKE with escaping; minimum 4 chars) and rejects unknown
or ambiguous ids instead of inserting garbage.

Found by sweeping for the same bug class as the unfinished-business resolve
fix in #176 (surfaced token ≠ lookup key). Pre-existing bug, independent of
#176; the two PRs touch different regions of memory.py.

## Tests

+2 (8-char prefix produces a real, queryable link; unknown target rejected).
Full suite 1072 passed; ruff/format/mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)