### PR TITLE
feat(mind): companion life threads — capture and follow up later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Companion-thread follow-up: after each conversational turn the agent extracts follow-up-worthy events from the companion's life ("presentation tomorrow") and stores them as unfinished business (source `companion_thread`); open threads surface with a dedicated ask-how-it-went instruction, are capped at 3, dedup against open items, and expire after 14 days
 - Secretary layer: commitments (reminders, appointments, promises, follow-ups) with due times, priorities, and snooze in a dedicated store; add/list/complete/snooze tools; due and upcoming items surface in every turn and a `[Today's agenda]` block opens the day
 - Proactive reminders: due commitments fire self-initiated turns from REPL/TUI/GUI idle loops, independent of `auto_desire` (`FAMILIAR_PROACTIVE_REMINDERS`, default on), quiet-hours aware (urgent-only at night), with escalating backoff capped at 3 reminders
 - Persistent person model: ToM inferences accumulate per person (`person_inferences`) and surface as an accumulated `[Person model]` prompt block with a 7-day staleness cutoff

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -710,6 +710,9 @@ class EmbodiedAgent:
                     )
                     logger.info("Curiosity persisted: %s", curiosity)
 
+            if user_input and not is_desire_turn:
+                await self._capture_companion_thread(user_input, desires)
+
             pred_signal = self._prediction.last_signal()
             concerns = getattr(self, "_concerns", None)
             if concerns is not None:
@@ -2079,6 +2082,64 @@ class EmbodiedAgent:
         except Exception as e:
             logger.warning("Curiosity extraction failed: %s", e)
         return None
+
+    async def extract_companion_thread(self, user_input: str) -> str | None:
+        """Ask the LLM whether the companion mentioned something to follow up on.
+
+        "I have a presentation tomorrow" should resurface later as "how did it
+        go?" — the thread is an event or situation in THEIR life, not a request
+        to the agent (that is the commitments domain).
+        """
+        if not user_input or not user_input.strip():
+            return None
+        try:
+            none_word = _t("curiosity_none")
+            text = await self._utility_backend.complete(
+                "Read the companion's message. If it mentions a concrete upcoming "
+                "event or an ongoing situation in THEIR life that a caring friend "
+                "would ask about later (a presentation tomorrow, feeling unwell, "
+                "a job interview, a trip), describe it in one short sentence in "
+                f"{_t('summary_lang')}. Only their life events qualify — not "
+                "requests to you, not questions, not small talk. If there is "
+                f'nothing to follow up on, reply with just "{none_word}".'
+                f"\n\nMessage: {user_input[:400]}",
+                max_tokens=60,
+            )
+            text = text.strip()
+            if not text or none_word in text or len(text) > 140:
+                return None
+            return text
+        except Exception as e:
+            logger.debug("Companion thread extraction failed: %s", e)
+        return None
+
+    async def _capture_companion_thread(
+        self, user_input: str, desires: DesireSystem | None
+    ) -> None:
+        """Persist a follow-up-worthy thread as unfinished business.
+
+        Source "companion_thread" reuses the existing surfacing + resolve loop:
+        the hook renders open threads with a follow-up instruction and the
+        model resolves them once the outcome is known.  Exact-duplicate
+        summaries are skipped and at most 3 threads stay open at a time.
+        """
+        try:
+            await self._memory.expire_stale_companion_threads_async(max_age_days=14.0)
+            thread = await self.extract_companion_thread(user_input)
+            if not thread:
+                return
+            open_items = await self._memory.list_unfinished_business_async(limit=20)
+            if any(item.get("summary") == thread for item in open_items):
+                return
+            open_threads = [item for item in open_items if item.get("source") == "companion_thread"]
+            if len(open_threads) >= 3:
+                return
+            await self._memory.open_unfinished_business_async(thread, source="companion_thread")
+            if desires is not None:
+                desires.boost("worry_companion", 0.1)
+            logger.info("Companion thread captured: %s", thread)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Companion thread capture failed: %s", exc)
 
     def _should_compact(self, threshold_tokens: int = 60_000) -> bool:
         """Return True when context is large enough to warrant compaction.

--- a/src/familiar_agent/tools/memory.py
+++ b/src/familiar_agent/tools/memory.py
@@ -1582,6 +1582,11 @@ class ObservationMemory:
     async def resolve_unfinished_business_async(self, business_id: str) -> bool:
         return await asyncio.to_thread(self.resolve_unfinished_business, business_id)
 
+    async def expire_stale_companion_threads_async(self, *, max_age_days: float = 14.0) -> int:
+        return await asyncio.to_thread(
+            self.expire_stale_companion_threads, max_age_days=max_age_days
+        )
+
     # ── Day summary support ────────────────────────────────────────
 
     def recall_day_summaries(self, n: int = 5) -> list[dict]:
@@ -1960,6 +1965,28 @@ class ObservationMemory:
         except Exception as e:
             logger.warning("resolve_unfinished_business failed: %s", e)
             return False
+
+    def expire_stale_companion_threads(self, *, max_age_days: float = 14.0) -> int:
+        """Expire open companion threads that nobody followed up on.
+
+        A thread like "presentation tomorrow" loses its value after a couple
+        of weeks; expiring keeps the surfaced list fresh without requiring the
+        model to resolve it.  Other sources (deferral, agent) are untouched.
+        """
+        cutoff = (datetime.now() - timedelta(days=max_age_days)).isoformat()
+        try:
+            with self._db_lock:
+                db = self._ensure_connected()
+                updated = db.execute(
+                    "UPDATE unfinished_business SET status = 'expired', resolved_at = ? "
+                    "WHERE source = 'companion_thread' AND status = 'open' AND created_at < ?",
+                    (self._now_iso(), cutoff),
+                )
+                db.commit()
+            return updated.rowcount
+        except Exception as e:
+            logger.warning("expire_stale_companion_threads failed: %s", e)
+            return 0
 
     def recall_divergent(
         self,

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -254,6 +254,8 @@ class EmbodiedAgentHook(RuntimeHookBase):
         interoception_signal, interoception_pressure = agent._collect_interoception()
         prediction_signal = agent._prediction.last_signal()
         unfinished_business: list[dict] = []
+        companion_threads: list[dict] = []
+        other_business: list[dict] = []
         if not candidate_brief_turn:
             list_unfinished_business = getattr(
                 agent._memory, "list_unfinished_business_async", None
@@ -265,7 +267,17 @@ class EmbodiedAgentHook(RuntimeHookBase):
                 limit=20,
                 fallback=[],
             )
-            unfinished_business = unfinished_open[:3]
+            # Companion threads ("presentation tomorrow") need a follow-up
+            # instruction, not the resolve-once-addressed one — render them
+            # as a separate block so the model doesn't resolve them right
+            # after wishing good luck.
+            companion_threads = [
+                item for item in unfinished_open if item.get("source") == "companion_thread"
+            ][:2]
+            other_business = [
+                item for item in unfinished_open if item.get("source") != "companion_thread"
+            ][:3]
+            unfinished_business = other_business + companion_threads
             # ── Deferred-topic capture ──
             # "後で話すわ" must not be lost: record it as unfinished business so
             # it stays surfaced until the model resolves it.
@@ -478,14 +490,26 @@ class EmbodiedAgentHook(RuntimeHookBase):
                     + "[Continuation]\n"
                     + heartbeat_ctx
                 )
-            if unfinished_business:
+            if other_business:
                 continuity_ctx = (
                     continuity_ctx
                     + ("\n\n" if continuity_ctx else "")
                     + "[Open unfinished business — resolve_unfinished_business(id) once addressed]\n"
                     + "\n".join(
                         f"- [{str(item.get('id', ''))[:8]}] {item['summary'][:160]}"
-                        for item in unfinished_business[:3]
+                        for item in other_business
+                    )
+                )
+            if companion_threads:
+                continuity_ctx = (
+                    continuity_ctx
+                    + ("\n\n" if continuity_ctx else "")
+                    + "[Companion's life threads — they mentioned these; when enough time "
+                    "has passed, ask how it went. Call resolve_unfinished_business(id) "
+                    "only once you learn the outcome]\n"
+                    + "\n".join(
+                        f"- [{str(item.get('id', ''))[:8]}] {item['summary'][:160]}"
+                        for item in companion_threads
                     )
                 )
             # First turn already carries [Today's agenda] in morning_ctx; skip the

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -271,9 +271,12 @@ class EmbodiedAgentHook(RuntimeHookBase):
             # instruction, not the resolve-once-addressed one — render them
             # as a separate block so the model doesn't resolve them right
             # after wishing good luck.
+            # Render cap matches the storage cap (3) — the model can only
+            # resolve what it sees, so a stored-but-hidden thread could only
+            # ever leave via expiry.
             companion_threads = [
                 item for item in unfinished_open if item.get("source") == "companion_thread"
-            ][:2]
+            ][:3]
             other_business = [
                 item for item in unfinished_open if item.get("source") != "companion_thread"
             ][:3]

--- a/tests/test_agent_react_loop.py
+++ b/tests/test_agent_react_loop.py
@@ -974,3 +974,124 @@ async def test_deferral_dedup_sees_beyond_surfaced_top3():
             p.stop()
 
     open_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Tests: companion-thread surfacing ("presentation tomorrow" -> follow up later)
+# ---------------------------------------------------------------------------
+
+
+def _system_text(agent) -> str:
+    system = agent.backend.stream_turn.await_args.kwargs.get("system")
+    if system is None:
+        system = agent.backend.stream_turn.await_args.args[0]
+    return "\n".join(system) if isinstance(system, tuple) else str(system)
+
+
+@pytest.mark.asyncio
+async def test_companion_threads_render_in_their_own_block():
+    """Threads get a follow-up instruction distinct from plain unfinished
+    business — otherwise the model resolves "presentation tomorrow" right
+    after wishing good luck, killing the next-day follow-up."""
+    agent = _make_agent()
+    agent.backend.stream_turn = AsyncMock(return_value=(_turn("end_turn", text="ん"), "ん"))
+    items = [
+        {"id": "biz-1234567", "summary": "deferred topic: 旅行の話", "source": "deferral"},
+        {"id": "thr-1234567", "summary": "presentation tomorrow", "source": "companion_thread"},
+    ]
+    agent._memory.list_unfinished_business_async = AsyncMock(return_value=items)
+    agent._memory.open_unfinished_business_async = AsyncMock(return_value=None)
+
+    ps = _patch_heavy()
+    for p in ps:
+        p.start()
+    try:
+        await agent.run("今日は新しいカメラの設定をいじっててんけど、なかなか難しいわ")
+    finally:
+        for p in ps:
+            p.stop()
+
+    joined = _system_text(agent)
+    assert "[Companion's life threads" in joined
+    assert "presentation tomorrow" in joined
+    assert "[Open unfinished business" in joined
+    assert "旅行の話" in joined
+    # The thread must NOT sit under the resolve-once-addressed header
+    business_block = joined.split("[Companion's life threads")[0]
+    assert "presentation tomorrow" not in business_block.split("[Open unfinished business")[-1]
+
+
+@pytest.mark.asyncio
+async def test_no_thread_block_when_no_threads():
+    agent = _make_agent()
+    agent.backend.stream_turn = AsyncMock(return_value=(_turn("end_turn", text="ん"), "ん"))
+    items = [{"id": "biz-1", "summary": "deferred topic: 旅行の話", "source": "deferral"}]
+    agent._memory.list_unfinished_business_async = AsyncMock(return_value=items)
+    agent._memory.open_unfinished_business_async = AsyncMock(return_value=None)
+
+    ps = _patch_heavy()
+    for p in ps:
+        p.start()
+    try:
+        await agent.run("今日は新しいカメラの設定をいじっててんけど、なかなか難しいわ")
+    finally:
+        for p in ps:
+            p.stop()
+
+    assert "[Companion's life threads" not in _system_text(agent)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_captures_companion_thread_on_conversational_turn():
+    from familiar_agent.agent import EmbodiedAgent
+
+    agent = _make_agent()
+    agent._concerns = MagicMock()
+    agent._infer_emotion = AsyncMock(return_value="neutral")
+    agent._summarize_exchange = AsyncMock(return_value="summary")
+    agent._update_self_model = AsyncMock()
+    agent._maybe_update_self_narrative = AsyncMock()
+    agent._maybe_adapt_values = AsyncMock()
+    agent._capture_companion_thread = AsyncMock()
+
+    await EmbodiedAgent._run_post_response_pipeline(
+        agent,
+        user_input="明日大事なプレゼンあるねん",
+        final_text="うまくいくとええな。",
+        camera_used=False,
+        observation_action_name=None,
+        observation_action_input=None,
+        companion_mood="engaged",
+        is_desire_turn=False,
+        desires=None,
+    )
+
+    agent._capture_companion_thread.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_skips_thread_capture_on_desire_turn():
+    from familiar_agent.agent import EmbodiedAgent
+
+    agent = _make_agent()
+    agent._concerns = MagicMock()
+    agent._infer_emotion = AsyncMock(return_value="neutral")
+    agent._summarize_exchange = AsyncMock(return_value="summary")
+    agent._update_self_model = AsyncMock()
+    agent._maybe_update_self_narrative = AsyncMock()
+    agent._maybe_adapt_values = AsyncMock()
+    agent._capture_companion_thread = AsyncMock()
+
+    await EmbodiedAgent._run_post_response_pipeline(
+        agent,
+        user_input="",
+        final_text="窓の外、晴れてるなあ。",
+        camera_used=False,
+        observation_action_name=None,
+        observation_action_input=None,
+        companion_mood="absent",
+        is_desire_turn=True,
+        desires=None,
+    )
+
+    agent._capture_companion_thread.assert_not_awaited()

--- a/tests/test_agent_react_loop.py
+++ b/tests/test_agent_react_loop.py
@@ -1022,6 +1022,33 @@ async def test_companion_threads_render_in_their_own_block():
 
 
 @pytest.mark.asyncio
+async def test_all_three_stored_threads_render():
+    """Render cap must match the storage cap (3): the model can only resolve
+    what it sees, so a stored-but-hidden thread could only leave via expiry."""
+    agent = _make_agent()
+    agent.backend.stream_turn = AsyncMock(return_value=(_turn("end_turn", text="ん"), "ん"))
+    items = [
+        {"id": f"thr-{i}", "summary": f"thread number {i}", "source": "companion_thread"}
+        for i in range(3)
+    ]
+    agent._memory.list_unfinished_business_async = AsyncMock(return_value=items)
+    agent._memory.open_unfinished_business_async = AsyncMock(return_value=None)
+
+    ps = _patch_heavy()
+    for p in ps:
+        p.start()
+    try:
+        await agent.run("今日は新しいカメラの設定をいじっててんけど、なかなか難しいわ")
+    finally:
+        for p in ps:
+            p.stop()
+
+    joined = _system_text(agent)
+    for i in range(3):
+        assert f"thread number {i}" in joined
+
+
+@pytest.mark.asyncio
 async def test_no_thread_block_when_no_threads():
     agent = _make_agent()
     agent.backend.stream_turn = AsyncMock(return_value=(_turn("end_turn", text="ん"), "ん"))

--- a/tests/test_companion_threads.py
+++ b/tests/test_companion_threads.py
@@ -1,0 +1,206 @@
+"""Companion-thread capture: "I have a presentation tomorrow" must resurface.
+
+After each conversational turn the agent asks the utility LLM whether the
+companion mentioned an upcoming event or ongoing situation in THEIR life worth
+following up on later.  Detected threads are stored as unfinished business
+(source "companion_thread") so the existing surfacing + resolve loop applies —
+no new resolution machinery.  Stale threads expire automatically.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from familiar_agent._i18n import _t
+from familiar_agent.tools.memory import ObservationMemory, _EmbeddingModel
+
+
+# ── Store: stale-thread expiry ──
+
+
+@pytest.fixture
+def store(tmp_path):
+    with patch.object(_EmbeddingModel, "pre_warm"):
+        s = ObservationMemory(db_path=str(tmp_path / "obs.db"))
+    yield s
+    s.close()
+
+
+def _insert_business(store, *, business_id, source, status, created_at):
+    with store._db_lock:
+        db = store._ensure_connected()
+        db.execute(
+            "INSERT INTO unfinished_business "
+            "(id, summary, status, source, related_memory_id, metadata_json, created_at, resolved_at) "
+            "VALUES (?, ?, ?, ?, NULL, '{}', ?, NULL)",
+            (business_id, f"item {business_id}", status, source, created_at),
+        )
+        db.commit()
+
+
+def test_expire_stale_companion_threads(store):
+    old = (datetime.now() - timedelta(days=20)).isoformat()
+    fresh = datetime.now().isoformat()
+    _insert_business(
+        store, business_id="t-old", source="companion_thread", status="open", created_at=old
+    )
+    _insert_business(
+        store, business_id="t-new", source="companion_thread", status="open", created_at=fresh
+    )
+    _insert_business(store, business_id="d-old", source="deferral", status="open", created_at=old)
+    _insert_business(
+        store, business_id="t-done", source="companion_thread", status="resolved", created_at=old
+    )
+
+    expired = store.expire_stale_companion_threads(max_age_days=14.0)
+
+    assert expired == 1
+    open_ids = {b["id"] for b in store.list_unfinished_business(limit=20)}
+    assert "t-old" not in open_ids
+    assert {"t-new", "d-old"} <= open_ids
+
+
+def test_expire_noop_when_nothing_stale(store):
+    fresh = datetime.now().isoformat()
+    _insert_business(
+        store, business_id="t-new", source="companion_thread", status="open", created_at=fresh
+    )
+    assert store.expire_stale_companion_threads(max_age_days=14.0) == 0
+
+
+@pytest.mark.asyncio
+async def test_expire_async_wrapper(store):
+    old = (datetime.now() - timedelta(days=20)).isoformat()
+    _insert_business(
+        store, business_id="t-old", source="companion_thread", status="open", created_at=old
+    )
+    assert await store.expire_stale_companion_threads_async(max_age_days=14.0) == 1
+
+
+# ── Extraction: extract_companion_thread ──
+
+
+def _extraction_agent(reply: str | Exception):
+    from familiar_agent.agent import EmbodiedAgent
+
+    agent = EmbodiedAgent.__new__(EmbodiedAgent)
+    if isinstance(reply, Exception):
+        agent._utility_backend = SimpleNamespace(complete=AsyncMock(side_effect=reply))
+    else:
+        agent._utility_backend = SimpleNamespace(complete=AsyncMock(return_value=reply))
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_extracts_followup_thread():
+    agent = _extraction_agent("明日プレゼンがあるらしい。")
+    thread = await agent.extract_companion_thread("明日大事なプレゼンあるねん、緊張するわ")
+    assert thread == "明日プレゼンがあるらしい。"
+
+
+@pytest.mark.asyncio
+async def test_none_word_means_no_thread():
+    agent = _extraction_agent(_t("curiosity_none"))
+    assert await agent.extract_companion_thread("おはよう、ええ天気やな") is None
+
+
+@pytest.mark.asyncio
+async def test_overlong_reply_rejected():
+    agent = _extraction_agent("x" * 200)
+    assert await agent.extract_companion_thread("明日プレゼンあるねん") is None
+
+
+@pytest.mark.asyncio
+async def test_extraction_failure_degrades_to_none():
+    agent = _extraction_agent(RuntimeError("backend down"))
+    assert await agent.extract_companion_thread("明日プレゼンあるねん") is None
+
+
+@pytest.mark.asyncio
+async def test_empty_input_skips_llm_call():
+    agent = _extraction_agent("should not be called")
+    assert await agent.extract_companion_thread("   ") is None
+    agent._utility_backend.complete.assert_not_awaited()
+
+
+# ── Capture: _capture_companion_thread (dedup, cap, expiry, drive boost) ──
+
+
+def _capture_agent(*, thread: str | None, open_items: list[dict] | None = None):
+    from familiar_agent.agent import EmbodiedAgent
+
+    agent = EmbodiedAgent.__new__(EmbodiedAgent)
+    agent.extract_companion_thread = AsyncMock(return_value=thread)
+    mem = MagicMock()
+    mem.expire_stale_companion_threads_async = AsyncMock(return_value=0)
+    mem.list_unfinished_business_async = AsyncMock(return_value=open_items or [])
+    mem.open_unfinished_business_async = AsyncMock(return_value="biz-1")
+    agent._memory = mem
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_capture_opens_thread_with_source():
+    agent = _capture_agent(thread="presentation tomorrow")
+    desires = MagicMock()
+
+    await agent._capture_companion_thread("明日プレゼンあるねん", desires)
+
+    agent._memory.open_unfinished_business_async.assert_awaited_once()
+    args = agent._memory.open_unfinished_business_async.await_args
+    assert args.args[0] == "presentation tomorrow"
+    assert args.kwargs.get("source") == "companion_thread"
+    desires.boost.assert_called_once()
+    assert desires.boost.call_args.args[0] == "worry_companion"
+
+
+@pytest.mark.asyncio
+async def test_capture_expires_stale_threads_first():
+    agent = _capture_agent(thread=None)
+    await agent._capture_companion_thread("おはよう", None)
+    agent._memory.expire_stale_companion_threads_async.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_thread_opens_nothing():
+    agent = _capture_agent(thread=None)
+    await agent._capture_companion_thread("おはよう", None)
+    agent._memory.open_unfinished_business_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_summary_not_reopened():
+    existing = [{"id": "b1", "summary": "presentation tomorrow", "source": "companion_thread"}]
+    agent = _capture_agent(thread="presentation tomorrow", open_items=existing)
+    await agent._capture_companion_thread("明日プレゼンあるねん", None)
+    agent._memory.open_unfinished_business_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_open_thread_cap_respected():
+    existing = [
+        {"id": f"b{i}", "summary": f"thread {i}", "source": "companion_thread"} for i in range(3)
+    ]
+    agent = _capture_agent(thread="a fourth thread", open_items=existing)
+    await agent._capture_companion_thread("また別の話", None)
+    agent._memory.open_unfinished_business_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_other_sources_do_not_count_toward_cap():
+    existing = [{"id": f"b{i}", "summary": f"deferred {i}", "source": "deferral"} for i in range(5)]
+    agent = _capture_agent(thread="presentation tomorrow", open_items=existing)
+    await agent._capture_companion_thread("明日プレゼンあるねん", None)
+    agent._memory.open_unfinished_business_async.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_capture_survives_store_failure():
+    agent = _capture_agent(thread="presentation tomorrow")
+    agent._memory.list_unfinished_business_async = AsyncMock(side_effect=RuntimeError("db locked"))
+    await agent._capture_companion_thread("明日プレゼンあるねん", None)  # must not raise
+    agent._memory.open_unfinished_business_async.assert_not_awaited()


### PR DESCRIPTION
## Summary

Makes the agent remember follow-up-worthy events in the companion's life and bring them back up naturally: "I have a presentation tomorrow" resurfaces later as "how did it go?".

- **Extraction** — after each conversational turn (not desire turns), one bounded utility-LLM call (`extract_companion_thread`) checks whether the companion mentioned an upcoming event or ongoing situation in *their* life (a presentation, feeling unwell, a trip). Requests to the agent stay in the commitments domain.
- **Storage** — detected threads are stored as unfinished business with `source="companion_thread"`, reusing the existing surfacing + `resolve_unfinished_business` loop (including the 8-char-prefix resolution) instead of adding new resolution machinery. Exact-summary dedup against the open window; at most 3 threads open at a time.
- **Surfacing** — the per-turn hook renders threads in their own prompt block with an ask-how-it-went instruction (distinct from the resolve-once-addressed block), so the model does not resolve "presentation tomorrow" right after wishing good luck. Render cap matches the storage cap (3).
- **Hygiene** — open threads expire automatically after 14 days (`expire_stale_companion_threads`), keeping the list fresh without a resolve call. Capture never raises into the post-response pipeline.

## Test plan

- [x] Store: expiry only touches open `companion_thread` rows; deferral/agent sources and resolved rows untouched; async wrapper covered
- [x] Extraction: none-word rejection, overlong rejection, backend-failure degradation, empty-input LLM skip
- [x] Capture: source tag, exact-summary dedup, cap of 3 (other sources excluded from the cap), worry_companion boost, store-failure survival
- [x] Hook rendering through the real `agent.run()` path: threads in their own block, no block when none, all 3 stored threads visible
- [x] Pipeline wiring: capture on conversational turns, skipped on desire turns
- [x] Full gate green: ruff check, ruff format, mypy (118 files), pytest **1160 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)