### PR TITLE
feat(runtime): substrate extensions for hosting the embodied turn loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Runtime substrate extensions toward hosting the embodied turn loop: `after_tool_result` hooks can replace tool results (adaptive replan), new `mid_turn_user_messages` and `format_interrupt_message` hooks, `run_turn` accepts the cache-preserving `(stable, variable)` system-prompt tuple, and `on_action` / `on_image` / `on_tool_result` observer callbacks thread through the ReAct loop
 - Secretary layer: commitments (reminders, appointments, promises, follow-ups) with due times, priorities, and snooze in a dedicated store; add/list/complete/snooze tools; due and upcoming items surface in every turn and a `[Today's agenda]` block opens the day
 - Proactive reminders: due commitments fire self-initiated turns from REPL/TUI/GUI idle loops, independent of `auto_desire` (`FAMILIAR_PROACTIVE_REMINDERS`, default on), quiet-hours aware (urgent-only at night), with escalating backoff capped at 3 reminders
 - Persistent person model: ToM inferences accumulate per person (`person_inferences`) and surface as an accumulated `[Person model]` prompt block with a 7-day staleness cutoff

--- a/src/familiar_runtime/react_loop.py
+++ b/src/familiar_runtime/react_loop.py
@@ -84,6 +84,9 @@ class ReActLoop:
         turn_id: str | None = None,
         context: "TurnContext | None" = None,
         interrupt_source: "InterruptSource | None" = None,
+        on_action: Callable[[str, dict], None] | None = None,
+        on_image: Callable[[str], None] | None = None,
+        on_tool_result: Callable[[str, dict, str], None] | None = None,
     ) -> RunTurnResult:
         from .runtime import RetryDecision  # local import avoids circular import
 
@@ -117,8 +120,18 @@ class ReActLoop:
                 drained = await interrupt_source.drain()
                 if drained:
                     joined = " / ".join(drained)
+                    # A hook may reshape the spliced interrupt line (e.g. add a
+                    # respond-with-say directive); first non-None wins.
+                    formatted: str | None = None
+                    if context is not None:
+                        for hook in self._hooks:
+                            formatted = await hook.format_interrupt_message(context, drained)
+                            if formatted is not None:
+                                break
                     messages.append(
-                        self._backend.make_user_message(f"[User interrupted]: {joined}")
+                        self._backend.make_user_message(
+                            formatted or f"[User interrupted]: {joined}"
+                        )
                     )
                     emit("user", "interrupt", {"count": len(drained), "text": joined})
 
@@ -133,6 +146,13 @@ class ReActLoop:
                 if extra_blocks:
                     rendered = "\n\n".join(block.rendered_text() for block in extra_blocks)
                     iter_system = _with_extra_system(system, rendered)
+                # Hooks may also append explicit user messages (e.g. a say()
+                # reminder that must read as conversational pressure, not as
+                # system framing).
+                for hook in self._hooks:
+                    for user_message in await hook.mid_turn_user_messages(context, iteration):
+                        messages.append(self._backend.make_user_message(user_message))
+                        emit("system", "mid_turn_message", {"text": user_message[:200]})
 
             emit("model", "model_request_start", {"iteration": iteration + 1})
             result, raw_content = await self._backend.stream_turn(
@@ -205,52 +225,54 @@ class ReActLoop:
                         "tool_call",
                         {"name": tool_call.name, "input": tool_call.input},
                     )
+                    if on_action is not None:
+                        on_action(tool_call.name, tool_call.input)
                     timeout = self._tool_timeouts.get(tool_call.name, self._default_tool_timeout)
                     try:
                         tool_result = await asyncio.wait_for(
                             self._tools.call(tool_call.name, tool_call.input),
                             timeout=timeout,
                         )
+                        emit(
+                            "tool",
+                            "tool_result",
+                            {
+                                "name": tool_call.name,
+                                "success": tool_result.success,
+                                "error": tool_result.error,
+                            },
+                        )
                     except asyncio.TimeoutError:
-                        text = f"Tool timeout: {tool_call.name} exceeded {timeout:.1f}s."
-                        collected.append((text, None))
+                        tool_result = ToolExecutionResult(
+                            text=f"Tool timeout: {tool_call.name} exceeded {timeout:.1f}s.",
+                            success=False,
+                            error="timeout",
+                        )
                         emit(
                             "tool",
                             "tool_timeout",
                             {"name": tool_call.name, "timeout": timeout},
                         )
-                        if context is not None and self._hooks:
-                            timeout_result = ToolExecutionResult(
-                                text=text, success=False, error="timeout"
-                            )
-                            for hook in self._hooks:
-                                await hook.after_tool_result(context, tool_call, timeout_result)
-                        continue
                     except Exception as exc:  # noqa: BLE001
-                        text = f"Tool error: {exc}"
-                        collected.append((text, None))
+                        tool_result = ToolExecutionResult(
+                            text=f"Tool error: {exc}", success=False, error=str(exc)
+                        )
                         emit("tool", "tool_error", {"name": tool_call.name, "error": str(exc)})
-                        if context is not None and self._hooks:
-                            error_result = ToolExecutionResult(
-                                text=text, success=False, error=str(exc)
-                            )
-                            for hook in self._hooks:
-                                await hook.after_tool_result(context, tool_call, error_result)
-                        continue
 
-                    collected.append((tool_result.text, tool_result.image_b64))
-                    emit(
-                        "tool",
-                        "tool_result",
-                        {
-                            "name": tool_call.name,
-                            "success": tool_result.success,
-                            "error": tool_result.error,
-                        },
-                    )
+                    # Hooks may replace the result (e.g. splice an adaptive
+                    # replan into the text); the first non-None return wins
+                    # and later hooks observe the replacement.
                     if context is not None:
                         for hook in self._hooks:
-                            await hook.after_tool_result(context, tool_call, tool_result)
+                            replaced = await hook.after_tool_result(context, tool_call, tool_result)
+                            if replaced is not None:
+                                tool_result = replaced
+
+                    collected.append((tool_result.text, tool_result.image_b64))
+                    if tool_result.image_b64 and on_image is not None:
+                        on_image(tool_result.image_b64)
+                    if on_tool_result is not None:
+                        on_tool_result(tool_call.name, tool_call.input, tool_result.text)
 
                 messages.append(self._backend.make_assistant_message(result, raw_content))
                 messages.append(self._backend.make_tool_results(result.tool_calls, collected))

--- a/src/familiar_runtime/runtime.py
+++ b/src/familiar_runtime/runtime.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
@@ -82,6 +82,18 @@ class RuntimeHook(Protocol):
         iteration: int,
     ) -> list[ContextBlock]: ...
 
+    async def mid_turn_user_messages(
+        self,
+        ctx: TurnContext,
+        iteration: int,
+    ) -> list[str]: ...
+
+    async def format_interrupt_message(
+        self,
+        ctx: TurnContext,
+        interrupts: list[str],
+    ) -> str | None: ...
+
     async def after_model_result(
         self,
         ctx: TurnContext,
@@ -93,7 +105,7 @@ class RuntimeHook(Protocol):
         ctx: TurnContext,
         call: ToolCall,
         result: ToolExecutionResult,
-    ) -> None: ...
+    ) -> ToolExecutionResult | None: ...
 
     async def after_turn(self, ctx: TurnContext, final_text: str) -> None: ...
 
@@ -114,6 +126,20 @@ class RuntimeHookBase:
     ) -> list[ContextBlock]:
         return []
 
+    async def mid_turn_user_messages(
+        self,
+        ctx: TurnContext,  # noqa: ARG002
+        iteration: int,  # noqa: ARG002
+    ) -> list[str]:
+        return []
+
+    async def format_interrupt_message(
+        self,
+        ctx: TurnContext,  # noqa: ARG002
+        interrupts: list[str],  # noqa: ARG002
+    ) -> str | None:
+        return None
+
     async def after_model_result(
         self,
         ctx: TurnContext,  # noqa: ARG002
@@ -126,7 +152,7 @@ class RuntimeHookBase:
         ctx: TurnContext,  # noqa: ARG002
         call: ToolCall,  # noqa: ARG002
         result: ToolExecutionResult,  # noqa: ARG002
-    ) -> None:
+    ) -> ToolExecutionResult | None:
         return None
 
     async def after_turn(self, ctx: TurnContext, final_text: str) -> None:  # noqa: ARG002
@@ -157,10 +183,14 @@ class AgentRuntime:
         *,
         profile: str = "task",
         task_id: str | None = None,
-        system_prompt: str = "",
+        system_prompt: str | tuple[str, str] = "",
         messages: list[Any] | None = None,
         max_tokens: int = 4096,
         interrupt_source: InterruptSource | None = None,
+        on_text: Callable[[str], None] | None = None,
+        on_action: Callable[[str, dict], None] | None = None,
+        on_image: Callable[[str], None] | None = None,
+        on_tool_result: Callable[[str, dict, str], None] | None = None,
     ) -> RunTurnResult:
         # ``interrupt_source`` is polled by the ReAct loop between iterations so
         # async user input gets folded into the in-flight turn (see ReActLoop.run).
@@ -173,7 +203,16 @@ class AgentRuntime:
             blocks.extend(await hook.build_context(ctx))
         selected = select_context_blocks(blocks, max_chars=self._max_context_chars)
         context_text = "\n\n".join(block.rendered_text() for block in selected)
-        system = f"{system_prompt}\n\n{context_text}".strip()
+        system: str | tuple[str, str]
+        if isinstance(system_prompt, tuple):
+            # Preserve the (stable, variable) split — the Anthropic adapter's
+            # cache_control on the stable half depends on it. Hook context
+            # joins the variable half.
+            stable, variable = system_prompt
+            merged = f"{variable}\n\n{context_text}".strip() if context_text else variable
+            system = (stable, merged)
+        else:
+            system = f"{system_prompt}\n\n{context_text}".strip()
 
         turn_messages = messages if messages is not None else []
         turn_messages.append(self._backend.make_user_message(user_input))
@@ -197,6 +236,10 @@ class AgentRuntime:
             task_id=task_id,
             context=ctx,
             interrupt_source=interrupt_source,
+            on_text=on_text,
+            on_action=on_action,
+            on_image=on_image,
+            on_tool_result=on_tool_result,
         )
         for hook in self._hooks:
             await hook.after_turn(ctx, result.final_text)

--- a/tests/test_runtime_hooks.py
+++ b/tests/test_runtime_hooks.py
@@ -515,3 +515,235 @@ async def test_runtime_without_hooks_still_runs_react_loop() -> None:
     )
     result = await runtime.run_turn("hi")
     assert result.final_text == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Thin-wrap substrate extensions: result replacement, user-message injection,
+# interrupt formatting, tuple system prompts, and observer callbacks.
+# ---------------------------------------------------------------------------
+
+
+class _ImageTool:
+    def specs(self) -> list[ToolSpec]:
+        return [
+            ToolSpec(
+                name="snap",
+                description="Snap",
+                input_schema={"type": "object", "properties": {}},
+            )
+        ]
+
+    async def call(self, name: str, tool_input: dict[str, Any]) -> ToolExecutionResult:  # noqa: ARG002
+        return ToolExecutionResult(text="a photo", image_b64="IMGB64")
+
+
+class _ReplanHook(RuntimeHookBase):
+    """Mimics TAPE replan: splices a replan note into the tool result."""
+
+    async def after_tool_result(
+        self,
+        ctx: TurnContext,  # noqa: ARG002
+        call: ToolCall,  # noqa: ARG002
+        result: ToolExecutionResult,
+    ) -> ToolExecutionResult | None:
+        return ToolExecutionResult(
+            text=f"{result.text}\n\n[ADAPTIVE REPLAN] new plan",
+            image_b64=result.image_b64,
+            success=result.success,
+            error=result.error,
+        )
+
+
+@pytest.mark.asyncio
+async def test_after_tool_result_replacement_reaches_history() -> None:
+    backend = _ScriptedBackend(
+        [
+            ModelTurnResult(
+                stop_reason="tool_use",
+                text="",
+                tool_calls=[ToolCall(id="tc1", name="echo", input={"text": "hi"})],
+            ),
+            ModelTurnResult(stop_reason="end_turn", text="done"),
+        ]
+    )
+    registry = ToolRegistry()
+    registry.register(_EchoTool())
+    runtime = AgentRuntime(backend=backend, tools=registry, hooks=[_ReplanHook()])
+    messages: list[Any] = []
+    await runtime.run_turn("go", messages=messages)
+    flat: list[Any] = []
+    for m in messages:
+        flat.extend(m if isinstance(m, list) else [m])
+    tool_messages = [m for m in flat if isinstance(m, dict) and m.get("role") == "tool"]
+    assert tool_messages
+    assert "[ADAPTIVE REPLAN] new plan" in tool_messages[0]["content"]
+
+
+class _SayReminderHook(RuntimeHookBase):
+    """Injects a user message before the second model call."""
+
+    async def mid_turn_user_messages(
+        self,
+        ctx: TurnContext,  # noqa: ARG002
+        iteration: int,
+    ) -> list[str]:
+        if iteration == 1:
+            return ["REMINDER: call say() now."]
+        return []
+
+
+@pytest.mark.asyncio
+async def test_mid_turn_user_messages_appended_to_history() -> None:
+    backend = _ScriptedBackend(
+        [
+            ModelTurnResult(
+                stop_reason="tool_use",
+                text="",
+                tool_calls=[ToolCall(id="tc1", name="echo", input={})],
+            ),
+            ModelTurnResult(stop_reason="end_turn", text="done"),
+        ]
+    )
+    registry = ToolRegistry()
+    registry.register(_EchoTool())
+    runtime = AgentRuntime(backend=backend, tools=registry, hooks=[_SayReminderHook()])
+    messages: list[Any] = []
+    await runtime.run_turn("go", messages=messages)
+    user_texts = [
+        m["content"]
+        for m in messages
+        if isinstance(m, dict) and m.get("role") == "user" and isinstance(m.get("content"), str)
+    ]
+    assert "REMINDER: call say() now." in user_texts
+
+
+class _ListInterrupts:
+    def __init__(self, items: list[str]) -> None:
+        self._items = list(items)
+
+    async def drain(self) -> list[str]:
+        items, self._items = self._items, []
+        return items
+
+    def empty(self) -> bool:
+        return not self._items
+
+
+class _InterruptFormatHook(RuntimeHookBase):
+    async def format_interrupt_message(
+        self,
+        ctx: TurnContext,  # noqa: ARG002
+        interrupts: list[str],
+    ) -> str | None:
+        return f"[User interrupted x{len(interrupts)}]: {interrupts[0]}. Respond with say() now."
+
+
+@pytest.mark.asyncio
+async def test_interrupt_format_hook_overrides_default() -> None:
+    backend = _ScriptedBackend([ModelTurnResult(stop_reason="end_turn", text="ok")])
+    runtime = AgentRuntime(backend=backend, tools=ToolRegistry(), hooks=[_InterruptFormatHook()])
+    messages: list[Any] = []
+    await runtime.run_turn(
+        "go", messages=messages, interrupt_source=_ListInterrupts(["まだ起きてる？"])
+    )
+    user_texts = [
+        m["content"]
+        for m in messages
+        if isinstance(m, dict) and m.get("role") == "user" and isinstance(m.get("content"), str)
+    ]
+    assert any(t.startswith("[User interrupted x1]") and "say() now" in t for t in user_texts)
+
+
+@pytest.mark.asyncio
+async def test_interrupt_default_format_without_hook() -> None:
+    backend = _ScriptedBackend([ModelTurnResult(stop_reason="end_turn", text="ok")])
+    runtime = AgentRuntime(backend=backend, tools=ToolRegistry(), hooks=[RuntimeHookBase()])
+    messages: list[Any] = []
+    await runtime.run_turn("go", messages=messages, interrupt_source=_ListInterrupts(["hello"]))
+    user_texts = [
+        m["content"]
+        for m in messages
+        if isinstance(m, dict) and m.get("role") == "user" and isinstance(m.get("content"), str)
+    ]
+    assert any(t.startswith("[User interrupted]:") for t in user_texts)
+
+
+class _SystemRecordingBackend(_ScriptedBackend):
+    def __init__(self, turns: list[ModelTurnResult]) -> None:
+        super().__init__(turns)
+        self.systems: list[Any] = []
+
+    async def stream_turn(self, **kwargs: Any) -> tuple[ModelTurnResult, Any]:
+        self.systems.append(kwargs.get("system"))
+        return await super().stream_turn(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_run_turn_accepts_tuple_system_prompt() -> None:
+    """The (stable, variable) split must survive run_turn so the Anthropic
+    adapter's cache_control on the stable half stays effective."""
+    backend = _SystemRecordingBackend([ModelTurnResult(stop_reason="end_turn", text="ok")])
+    hook = _RecordingHook("ctx")
+    runtime = AgentRuntime(backend=backend, tools=ToolRegistry(), hooks=[hook])
+    await runtime.run_turn("go", system_prompt=("STABLE-CORE", "variable bits"))
+    system = backend.systems[0]
+    assert isinstance(system, tuple)
+    stable, variable = system
+    assert stable == "STABLE-CORE"
+    assert "variable bits" in variable
+    assert "[ctx] context for go" in variable  # build_context lands in the variable half
+    assert "STABLE-CORE" not in variable
+
+
+@pytest.mark.asyncio
+async def test_observer_callbacks_fire() -> None:
+    backend = _ScriptedBackend(
+        [
+            ModelTurnResult(
+                stop_reason="tool_use",
+                text="",
+                tool_calls=[ToolCall(id="tc1", name="snap", input={"x": 1})],
+            ),
+            ModelTurnResult(stop_reason="end_turn", text="done"),
+        ]
+    )
+    registry = ToolRegistry()
+    registry.register(_ImageTool())
+    runtime = AgentRuntime(backend=backend, tools=registry)
+    actions: list[tuple[str, dict]] = []
+    images: list[str] = []
+    tool_results: list[tuple[str, dict, str]] = []
+    await runtime.run_turn(
+        "go",
+        on_action=lambda name, tool_input: actions.append((name, tool_input)),
+        on_image=images.append,
+        on_tool_result=lambda name, tool_input, text: tool_results.append((name, tool_input, text)),
+    )
+    assert actions == [("snap", {"x": 1})]
+    assert images == ["IMGB64"]
+    assert tool_results == [("snap", {"x": 1}, "a photo")]
+
+
+@pytest.mark.asyncio
+async def test_on_tool_result_fires_on_tool_error() -> None:
+    backend = _ScriptedBackend(
+        [
+            ModelTurnResult(
+                stop_reason="tool_use",
+                text="",
+                tool_calls=[ToolCall(id="tc1", name="boom", input={})],
+            ),
+            ModelTurnResult(stop_reason="end_turn", text="done"),
+        ]
+    )
+    registry = ToolRegistry()
+    registry.register(_ExplodingTool())
+    runtime = AgentRuntime(backend=backend, tools=registry)
+    tool_results: list[tuple[str, dict, str]] = []
+    await runtime.run_turn(
+        "go",
+        on_tool_result=lambda name, tool_input, text: tool_results.append((name, tool_input, text)),
+    )
+    assert len(tool_results) == 1
+    assert tool_results[0][0] == "boom"
+    assert "Tool error" in tool_results[0][2]


### PR DESCRIPTION
## Summary

PR (a) of the thin-wrap migration (per the consultation: rewrite `EmbodiedAgent.run()` as a thin wrapper around `AgentRuntime.run_turn()`). This PR stays inside `familiar_runtime` and adds the missing receptors the gap analysis identified; the agent-side migration follows as PR (b) on top.

- **`after_tool_result` can replace the tool result** — the host for TAPE adaptive replan ("splice `[ADAPTIVE REPLAN]` into the tool text"). First non-None return wins; later hooks observe the replacement. Timeout/error results now flow through the same path, so hooks see one consistent shape.
- **`mid_turn_user_messages` hook** — per-iteration *user-message* injection. say() reminders must arrive as conversational pressure; the existing `mid_turn_inject` only reaches the system prompt.
- **`format_interrupt_message` hook** — profiles can reshape the spliced interrupt line (the embodied agent uses `[User interrupted xN]: … Respond with say() now.`). Default format unchanged when no hook answers.
- **`run_turn` accepts the `(stable, variable)` system-prompt tuple** — stable half stays byte-identical so the Anthropic adapter's `cache_control` keeps its prompt-cache eligibility; hook context joins the variable half.
- **`on_action` / `on_image` / `on_tool_result` observer callbacks** — keyword-only with None defaults through `run_turn` → `ReActLoop.run`; existing call sites unchanged. `on_tool_result` fires on errors too (matching the embodied loop).

All existing public signatures preserved (additive keyword-only params; `after_tool_result`'s widened return type is satisfied by every existing hook returning None).

## Test plan

- [x] Replacement reaches message history (`[ADAPTIVE REPLAN]` in tool results)
- [x] `mid_turn_user_messages` lands as a user message before the next model call
- [x] Interrupt format hook overrides; default format preserved without a hook
- [x] Tuple system prompt: stable half untouched, build_context blocks land in the variable half
- [x] Observer callbacks fire for action/image/result; `on_tool_result` fires on tool error
- [x] Existing hook/tripwire tests untouched and green
- [x] Full gate: ruff check, ruff format, mypy (118 files), pytest **1147 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)