### PR TITLE
refactor(agent): thin-wrap EmbodiedAgent.run() around the substrate ReActLoop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Agent replies no longer wait on post-response memory/self-model updates, and TAPE planning is skipped when no separate utility backend is configured
 - System prompts now surface at most one active concern and one recent misaligned intention trace, while post-response updates carry those states forward without adding hot-path LLM calls
 - Embodied tool routing now goes through the generic ToolRegistry while preserving existing camera, voice, memory, coding, and MCP behavior
+- `EmbodiedAgent.run()` is now a thin wrapper around the substrate `ReActLoop`: TAPE replan, coherence retry, interrupt drain, and say() reminders ride `EmbodiedAgentHook` lifecycle methods; finalisation and the forced final response stay in the wrapper, and the public `run()` signature is unchanged
 
 ### Fixed
 - Commitment store no longer pins its SQLite connection to the creating thread: in the GUI the agent (and store) are built inside `asyncio.to_thread`, so every commitment write from the event-loop thread (add/complete/snooze tools, reminder bookkeeping, delegated-task follow-ups) raised `ProgrammingError` and was silently swallowed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,14 +93,20 @@ prompt is `str | tuple[str, str]`, where the tuple is `(stable, variable)` — t
 Anthropic adapter's `cache_control` depends on this shape. Use `_with_extra_system`
 to append to the variable half.
 
-**Important caveat:** `EmbodiedAgent.run()` in `familiar_agent/agent.py` (~2400 lines)
-still runs its **own** ReAct loop and has not yet been routed through
-`AgentRuntime.run_turn`. `EmbodiedAgentHook` already structurally implements
-`RuntimeHook` but currently drives the agent via `prepare_turn` /
-`commit_after_end_turn`. Routing `EmbodiedAgent.run()` through the substrate is the
-known next step — it is **high-risk** (touches the TAPE replan / coherence retry /
-interrupt drain / say-reminder loop internals and ~23 `test_agent_react_loop.py`
-tests) and should not be attempted without explicit confirmation.
+**Thin-wrap (landed):** `EmbodiedAgent.run()` now drives the substrate
+`ReActLoop` directly. The four historical inline behaviours ride
+`EmbodiedAgentHook` lifecycle methods — coherence retry (`after_model_result` →
+`RetryDecision`), TAPE replan (`after_tool_result` result replacement), say()
+reminders (`mid_turn_user_messages`), and the embodied interrupt line
+(`format_interrupt_message`) — with the `PreparedTurn` carried in
+`ctx.metadata["prep"]`. Two adapters in `agent.py` bridge the seams:
+`_TurnToolAdapter` (per-turn tool defs + `_execute_tool` routing, so MCP
+late-start and the `_tool_timeout_seconds` patch seam stay intact) and
+`_InterruptQueueSource` (armed only after the first model call so pre-turn
+input is not double-included). Finalisation (meta-gate repair, continuation
+status, auto-say, `commit_after_end_turn`) and the forced final response on
+max-iterations remain in `run()`. The `run()` public signature is unchanged
+and must stay that way.
 
 ### Turn flow (conceptual)
 

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -11,7 +11,7 @@ import time
 from collections.abc import Callable, Coroutine, Mapping
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from ._runtime_helpers import (
     MAX_ITERATIONS,
@@ -49,7 +49,10 @@ from .prediction import PredictionEngine
 from .social_policy import SocialPolicyDecision, SocialPolicyEngine
 from .workspace import GlobalWorkspace
 from .memory_worker import MemoryJobWorker
-from .tape import check_plan_blocked, generate_plan, generate_replan
+
+# check_plan_blocked / generate_replan are referenced via this module's
+# namespace by EmbodiedAgentHook.after_tool_result (and patched here by tests).
+from .tape import check_plan_blocked, generate_plan, generate_replan  # noqa: F401
 from .tools.camera import CameraTool
 from .tools.coding import CodingTool
 from .tools.commitments import (
@@ -80,6 +83,10 @@ from familiar_neighbor.embodied_hook import EmbodiedAgentHook
 from familiar_neighbor.mind.person_model import PersonModelTracker
 from familiar_neighbor.prompts import assemble_neighbor_system_prompt
 from familiar_runtime.commitments import SQLiteCommitmentStore
+from familiar_runtime.models.base import ModelBackend as RuntimeModelBackend
+from familiar_runtime.react_loop import ReActLoop
+from familiar_runtime.runtime import TurnContext
+from familiar_runtime.tools.base import ToolExecutionResult
 from familiar_runtime.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
@@ -469,6 +476,51 @@ def _react_to_scene_events(events: list[dict], desires: DesireSystem | None) -> 
                 desires.boost("greet_companion", 0.6)
             elif event_type == "disappeared":
                 desires.boost("worry_companion", 0.2)
+
+
+class _TurnToolAdapter:
+    """Present the agent's per-turn tool surface to the substrate ReActLoop.
+
+    ``tool_defs()`` returns the (possibly brief-turn-restricted) defs prepared
+    for this turn, and ``call()`` routes through ``EmbodiedAgent._execute_tool``
+    so MCP late-start and registry rebuild behaviour stay intact. Timeouts are
+    applied by the loop itself, mirroring the historical inline handling.
+    """
+
+    def __init__(self, agent: "EmbodiedAgent", tool_defs: list[dict]) -> None:
+        self._agent = agent
+        self._defs = tool_defs
+
+    def tool_defs(self) -> list[dict]:
+        return self._defs
+
+    async def call(self, name: str, tool_input: dict) -> ToolExecutionResult:
+        logger.info("Tool call: %s(%s)", name, tool_input)
+        text, image = await self._agent._execute_tool(name, tool_input)
+        logger.info("Tool result: %s", text[:100])
+        return ToolExecutionResult(text=text, image_b64=image)
+
+
+class _InterruptQueueSource:
+    """Adapt the UI's asyncio interrupt queue to the runtime InterruptSource.
+
+    Stays disarmed until the hook arms it after the first model call, so an
+    input queued before the turn started is not double-included.
+    """
+
+    def __init__(self, agent: "EmbodiedAgent", queue: Any) -> None:
+        self._agent = agent
+        self._queue = queue
+        self._armed = False
+
+    def arm(self) -> None:
+        self._armed = True
+
+    def empty(self) -> bool:
+        return not self._armed or self._queue.empty()
+
+    async def drain(self) -> list[str]:
+        return self._agent._drain_interrupt_queue(self._queue)
 
 
 class EmbodiedAgent:
@@ -2301,14 +2353,14 @@ class EmbodiedAgent:
         """Run one conversation turn with the agent loop.
 
         inner_voice: agent's own desire/impulse (injected into system prompt, NOT a user message).
+
+        The deterministic pre-loop pipeline lives in
+        ``EmbodiedAgentHook.prepare_turn``; the loop body is the substrate
+        ``ReActLoop`` with the embodied behaviours (TAPE replan, coherence
+        retry, interrupt drain, say reminders) supplied by the hook's
+        lifecycle methods; finalisation (meta-gate repair, continuation
+        status, auto-say, commit) stays here.
         """
-        # The deterministic pre-loop pipeline (late-init, phase callback,
-        # morning reconstruction, memory recall, appraisal, social policy,
-        # desire regulation, plan / workspace context, mental snapshot)
-        # lives in ``EmbodiedAgentHook.prepare_turn``.  See PR3 of the
-        # runtime reorg.  The hook mutates this agent's state in place and
-        # appends the user message to ``self.messages`` before returning;
-        # the loop below stays focused on model/tool dispatch.
         prep = await self._hook.prepare_turn(
             user_input=user_input,
             on_phase=on_phase,
@@ -2317,222 +2369,106 @@ class EmbodiedAgent:
         )
 
         try:
-            for i in range(prep.turn_max_iterations):
-                logger.debug("Agent iteration %d", i + 1)
+            interrupt_source = (
+                _InterruptQueueSource(self, interrupt_queue)
+                if interrupt_queue is not None
+                else None
+            )
+            ctx = TurnContext(user_input=user_input, profile="neighbor")
+            ctx.metadata["prep"] = prep
+            ctx.metadata["interrupt_source"] = interrupt_source
 
-                result, raw_content = await self.backend.stream_turn(
-                    system=self._system_prompt(
-                        prep.feelings_ctx,
-                        prep.morning_ctx,
-                        inner_voice=prep.inner_voice,
-                        plan_ctx=prep.plan_ctx,
-                        companion_mood=prep.companion_mood,
-                        continuity_ctx=prep.continuity_ctx,
-                        workspace_ctx=prep.workspace_ctx,
-                        mental_ctx=prep.mental_ctx,
-                    ),
-                    messages=self.messages,
-                    tools=prep.turn_tools,
-                    max_tokens=prep.turn_max_tokens,
-                    on_text=on_text,
+            # Timeouts go through _tool_timeout_seconds so the historical
+            # per-tool seam (and its test patches) stays authoritative —
+            # resolved for every tool on this turn's surface, not just the
+            # static override table.
+            turn_tool_names = {str(tool_def.get("name", "")) for tool_def in prep.turn_tools} | set(
+                _TOOL_TIMEOUTS
+            )
+            loop = ReActLoop(
+                backend=cast("RuntimeModelBackend", self.backend),
+                tools=cast(ToolRegistry, _TurnToolAdapter(self, prep.turn_tools)),
+                max_iterations=prep.turn_max_iterations,
+                default_tool_timeout=self._tool_timeout_seconds(""),
+                tool_timeouts={
+                    name: self._tool_timeout_seconds(name) for name in turn_tool_names if name
+                },
+                hooks=[self._hook],
+            )
+            run_result = await loop.run(
+                system=self._system_prompt(
+                    prep.feelings_ctx,
+                    prep.morning_ctx,
+                    inner_voice=prep.inner_voice,
+                    plan_ctx=prep.plan_ctx,
+                    companion_mood=prep.companion_mood,
+                    continuity_ctx=prep.continuity_ctx,
+                    workspace_ctx=prep.workspace_ctx,
+                    mental_ctx=prep.mental_ctx,
+                ),
+                messages=self.messages,
+                max_tokens=prep.turn_max_tokens,
+                on_text=on_text,
+                context=ctx,
+                interrupt_source=interrupt_source,
+                on_action=on_action,
+                on_image=on_image,
+                on_tool_result=on_tool_result,
+            )
+
+            if run_result.stop_reason == "end_turn":
+                final_text = run_result.final_text
+
+                gate_method = getattr(self._meta_monitor, "gate_response", None)
+                gate: MetaGateDecision | None = None
+                if callable(gate_method):
+                    maybe_gate = gate_method(
+                        user_text=user_input,
+                        candidate_response=final_text,
+                        social_policy=prep.social_policy,
+                        last_error=self._last_tool_error,
+                    )
+                    if isinstance(maybe_gate, MetaGateDecision):
+                        gate = maybe_gate
+                if gate is not None and gate.needs_repair and gate.repaired_response:
+                    final_text = gate.repaired_response
+
+                continuation_status = "DONE"
+                status_match = re.search(
+                    r"(?:^|\n)(DONE|CONTINUE:[^\n]+|DEFER:[^\n]+)\s*$", final_text
                 )
-                self._last_context_tokens = result.input_tokens
-                self._session_input_tokens += result.input_tokens
-                self._session_output_tokens += result.output_tokens
+                if status_match:
+                    continuation_status = status_match.group(1)
+                    final_text = final_text[: status_match.start(1)].rstrip() or "(no response)"
+                self._heartbeat.apply_status(continuation_status)
 
-                # HOT layer: record this step metacognitively
-                _focus = self._attention_schema.current_focus()
-                if _focus is not None:
-                    _action = result.stop_reason
-                    if result.stop_reason == "tool_use" and result.tool_calls:
-                        _action = result.tool_calls[0].name
-                    _conf = min(1.0, result.output_tokens / max(1, self.config.max_tokens))
-                    self._meta_monitor.record_step(_focus, action=_action, confidence=_conf)
+                self._coherence_retried = False
 
-                if result.stop_reason == "end_turn":
-                    self.messages.append(self.backend.make_assistant_message(result, raw_content))
-                    final_text = result.text or "(no response)"
+                # Auto-say: if the model wrote text but never called say(), speak it aloud.
+                _auto_say_enabled = getattr(self.config, "auto_say", False)
+                if (
+                    _auto_say_enabled
+                    and self._tts
+                    and not prep.say_used
+                    and final_text
+                    and final_text != "(no response)"
+                ):
+                    if on_action:
+                        on_action("say", {"text": final_text})
+                    await self._tts.call("say", {"text": final_text})
 
-                    gate_method = getattr(self._meta_monitor, "gate_response", None)
-                    gate: MetaGateDecision | None = None
-                    if callable(gate_method):
-                        maybe_gate = gate_method(
-                            user_text=user_input,
-                            candidate_response=final_text,
-                            social_policy=prep.social_policy,
-                            last_error=self._last_tool_error,
-                        )
-                        if isinstance(maybe_gate, MetaGateDecision):
-                            gate = maybe_gate
-                    if gate is not None and gate.needs_repair and gate.repaired_response:
-                        final_text = gate.repaired_response
+                await self._hook.commit_after_end_turn(
+                    prep=prep,
+                    user_input=user_input,
+                    final_text=final_text,
+                    is_desire_turn=prep.is_desire_turn,
+                    desires=desires,
+                )
 
-                    continuation_status = "DONE"
-                    status_match = re.search(
-                        r"(?:^|\n)(DONE|CONTINUE:[^\n]+|DEFER:[^\n]+)\s*$", final_text
-                    )
-                    if status_match:
-                        continuation_status = status_match.group(1)
-                        final_text = final_text[: status_match.start(1)].rstrip() or "(no response)"
-                    self._heartbeat.apply_status(continuation_status)
+                return final_text
 
-                    # Coherence gate: ask utility backend whether the response contains
-                    # a logical error. Only fires once to avoid infinite loops.
-                    _coherence_enabled = os.environ.get("FAMILIAR_COHERENCE_CHECK", "").strip() in (
-                        "1",
-                        "true",
-                        "yes",
-                    )
-                    if _coherence_enabled and not getattr(self, "_coherence_retried", False):
-                        violation = await self._check_response_coherence(final_text)
-                        if violation:
-                            self._coherence_retried = True
-                            self.messages.append(
-                                self.backend.make_user_message(
-                                    f"[SELF-CHECK] Your previous response has a problem: "
-                                    f"{violation}. Please correct it and respond again."
-                                )
-                            )
-                            prep.say_used = False
-                            continue
-
-                    self._coherence_retried = False
-
-                    # Auto-say: if the model wrote text but never called say(), speak it aloud.
-                    _auto_say_enabled = getattr(self.config, "auto_say", False)
-                    if (
-                        _auto_say_enabled
-                        and self._tts
-                        and not prep.say_used
-                        and final_text
-                        and final_text != "(no response)"
-                    ):
-                        if on_action:
-                            on_action("say", {"text": final_text})
-                        await self._tts.call("say", {"text": final_text})
-
-                    await self._hook.commit_after_end_turn(
-                        prep=prep,
-                        user_input=user_input,
-                        final_text=final_text,
-                        is_desire_turn=prep.is_desire_turn,
-                        desires=desires,
-                    )
-
-                    return final_text
-
-                if result.stop_reason == "tool_use":
-                    collected: list[tuple[str, str | None]] = []
-                    for tc in result.tool_calls:
-                        if tc.name == "see":
-                            prep.camera_used = True
-                            if prep.pending_view_action_name is not None:
-                                prep.observation_action_name = prep.pending_view_action_name
-                                prep.observation_action_input = dict(
-                                    prep.pending_view_action_input or {}
-                                )
-                            else:
-                                prep.observation_action_name = "see"
-                                prep.observation_action_input = dict(tc.input)
-                            prep.pending_view_action_name = None
-                            prep.pending_view_action_input = None
-                        elif tc.name in {"look", "walk"}:
-                            prep.pending_view_action_name = tc.name
-                            prep.pending_view_action_input = dict(tc.input)
-                        if tc.name == "say":
-                            prep.say_used = True
-                            prep.non_say_streak = 0
-                        else:
-                            prep.non_say_streak += 1
-                        logger.info("Tool call: %s(%s)", tc.name, tc.input)
-                        if on_action:
-                            on_action(tc.name, tc.input)
-
-                        timeout_s = self._tool_timeout_seconds(tc.name)
-                        try:
-                            text, image = await asyncio.wait_for(
-                                self._execute_tool(tc.name, tc.input),
-                                timeout=timeout_s,
-                            )
-                            self._last_tool_error = None
-                            self._tool_failure_streak = 0
-                        except asyncio.TimeoutError:
-                            logger.warning("Tool %s timed out after %.1fs", tc.name, timeout_s)
-                            text, image = (
-                                f"Tool timeout: {tc.name} exceeded {timeout_s:.1f}s.",
-                                None,
-                            )
-                            self._last_tool_error = text
-                            self._tool_failure_streak += 1
-                        except Exception as e:
-                            logger.warning("Tool %s failed: %s", tc.name, e)
-                            text, image = f"Tool error: {e}", None
-                            self._last_tool_error = str(e)
-                            self._tool_failure_streak += 1
-
-                        if (
-                            prep.tape_backend
-                            and prep.plan_ctx
-                            and await check_plan_blocked(
-                                prep.tape_backend, prep.plan_ctx, tc.name, tc.input, text
-                            )
-                        ):
-                            logger.info("TAPE: plan blocked after %s, replanning...", tc.name)
-                            replan = await generate_replan(
-                                prep.tape_backend, prep.plan_ctx, tc.name, tc.input, text
-                            )
-                            if replan:
-                                text = f"{text}\n\n[ADAPTIVE REPLAN] {replan}"
-                                logger.info("TAPE replan: %s", replan[:80])
-
-                        logger.info("Tool result: %s", text[:100])
-                        if image and on_image is not None:
-                            on_image(image)
-                        if on_tool_result is not None:
-                            on_tool_result(tc.name, tc.input, text)
-                        collected.append((text, image))
-
-                    self.messages.append(self.backend.make_assistant_message(result, raw_content))
-                    tool_msgs = self.backend.make_tool_results(result.tool_calls, collected)
-                    self.messages.append(tool_msgs)
-
-                    if interrupt_queue is not None and not interrupt_queue.empty():
-                        interrupts = self._drain_interrupt_queue(interrupt_queue)
-                        if interrupts:
-                            head = " / ".join(interrupts[:3])
-                            if len(interrupts) > 3:
-                                head += f" (+{len(interrupts) - 3} more)"
-                            logger.debug("Consumed %d queued interrupts", len(interrupts))
-                            self.messages.append(
-                                self.backend.make_user_message(
-                                    f"[User interrupted x{len(interrupts)}]: {head}. "
-                                    "Respond to this directly with say() now."
-                                )
-                            )
-                            prep.non_say_streak = 0
-
-                    elif prep.non_say_streak >= 2 and not prep.say_used:
-                        self.messages.append(
-                            self.backend.make_user_message(
-                                "REMINDER: Writing text is silent. You MUST call say() to be heard. "
-                                "Call say() NOW. Keep it to 1-2 sentences."
-                            )
-                        )
-                        prep.non_say_streak = 0
-
-                    elif prep.say_used and prep.non_say_streak >= 2:
-                        self.messages.append(
-                            self.backend.make_user_message(
-                                "You already spoke. Stop exploring and end your turn now."
-                            )
-                        )
-                        prep.non_say_streak = 0
-
-                    continue
-
-                logger.warning("Unexpected stop_reason: %s", result.stop_reason)
-                break
-
+            # max_iterations (or an unexpected stop reason): force a final,
+            # tool-free response so the turn always ends with words.
             logger.warning(
                 "Reached max iterations (%d). Forcing final response.",
                 prep.turn_max_iterations,

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -7,19 +7,21 @@ snapshot building) and the post-end-turn commit (mental-state bus append,
 post-response pipeline kick) so the ReAct loop body in ``agent.py`` reads
 as a thin model/tool dispatcher around the prepared state.
 
-``EmbodiedAgentHook`` subclasses :class:`RuntimeHookBase`, so it satisfies
-the ``RuntimeHook`` interface (inheriting safe no-op lifecycle methods) while
-still holding a back-reference to the ``EmbodiedAgent`` instance for its
-``prepare_turn`` / ``commit_after_end_turn`` flow.  The substrate now honours
-``mid_turn_inject`` / ``RetryDecision`` / ``InterruptSource`` (wired in
-``ReActLoop``); routing ``EmbodiedAgent.run`` through ``AgentRuntime.run_turn``
-end-to-end remains a later migration.
+``EmbodiedAgentHook`` subclasses :class:`RuntimeHookBase` and is a live
+``RuntimeHook``: ``EmbodiedAgent.run()`` now drives the substrate
+``ReActLoop`` directly, with the four historical inline behaviours carried by
+lifecycle methods here — coherence retry (``after_model_result`` →
+``RetryDecision``), TAPE replan (``after_tool_result`` result replacement),
+say() reminders (``mid_turn_user_messages``), and the embodied interrupt line
+(``format_interrupt_message``). ``prepare_turn`` / ``commit_after_end_turn``
+remain the pre-loop and post-end_turn bookends called by the wrapper.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -79,6 +81,9 @@ def _should_auto_tom(
 
 if TYPE_CHECKING:
     from familiar_agent.agent import EmbodiedAgent
+    from familiar_runtime.models import ModelTurnResult, ToolCall
+    from familiar_runtime.runtime import RetryDecision, TurnContext
+    from familiar_runtime.tools.base import ToolExecutionResult
 
 
 logger = logging.getLogger(__name__)
@@ -152,11 +157,10 @@ class EmbodiedAgentHook(RuntimeHookBase):
     a constructor parameter.  The agent itself stays the single owner of
     long-lived state; the hook only encapsulates the per-turn flow.
 
-    Subclassing :class:`RuntimeHookBase` makes it a structural ``RuntimeHook``
-    (inheriting no-op ``before_turn`` / ``build_context`` / ``mid_turn_inject`` /
-    ``after_model_result`` / ``after_tool_result`` / ``after_turn`` defaults);
-    the embodied flow currently drives the loop via ``prepare_turn`` /
-    ``commit_after_end_turn`` rather than those lifecycle hooks.
+    Subclassing :class:`RuntimeHookBase` makes it a structural ``RuntimeHook``;
+    ``after_model_result`` / ``after_tool_result`` / ``mid_turn_user_messages`` /
+    ``format_interrupt_message`` below carry the embodied loop behaviours, and
+    ``prepare_turn`` / ``commit_after_end_turn`` bookend the substrate loop.
     """
 
     def __init__(self, agent: "EmbodiedAgent") -> None:
@@ -630,4 +634,176 @@ class EmbodiedAgentHook(RuntimeHookBase):
                 desires=desires,
             ),
             name="post-response-pipeline",
+        )
+
+    # ── ReActLoop lifecycle (thin-wrap migration) ─────────────────
+    #
+    # These methods carry the four inline behaviours of the historical
+    # EmbodiedAgent.run() loop body. They all read the PreparedTurn stored
+    # in ``ctx.metadata["prep"]`` by the wrapper and no-op when it is absent
+    # (e.g. when the hook ever runs under a foreign runtime).
+
+    @staticmethod
+    def _prep_from(ctx: "TurnContext") -> PreparedTurn | None:
+        prep = ctx.metadata.get("prep")
+        return prep if isinstance(prep, PreparedTurn) else None
+
+    async def after_model_result(
+        self,
+        ctx: "TurnContext",
+        result: "ModelTurnResult",
+    ) -> "ModelTurnResult | RetryDecision | None":
+        """Per-iteration accounting, metacognition, and the coherence gate."""
+        prep = self._prep_from(ctx)
+        if prep is None:
+            return None
+        agent = self._agent
+
+        agent._last_context_tokens = result.input_tokens
+        agent._session_input_tokens += result.input_tokens
+        agent._session_output_tokens += result.output_tokens
+
+        # HOT layer: record this step metacognitively
+        focus = agent._attention_schema.current_focus()
+        if focus is not None:
+            action = result.stop_reason
+            if result.stop_reason == "tool_use" and result.tool_calls:
+                action = result.tool_calls[0].name
+            confidence = min(1.0, result.output_tokens / max(1, agent.config.max_tokens))
+            agent._meta_monitor.record_step(focus, action=action, confidence=confidence)
+
+        if result.stop_reason != "end_turn":
+            return None
+
+        # Coherence gate: ask the utility backend whether the response contains
+        # a logical error. Only fires once per turn to avoid infinite loops.
+        coherence_enabled = os.environ.get("FAMILIAR_COHERENCE_CHECK", "").strip() in (
+            "1",
+            "true",
+            "yes",
+        )
+        if not coherence_enabled or getattr(agent, "_coherence_retried", False):
+            return None
+        violation = await agent._check_response_coherence(result.text or "")
+        if not violation:
+            return None
+        agent._coherence_retried = True
+        prep.say_used = False
+        from familiar_runtime.runtime import RetryDecision
+
+        return RetryDecision(
+            retry=True,
+            inject_user_message=(
+                f"[SELF-CHECK] Your previous response has a problem: "
+                f"{violation}. Please correct it and respond again."
+            ),
+        )
+
+    async def after_tool_result(
+        self,
+        ctx: "TurnContext",
+        call: "ToolCall",
+        result: "ToolExecutionResult",
+    ) -> "ToolExecutionResult | None":
+        """Observation tracking, say/failure streaks, and TAPE replan."""
+        prep = self._prep_from(ctx)
+        if prep is None:
+            return None
+        agent = self._agent
+
+        if call.name == "see":
+            prep.camera_used = True
+            if prep.pending_view_action_name is not None:
+                prep.observation_action_name = prep.pending_view_action_name
+                prep.observation_action_input = dict(prep.pending_view_action_input or {})
+            else:
+                prep.observation_action_name = "see"
+                prep.observation_action_input = dict(call.input)
+            prep.pending_view_action_name = None
+            prep.pending_view_action_input = None
+        elif call.name in {"look", "walk"}:
+            prep.pending_view_action_name = call.name
+            prep.pending_view_action_input = dict(call.input)
+        if call.name == "say":
+            prep.say_used = True
+            prep.non_say_streak = 0
+        else:
+            prep.non_say_streak += 1
+
+        if result.success:
+            agent._last_tool_error = None
+            agent._tool_failure_streak = 0
+        else:
+            # Preserve the historical shape: timeouts store the full message,
+            # exceptions store just the error string.
+            agent._last_tool_error = result.text if result.error == "timeout" else result.error
+            agent._tool_failure_streak += 1
+
+        if prep.tape_backend and prep.plan_ctx:
+            # Late import so test patches on familiar_agent.agent.* keep working.
+            from familiar_agent import agent as agent_module
+
+            if await agent_module.check_plan_blocked(
+                prep.tape_backend, prep.plan_ctx, call.name, call.input, result.text
+            ):
+                logger.info("TAPE: plan blocked after %s, replanning...", call.name)
+                replan = await agent_module.generate_replan(
+                    prep.tape_backend, prep.plan_ctx, call.name, call.input, result.text
+                )
+                if replan:
+                    logger.info("TAPE replan: %s", replan[:80])
+                    from familiar_runtime.tools.base import ToolExecutionResult as _ToolResult
+
+                    return _ToolResult(
+                        text=f"{result.text}\n\n[ADAPTIVE REPLAN] {replan}",
+                        image_b64=result.image_b64,
+                        success=result.success,
+                        error=result.error,
+                    )
+        return None
+
+    async def mid_turn_user_messages(
+        self,
+        ctx: "TurnContext",
+        iteration: int,
+    ) -> list[str]:
+        """say() reminders between iterations, mirroring the historical loop."""
+        prep = self._prep_from(ctx)
+        if prep is None:
+            return []
+        if iteration == 0:
+            # Arm the interrupt source only after the first model call so an
+            # input queued before the turn does not get double-included.
+            source = ctx.metadata.get("interrupt_source")
+            arm = getattr(source, "arm", None)
+            if callable(arm):
+                arm()
+            return []
+        if prep.non_say_streak >= 2 and not prep.say_used:
+            prep.non_say_streak = 0
+            return [
+                "REMINDER: Writing text is silent. You MUST call say() to be heard. "
+                "Call say() NOW. Keep it to 1-2 sentences."
+            ]
+        if prep.say_used and prep.non_say_streak >= 2:
+            prep.non_say_streak = 0
+            return ["You already spoke. Stop exploring and end your turn now."]
+        return []
+
+    async def format_interrupt_message(
+        self,
+        ctx: "TurnContext",
+        interrupts: list[str],
+    ) -> str | None:
+        """Reproduce the embodied interrupt line and reset the say streak."""
+        prep = self._prep_from(ctx)
+        if prep is not None:
+            prep.non_say_streak = 0
+        head = " / ".join(interrupts[:3])
+        if len(interrupts) > 3:
+            head += f" (+{len(interrupts) - 3} more)"
+        logger.debug("Consumed %d queued interrupts", len(interrupts))
+        return (
+            f"[User interrupted x{len(interrupts)}]: {head}. "
+            "Respond to this directly with say() now."
         )

--- a/tests/test_agent_react_loop.py
+++ b/tests/test_agent_react_loop.py
@@ -1122,3 +1122,162 @@ async def test_pipeline_skips_thread_capture_on_desire_turn():
     )
 
     agent._capture_companion_thread.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Tests: thin-wrap migration — the four inline loop behaviours now ride the
+# substrate ReActLoop via EmbodiedAgentHook lifecycle methods.
+# ---------------------------------------------------------------------------
+
+
+def _user_texts(agent) -> list[str]:
+    return [
+        m["content"]
+        for m in agent.messages
+        if isinstance(m, dict) and m.get("role") == "user" and isinstance(m.get("content"), str)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_say_reminder_injected_after_two_silent_tools():
+    """Two non-say tool iterations without say() must inject the reminder."""
+    agent = _make_agent(with_camera=True)
+    tc1 = ToolCall(id="t1", name="see", input={})
+    tc2 = ToolCall(id="t2", name="look", input={"direction": "left"})
+    agent.backend.stream_turn = AsyncMock(
+        side_effect=[
+            (_turn("tool_use", tool_calls=[tc1]), None),
+            (_turn("tool_use", tool_calls=[tc2]), None),
+            (_turn("end_turn", text="見えたで"), "見えたで"),
+        ]
+    )
+
+    ps = _patch_heavy()
+    for p in ps:
+        p.start()
+    try:
+        result = await agent.run("外どうなってる？")
+    finally:
+        for p in ps:
+            p.stop()
+
+    assert result == "見えたで"
+    reminders = [t for t in _user_texts(agent) if t.startswith("REMINDER: Writing text is silent")]
+    assert reminders
+
+
+@pytest.mark.asyncio
+async def test_interrupt_queue_drained_with_embodied_format():
+    """Queued interrupts surface with the [User interrupted xN] say() directive."""
+    agent = _make_agent()
+    tc = ToolCall(id="t1", name="remember", input={"content": "x"})
+    agent.backend.stream_turn = AsyncMock(
+        side_effect=[
+            (_turn("tool_use", tool_calls=[tc]), None),
+            (_turn("end_turn", text="ん"), "ん"),
+        ]
+    )
+    queue = asyncio.Queue()
+    queue.put_nowait("なあ、聞いてる？")
+
+    ps = _patch_heavy()
+    for p in ps:
+        p.start()
+    try:
+        await agent.run("覚えといて", interrupt_queue=queue)
+    finally:
+        for p in ps:
+            p.stop()
+
+    interrupted = [t for t in _user_texts(agent) if t.startswith("[User interrupted x1]")]
+    assert interrupted
+    assert "なあ、聞いてる？" in interrupted[0]
+    assert "say() now" in interrupted[0]
+
+
+@pytest.mark.asyncio
+async def test_interrupt_not_drained_before_first_model_call():
+    """An input queued before the turn starts must not be folded into iteration 0."""
+    agent = _make_agent()
+    agent.backend.stream_turn = AsyncMock(return_value=(_turn("end_turn", text="ん"), "ん"))
+    queue = asyncio.Queue()
+    queue.put_nowait("これは次のターンの入力")
+
+    ps = _patch_heavy()
+    for p in ps:
+        p.start()
+    try:
+        await agent.run("おーい", interrupt_queue=queue)
+    finally:
+        for p in ps:
+            p.stop()
+
+    assert not [t for t in _user_texts(agent) if t.startswith("[User interrupted")]
+    assert not queue.empty()  # left for the next turn
+
+
+@pytest.mark.asyncio
+async def test_tape_replan_spliced_into_tool_result():
+    """A blocked plan splices [ADAPTIVE REPLAN] into the tool result text."""
+    agent = _make_agent()
+    tc = ToolCall(id="t1", name="remember", input={"content": "x"})
+    agent.backend.stream_turn = AsyncMock(
+        side_effect=[
+            (_turn("tool_use", tool_calls=[tc]), None),
+            (_turn("end_turn", text="ん"), "ん"),
+        ]
+    )
+
+    patches = dict(_HEAVY_PATCHES)
+    patches["familiar_agent.agent.check_plan_blocked"] = AsyncMock(return_value=True)
+    patches["familiar_agent.agent.generate_replan"] = AsyncMock(return_value="try the camera")
+    ps = [patch(t, n) for t, n in patches.items()]
+    for p in ps:
+        p.start()
+    try:
+        # prepare_turn computes plan/tape lazily; force the prep fields instead
+        real_prepare = agent._hook.prepare_turn
+
+        async def _prepare_with_plan(**kwargs):
+            prep = await real_prepare(**kwargs)
+            prep.tape_backend = object()
+            prep.plan_ctx = "PLAN: inspect the room"
+            return prep
+
+        agent._hook.prepare_turn = _prepare_with_plan
+        await agent.run("部屋見といて")
+    finally:
+        for p in ps:
+            p.stop()
+
+    collected = agent.backend.make_tool_results.call_args.args[1]
+    assert "[ADAPTIVE REPLAN] try the camera" in collected[0][0]
+
+
+@pytest.mark.asyncio
+async def test_coherence_retry_reruns_loop_once(monkeypatch):
+    """A coherence violation rejects the reply, injects SELF-CHECK, and retries."""
+    agent = _make_agent()
+    agent.backend.stream_turn = AsyncMock(
+        side_effect=[
+            (_turn("end_turn", text="矛盾した返事"), "矛盾した返事"),
+            (_turn("end_turn", text="直した返事"), "直した返事"),
+        ]
+    )
+    monkeypatch.setenv("FAMILIAR_COHERENCE_CHECK", "1")
+    agent._check_response_coherence = AsyncMock(side_effect=["contradicts earlier turn", None])
+
+    ps = _patch_heavy()
+    for p in ps:
+        p.start()
+    try:
+        result = await agent.run("どう思う？")
+    finally:
+        for p in ps:
+            p.stop()
+
+    assert result == "直した返事"
+    self_checks = [t for t in _user_texts(agent) if t.startswith("[SELF-CHECK]")]
+    assert self_checks
+    assert "contradicts earlier turn" in self_checks[0]
+    assert agent._coherence_retried is False  # reset after a clean finalisation


### PR DESCRIPTION
## Summary

PR (b) of the thin-wrap migration — the endgame of the runtime reorg. `EmbodiedAgent.run()` no longer runs its own model/tool loop: the body is now the provider-neutral `ReActLoop`, with the four historical inline behaviours carried by `EmbodiedAgentHook` lifecycle methods (receptors landed in #180):

| Behaviour | New home |
|---|---|
| Coherence retry | `after_model_result` → `RetryDecision` |
| TAPE adaptive replan | `after_tool_result` result replacement (late module import keeps `familiar_agent.agent.*` test patches working) |
| say() reminders | `mid_turn_user_messages` |
| Embodied interrupt line | `format_interrupt_message` |

Per-iteration token accounting and metacognitive recording also moved to `after_model_result`. Two adapters bridge the seams:

- **`_TurnToolAdapter`** — per-turn (possibly brief-turn-restricted) tool defs + routing through `_execute_tool`, preserving MCP late-start and registry-rebuild behaviour; timeouts resolve through the `_tool_timeout_seconds` seam for every tool on the turn's surface
- **`_InterruptQueueSource`** — armed only after the first model call, so input queued before the turn is not double-included

Finalisation (meta-gate repair, continuation status strip, auto-say, `commit_after_end_turn`) and the forced final response on max-iterations remain in `run()`. **The public `run()` signature and the cache-preserving `(stable, variable)` system-prompt tuple are unchanged.**

### Documented behaviour divergences (all rare or env-gated)

1. The coherence check now sees the raw model text (not post-gate, post-strip) and runs before the assistant message lands in history
2. A queued interrupt now also drains at the start of a post-coherence-retry iteration
3. A say() reminder earned on the very last iteration is dropped before the tool-free forced final

### Review

Adversarial line-by-line review against the old loop: **APPROVE, no CRITICAL/HIGH findings.** Verified equivalent: message-history shape, prep-mutation timing (incl. look→see pending-action chaining within one batch), interrupt/reminder mutual exclusivity, iteration budget under retries, token accounting, `_last_tool_error` shape for timeout vs exception, error-result semantics through `LegacyToolProvider`.

## Test plan

- [x] **All 1186 pre-existing tests pass unmodified** — zero patch-path fixes needed, including all 34 `test_agent_react_loop.py` ReAct-loop tests
- [x] Five new tests pin the migrated behaviours through the real `agent.run()` path: say reminder after two silent tool iterations; interrupt drained with the `[User interrupted xN]` say() directive; pre-turn input NOT drained at iteration 0; TAPE `[ADAPTIVE REPLAN]` splice; coherence retry rerunning the loop once with `[SELF-CHECK]`
- [x] Full gate on the rebased tree: ruff check, ruff format, mypy (120 files), pytest **1191 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)