### PR TITLE
feat(mind): LLM fallback for speech-act classification (ADR 0004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- LLM fallback for speech-act classification (ADR 0004, accepted): when the regex layer has no signal (pattern fallthrough) or branch order would decide an inversion-risk conflict ({delight, distress, repair, boundary} co-match), one bounded utility call picks the act from the fixed vocabulary; the deterministic layer stays authoritative everywhere else and on any fallback failure
 - Runtime substrate extensions toward hosting the embodied turn loop: `after_tool_result` hooks can replace tool results (adaptive replan), new `mid_turn_user_messages` and `format_interrupt_message` hooks, `run_turn` accepts the cache-preserving `(stable, variable)` system-prompt tuple, and `on_action` / `on_image` / `on_tool_result` observer callbacks thread through the ReAct loop
 - Secretary layer: commitments (reminders, appointments, promises, follow-ups) with due times, priorities, and snooze in a dedicated store; add/list/complete/snooze tools; due and upcoming items surface in every turn and a `[Today's agenda]` block opens the day
 - Proactive reminders: due commitments fire self-initiated turns from REPL/TUI/GUI idle loops, independent of `auto_desire` (`FAMILIAR_PROACTIVE_REMINDERS`, default on), quiet-hours aware (urgent-only at night), with escalating backoff capped at 3 reminders

--- a/docs/adr/0004-llm-speech-act-fallback.md
+++ b/docs/adr/0004-llm-speech-act-fallback.md
@@ -40,12 +40,17 @@ fallback** via the existing utility backend for exactly two situations:
 1. **Fallthrough** — when no pattern matches and the turn lands in the
    `attuned`/`bid_for_connection` fallback *and* the utterance is substantive
    (length above a threshold, not a desire turn), ask the utility backend to
-   pick the speech act from the fixed 17-act vocabulary (single completion,
-   ~50 output tokens, strict JSON, 2s timeout, fallback to `attuned` on any
-   failure).
+   pick the speech act from the fixed 15-act vocabulary
+   (`SPEECH_ACT_VOCABULARY`; `silence_or_low_presence` and the dynamic
+   trailing default are excluded). Single completion, one bare label,
+   `max_tokens=12`, 2s timeout; any failure or out-of-vocabulary answer
+   leaves the regex verdict untouched.
 2. **Conflict** — when two or more of {delight, venting/grief, repair,
    boundary} pattern groups match the same utterance (the mixed-sentiment /
    inversion-risk zone), let the LLM arbitrate instead of branch order.
+   The hint arbitrates *order only*: a hurt previous response and the
+   deterministic delight guards (negation vetoes, valence gate) still
+   outrank it — うれしくない must never celebrate, whatever the LLM says.
 
 The deterministic layer remains authoritative for everything else, so
 existing tests and latency characteristics are unchanged for the common case.

--- a/docs/adr/0004-llm-speech-act-fallback.md
+++ b/docs/adr/0004-llm-speech-act-fallback.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted (2026-06-11)
 
 ## Context
 
@@ -32,7 +32,7 @@ regular expressions cannot close:
 Each class was patched for its reproduced instances, but the tail is
 structural: these distinctions require parsing, not matching.
 
-## Decision (proposed)
+## Decision
 
 Keep the regex layer as the deterministic fast path, and add an **LLM
 fallback** via the existing utility backend for exactly two situations:
@@ -71,8 +71,12 @@ the vocabulary.
 
 ## Consequences
 
-- `SocialPolicyEngine.decide()` would gain an optional async variant or a
-  pre-computed `llm_act_hint` input (computed in `prepare_turn` alongside
-  auto-ToM) so the engine itself stays synchronous and testable.
-- The fallback prompt and act vocabulary become versioned artifacts pinned by
-  the existing regression suite.
+- `SocialPolicyEngine.decide()` gained a pre-computed `llm_act_hint` input
+  (computed in `prepare_turn`, like auto-ToM) so the engine itself stays
+  synchronous and testable. `assess_classification()` is the cheap provenance
+  probe that gates the call.
+- Per-act decision shapes moved into `_build_act_decision`, the single source
+  of truth shared by the pattern branches and the hint dispatch, so a hinted
+  act is indistinguishable from the same act matched by pattern.
+- The fallback prompt and act vocabulary (`SPEECH_ACT_VOCABULARY`) are
+  versioned artifacts pinned by the existing regression suite.

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -41,8 +41,10 @@ from familiar_neighbor.mind.deferral import DEFERRAL_PREFIX, detect_deferral
 from familiar_neighbor.mind.desires import DesireSystem
 from familiar_neighbor.mind.mental_state import MentalStateBus, MentalStateSnapshot
 from familiar_neighbor.mind.social_policy import (
+    SPEECH_ACT_VOCABULARY,
     SocialPolicyDecision,
     SocialPolicyEngine,
+    assess_classification,
     relationship_learning_inputs,
 )
 from familiar_runtime.runtime import RuntimeHookBase
@@ -84,6 +86,40 @@ if TYPE_CHECKING:
     from familiar_runtime.models import ModelTurnResult, ToolCall
     from familiar_runtime.runtime import RetryDecision, TurnContext
     from familiar_runtime.tools.base import ToolExecutionResult
+
+
+# ADR 0004: only substantive turns are worth a fallback classification call.
+_ACT_FALLBACK_MIN_CHARS = 12
+_ACT_FALLBACK_TIMEOUT_S = 2.0
+
+
+async def _classify_speech_act_llm(
+    agent: Any,
+    user_input: str,
+    *,
+    timeout_s: float = _ACT_FALLBACK_TIMEOUT_S,
+) -> str | None:
+    """One bounded utility call: pick a speech act from the fixed vocabulary.
+
+    Degrades to None on timeout, backend failure, or any answer outside the
+    vocabulary — the regex verdict then stands unchanged.
+    """
+    vocabulary = ", ".join(sorted(SPEECH_ACT_VOCABULARY))
+    try:
+        raw = await asyncio.wait_for(
+            agent._utility_backend.complete(
+                "Classify the speaker's primary speech act. Reply with exactly "
+                f"one label from this list and nothing else: {vocabulary}.\n\n"
+                f"Utterance: {user_input[:300]}",
+                max_tokens=12,
+            ),
+            timeout=timeout_s,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Speech-act fallback classification failed: %s", exc)
+        return None
+    act = raw.strip().strip('"').strip("'").lower()
+    return act if act in SPEECH_ACT_VOCABULARY else None
 
 
 logger = logging.getLogger(__name__)
@@ -402,6 +438,19 @@ class EmbodiedAgentHook(RuntimeHookBase):
             )
         )
         learned_styles, learned_failures = relationship_learning_inputs(agent._relationship)
+        # ADR 0004: spend one bounded utility call only where the regex layer
+        # is least trustworthy (pattern fallthrough / conflict zone) on a
+        # substantive companion turn — and only when a dedicated utility
+        # backend exists, so the common case stays zero-latency.
+        llm_act_hint: str | None = None
+        if (
+            not is_desire_turn
+            and not candidate_brief_turn
+            and len(user_input.strip()) >= _ACT_FALLBACK_MIN_CHARS
+            and agent._utility_backend is not agent.backend
+            and assess_classification(user_input).wants_llm
+        ):
+            llm_act_hint = await _classify_speech_act_llm(agent, user_input)
         social_policy = agent._social_policy.decide(
             user_text=user_input,
             affect=affect,
@@ -411,6 +460,7 @@ class EmbodiedAgentHook(RuntimeHookBase):
             previous_response_hurt=previous_response_hurt,
             support_styles=learned_styles,
             failed_patterns=learned_failures,
+            llm_act_hint=llm_act_hint,
         )
         agent._provisional_relationship_update(user_text=user_input, social_policy=social_policy)
 

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -88,6 +88,9 @@ if TYPE_CHECKING:
     from familiar_runtime.tools.base import ToolExecutionResult
 
 
+logger = logging.getLogger(__name__)
+
+
 # ADR 0004: only substantive turns are worth a fallback classification call.
 _ACT_FALLBACK_MIN_CHARS = 12
 _ACT_FALLBACK_TIMEOUT_S = 2.0
@@ -120,9 +123,6 @@ async def _classify_speech_act_llm(
         return None
     act = raw.strip().strip('"').strip("'").lower()
     return act if act in SPEECH_ACT_VOCABULARY else None
-
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)

--- a/src/familiar_neighbor/mind/social_policy.py
+++ b/src/familiar_neighbor/mind/social_policy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import re
+from typing import cast
 
 from .interoception import InteroceptivePressure
 from .mental_state import AffectiveState
@@ -341,6 +342,294 @@ class SocialPolicyDecision:
     acknowledge_capacity: bool = False
 
 
+# ── ADR 0004: LLM fallback for speech-act classification ──
+#
+# The regex layer above is the deterministic fast path. An optional
+# ``llm_act_hint`` (computed by the caller via the utility backend) applies in
+# exactly two zones: pattern fallthrough (nothing matched, the turn would land
+# in the trailing attuned default) and the {delight, distress, repair,
+# boundary} conflict zone where branch order — not meaning — used to pick the
+# winner. Everywhere else the hint is ignored, so historical decisions stay
+# byte-stable.
+
+SPEECH_ACT_VOCABULARY: frozenset[str] = frozenset(
+    {
+        "repair_attempt",
+        "boundary_assertion",
+        "clarification",
+        "greeting",
+        "acknowledgement",
+        "delight_share",
+        "grief_signal",
+        "fatigue_signal",
+        "venting",
+        "request_for_action",
+        "request_for_advice",
+        "meta_conversation",
+        "playful_probe",
+        "bid_for_connection",
+        "conflict_signal",
+    }
+)
+
+# Acts the LLM may pick when arbitrating the inversion-risk conflict zone.
+_CONFLICT_HINT_ACTS = frozenset(
+    {"delight_share", "venting", "grief_signal", "repair_attempt", "boundary_assertion"}
+)
+
+
+@dataclass(slots=True)
+class SpeechActAssessment:
+    """Cheap provenance probe: does this utterance warrant the LLM fallback?"""
+
+    is_pattern_fallthrough: bool
+    conflict_groups: tuple[str, ...]
+
+    @property
+    def wants_llm(self) -> bool:
+        return self.is_pattern_fallthrough or len(self.conflict_groups) >= 2
+
+
+def assess_classification(user_text: str) -> SpeechActAssessment:
+    """Detect the two zones where the regex verdict is least trustworthy."""
+    text = user_text.strip()
+    if not text or _matches(text, _SILENCE_PATTERNS):
+        return SpeechActAssessment(is_pattern_fallthrough=False, conflict_groups=())
+    conflicts: list[str] = []
+    if _matches(text, _DELIGHT_PATTERNS):
+        conflicts.append("delight")
+    if _matches(text, _VENTING_PATTERNS) or _matches(text, _GRIEF_PATTERNS):
+        conflicts.append("distress")
+    if _matches(text, _REPAIR_PATTERNS):
+        conflicts.append("repair")
+    if _matches(text, _BOUNDARY_PATTERNS):
+        conflicts.append("boundary")
+    lexical_groups = (
+        _REPAIR_PATTERNS,
+        _BOUNDARY_PATTERNS,
+        _CORRECTION_PATTERNS,
+        _GREETING_PATTERNS,
+        _ACK_PATTERNS,
+        _DELIGHT_PATTERNS,
+        _GRIEF_PATTERNS,
+        _FATIGUE_PATTERNS,
+        _VENTING_PATTERNS,
+        _ACTION_PATTERNS,
+        _ADVICE_PATTERNS,
+        _META_PATTERNS,
+        _PLAYFUL_PATTERNS,
+    )
+    fallthrough = not any(_matches(text, group) for group in lexical_groups)
+    return SpeechActAssessment(
+        is_pattern_fallthrough=fallthrough,
+        conflict_groups=tuple(conflicts) if len(conflicts) >= 2 else (),
+    )
+
+
+def _default_initiative(intimacy: float, interoception: InteroceptivePressure) -> float:
+    initiative = 0.4 + intimacy * 0.2
+    if interoception.quiet_mode:
+        initiative *= 0.7
+    return initiative
+
+
+def _build_act_decision(
+    act: str,
+    *,
+    affect: AffectiveState,
+    trust: float,
+    intimacy: float,
+    interoception: InteroceptivePressure,
+) -> SocialPolicyDecision | None:
+    """Single source of truth for per-act decision shapes.
+
+    Used by the pattern branches in ``_base_decision`` and by the
+    ``llm_act_hint`` dispatch, so a hinted act is indistinguishable from the
+    same act matched by pattern.
+    """
+    if act == "repair_attempt":
+        return SocialPolicyDecision(
+            primary_act="repair_attempt",
+            response_mode="repair",
+            should_use_tom=True,
+            should_recall_relational_memory=True,
+            softness=0.92,
+            directness=0.55,
+            initiative=0.45,
+            avoid_problem_solving=True,
+            mention_memory=False,
+        )
+    if act == "boundary_assertion":
+        return SocialPolicyDecision(
+            primary_act="boundary_assertion",
+            response_mode="boundary",
+            should_use_tom=True,
+            should_recall_relational_memory=True,
+            softness=0.82,
+            directness=0.88,
+            initiative=0.2,
+            avoid_problem_solving=True,
+            mention_memory=False,
+        )
+    if act == "clarification":
+        return SocialPolicyDecision(
+            primary_act="clarification",
+            response_mode="clarify",
+            should_use_tom=False,
+            should_recall_relational_memory=False,
+            softness=0.86,
+            directness=0.82,
+            initiative=0.18,
+            avoid_problem_solving=True,
+            mention_memory=False,
+        )
+    if act == "greeting":
+        return SocialPolicyDecision(
+            primary_act="greeting",
+            response_mode="brief_warmth",
+            should_use_tom=False,
+            should_recall_relational_memory=False,
+            softness=0.86,
+            directness=0.36,
+            initiative=0.18,
+            avoid_problem_solving=True,
+            mention_memory=False,
+        )
+    if act == "acknowledgement":
+        return SocialPolicyDecision(
+            primary_act="acknowledgement",
+            response_mode="brief_attuned",
+            should_use_tom=False,
+            should_recall_relational_memory=False,
+            softness=0.8,
+            directness=0.44,
+            initiative=0.2,
+            avoid_problem_solving=True,
+            mention_memory=False,
+        )
+    if act == "delight_share":
+        return SocialPolicyDecision(
+            primary_act="delight_share",
+            response_mode="celebrate",
+            should_use_tom=False,
+            should_recall_relational_memory=False,
+            softness=0.8,
+            directness=0.45,
+            initiative=0.55,
+            avoid_problem_solving=True,
+            mention_memory=intimacy > 0.65,
+        )
+    if act == "grief_signal":
+        return SocialPolicyDecision(
+            primary_act="grief_signal",
+            response_mode="comfort",
+            should_use_tom=True,
+            should_recall_relational_memory=trust > 0.45,
+            softness=0.95,
+            directness=0.3,
+            initiative=0.3,
+            avoid_problem_solving=True,
+            mention_memory=False,
+        )
+    if act == "fatigue_signal":
+        return SocialPolicyDecision(
+            primary_act="fatigue_signal",
+            response_mode="validate",
+            should_use_tom=True,
+            should_recall_relational_memory=False,
+            softness=0.93,
+            directness=0.35,
+            initiative=0.25,
+            avoid_problem_solving=True,
+            mention_memory=False,
+        )
+    if act == "venting":
+        return SocialPolicyDecision(
+            primary_act="venting",
+            response_mode="validate",
+            should_use_tom=True,
+            should_recall_relational_memory=trust > 0.5,
+            softness=0.88,
+            directness=0.4,
+            initiative=0.35,
+            avoid_problem_solving=True,
+            mention_memory=False,
+        )
+    if act == "request_for_action":
+        return SocialPolicyDecision(
+            primary_act="request_for_action",
+            response_mode="act_or_explain",
+            should_use_tom=False,
+            should_recall_relational_memory=False,
+            softness=0.62,
+            directness=0.82,
+            initiative=0.7,
+            avoid_problem_solving=False,
+            mention_memory=False,
+        )
+    if act == "request_for_advice":
+        return SocialPolicyDecision(
+            primary_act="request_for_advice",
+            response_mode="advise",
+            should_use_tom=affect.threat > 0.4,
+            should_recall_relational_memory=trust > 0.55,
+            softness=0.72,
+            directness=0.72,
+            initiative=0.55,
+            avoid_problem_solving=False,
+            mention_memory=False,
+        )
+    if act == "meta_conversation":
+        return SocialPolicyDecision(
+            primary_act="meta_conversation",
+            response_mode="meta",
+            should_use_tom=True,
+            should_recall_relational_memory=False,
+            softness=0.7,
+            directness=0.7,
+            initiative=0.45,
+            avoid_problem_solving=False,
+            mention_memory=False,
+        )
+    if act == "playful_probe":
+        return SocialPolicyDecision(
+            primary_act="playful_probe",
+            response_mode="playful",
+            should_use_tom=False,
+            should_recall_relational_memory=intimacy > 0.7,
+            softness=0.7,
+            directness=0.45,
+            initiative=0.62,
+            avoid_problem_solving=True,
+            mention_memory=intimacy > 0.75,
+        )
+    if act == "bid_for_connection":
+        return SocialPolicyDecision(
+            primary_act="bid_for_connection",
+            response_mode="warm_presence",
+            should_use_tom=False,
+            should_recall_relational_memory=trust > 0.6,
+            softness=0.83,
+            directness=0.42,
+            initiative=min(1.0, _default_initiative(intimacy, interoception)),
+            avoid_problem_solving=affect.tenderness >= 0.45,
+            mention_memory=trust > 0.75,
+        )
+    if act == "conflict_signal":
+        return SocialPolicyDecision(
+            primary_act="conflict_signal",
+            response_mode="deescalate",
+            should_use_tom=True,
+            should_recall_relational_memory=True,
+            softness=0.86,
+            directness=0.46,
+            initiative=0.32,
+            avoid_problem_solving=True,
+            mention_memory=False,
+        )
+    return None
+
+
 class SocialPolicyEngine:
     """Deterministic interaction policy driven by affect + input."""
 
@@ -355,6 +644,7 @@ class SocialPolicyEngine:
         previous_response_hurt: bool = False,
         support_styles: list[str] | None = None,
         failed_patterns: list[str] | None = None,
+        llm_act_hint: str | None = None,
     ) -> SocialPolicyDecision:
         decision = self._base_decision(
             user_text=user_text,
@@ -363,6 +653,7 @@ class SocialPolicyEngine:
             intimacy=intimacy,
             interoception=interoception,
             previous_response_hurt=previous_response_hurt,
+            llm_act_hint=llm_act_hint,
         )
         decision = _apply_relationship_learning(
             decision,
@@ -380,74 +671,47 @@ class SocialPolicyEngine:
         intimacy: float,
         interoception: InteroceptivePressure,
         previous_response_hurt: bool = False,
+        llm_act_hint: str | None = None,
     ) -> SocialPolicyDecision:
         text = user_text.strip()
         low_presence = (not text) or _matches(text, _SILENCE_PATTERNS)
 
-        if previous_response_hurt or _matches(text, _REPAIR_PATTERNS):
-            return SocialPolicyDecision(
-                primary_act="repair_attempt",
-                response_mode="repair",
-                should_use_tom=True,
-                should_recall_relational_memory=True,
-                softness=0.92,
-                directness=0.55,
-                initiative=0.45,
-                avoid_problem_solving=True,
-                mention_memory=False,
+        def _act(name: str) -> SocialPolicyDecision:
+            decision = _build_act_decision(
+                name,
+                affect=affect,
+                trust=trust,
+                intimacy=intimacy,
+                interoception=interoception,
             )
+            assert decision is not None  # acts below are always in the table
+            return decision
+
+        # ADR 0004 conflict arbitration: when the inversion-risk groups
+        # co-match, branch order used to pick the winner; a valid hint from
+        # the LLM arbitrates instead. Relationship state (a hurt previous
+        # response) still outranks the hint.
+        if (
+            llm_act_hint in _CONFLICT_HINT_ACTS
+            and not previous_response_hurt
+            and len(assess_classification(text).conflict_groups) >= 2
+        ):
+            return _act(cast(str, llm_act_hint))
+
+        if previous_response_hurt or _matches(text, _REPAIR_PATTERNS):
+            return _act("repair_attempt")
 
         if _matches(text, _BOUNDARY_PATTERNS):
-            return SocialPolicyDecision(
-                primary_act="boundary_assertion",
-                response_mode="boundary",
-                should_use_tom=True,
-                should_recall_relational_memory=True,
-                softness=0.82,
-                directness=0.88,
-                initiative=0.2,
-                avoid_problem_solving=True,
-                mention_memory=False,
-            )
+            return _act("boundary_assertion")
 
         if _matches(text, _CORRECTION_PATTERNS):
-            return SocialPolicyDecision(
-                primary_act="clarification",
-                response_mode="clarify",
-                should_use_tom=False,
-                should_recall_relational_memory=False,
-                softness=0.86,
-                directness=0.82,
-                initiative=0.18,
-                avoid_problem_solving=True,
-                mention_memory=False,
-            )
+            return _act("clarification")
 
         if _matches(text, _GREETING_PATTERNS):
-            return SocialPolicyDecision(
-                primary_act="greeting",
-                response_mode="brief_warmth",
-                should_use_tom=False,
-                should_recall_relational_memory=False,
-                softness=0.86,
-                directness=0.36,
-                initiative=0.18,
-                avoid_problem_solving=True,
-                mention_memory=False,
-            )
+            return _act("greeting")
 
         if _matches(text, _ACK_PATTERNS):
-            return SocialPolicyDecision(
-                primary_act="acknowledgement",
-                response_mode="brief_attuned",
-                should_use_tom=False,
-                should_recall_relational_memory=False,
-                softness=0.8,
-                directness=0.44,
-                initiative=0.2,
-                avoid_problem_solving=True,
-                mention_memory=False,
-            )
+            return _act("acknowledgement")
 
         # Delight must lose to explicit distress in the same utterance
         # (「最悪や、最高の誕生日になるはずやったのに」 is a lament, not a share)
@@ -462,108 +726,28 @@ class SocialPolicyEngine:
             and not distress_overrides_delight
             and affect.valence >= -0.1
         ):
-            return SocialPolicyDecision(
-                primary_act="delight_share",
-                response_mode="celebrate",
-                should_use_tom=False,
-                should_recall_relational_memory=False,
-                softness=0.8,
-                directness=0.45,
-                initiative=0.55,
-                avoid_problem_solving=True,
-                mention_memory=intimacy > 0.65,
-            )
+            return _act("delight_share")
 
         if _matches(text, _GRIEF_PATTERNS):
-            return SocialPolicyDecision(
-                primary_act="grief_signal",
-                response_mode="comfort",
-                should_use_tom=True,
-                should_recall_relational_memory=trust > 0.45,
-                softness=0.95,
-                directness=0.3,
-                initiative=0.3,
-                avoid_problem_solving=True,
-                mention_memory=False,
-            )
+            return _act("grief_signal")
 
         if _matches(text, _FATIGUE_PATTERNS):
-            return SocialPolicyDecision(
-                primary_act="fatigue_signal",
-                response_mode="validate",
-                should_use_tom=True,
-                should_recall_relational_memory=False,
-                softness=0.93,
-                directness=0.35,
-                initiative=0.25,
-                avoid_problem_solving=True,
-                mention_memory=False,
-            )
+            return _act("fatigue_signal")
 
         if _matches(text, _VENTING_PATTERNS):
-            return SocialPolicyDecision(
-                primary_act="venting",
-                response_mode="validate",
-                should_use_tom=True,
-                should_recall_relational_memory=trust > 0.5,
-                softness=0.88,
-                directness=0.4,
-                initiative=0.35,
-                avoid_problem_solving=True,
-                mention_memory=False,
-            )
+            return _act("venting")
 
         if _matches(text, _ACTION_PATTERNS):
-            return SocialPolicyDecision(
-                primary_act="request_for_action",
-                response_mode="act_or_explain",
-                should_use_tom=False,
-                should_recall_relational_memory=False,
-                softness=0.62,
-                directness=0.82,
-                initiative=0.7,
-                avoid_problem_solving=False,
-                mention_memory=False,
-            )
+            return _act("request_for_action")
 
         if _matches(text, _ADVICE_PATTERNS):
-            return SocialPolicyDecision(
-                primary_act="request_for_advice",
-                response_mode="advise",
-                should_use_tom=affect.threat > 0.4,
-                should_recall_relational_memory=trust > 0.55,
-                softness=0.72,
-                directness=0.72,
-                initiative=0.55,
-                avoid_problem_solving=False,
-                mention_memory=False,
-            )
+            return _act("request_for_advice")
 
         if _matches(text, _META_PATTERNS):
-            return SocialPolicyDecision(
-                primary_act="meta_conversation",
-                response_mode="meta",
-                should_use_tom=True,
-                should_recall_relational_memory=False,
-                softness=0.7,
-                directness=0.7,
-                initiative=0.45,
-                avoid_problem_solving=False,
-                mention_memory=False,
-            )
+            return _act("meta_conversation")
 
         if _matches(text, _PLAYFUL_PATTERNS):
-            return SocialPolicyDecision(
-                primary_act="playful_probe",
-                response_mode="playful",
-                should_use_tom=False,
-                should_recall_relational_memory=intimacy > 0.7,
-                softness=0.7,
-                directness=0.45,
-                initiative=0.62,
-                avoid_problem_solving=True,
-                mention_memory=intimacy > 0.75,
-            )
+            return _act("playful_probe")
 
         if low_presence:
             return SocialPolicyDecision(
@@ -578,34 +762,18 @@ class SocialPolicyEngine:
                 mention_memory=False,
             )
 
-        initiative = 0.4 + intimacy * 0.2
-        if interoception.quiet_mode:
-            initiative *= 0.7
+        # ADR 0004 fallthrough: nothing lexical matched, so the regex layer
+        # has no signal here — adopt a valid LLM hint over the affect-driven
+        # and trailing defaults.
+        if llm_act_hint is not None and llm_act_hint in SPEECH_ACT_VOCABULARY:
+            return _act(llm_act_hint)
+
+        initiative = _default_initiative(intimacy, interoception)
         if affect.attachment_pull > 0.65:
-            return SocialPolicyDecision(
-                primary_act="bid_for_connection",
-                response_mode="warm_presence",
-                should_use_tom=False,
-                should_recall_relational_memory=trust > 0.6,
-                softness=0.83,
-                directness=0.42,
-                initiative=min(1.0, initiative),
-                avoid_problem_solving=affect.tenderness >= 0.45,
-                mention_memory=trust > 0.75,
-            )
+            return _act("bid_for_connection")
 
         if affect.threat > 0.55 or affect.frustration > 0.55:
-            return SocialPolicyDecision(
-                primary_act="conflict_signal",
-                response_mode="deescalate",
-                should_use_tom=True,
-                should_recall_relational_memory=True,
-                softness=0.86,
-                directness=0.46,
-                initiative=0.32,
-                avoid_problem_solving=True,
-                mention_memory=False,
-            )
+            return _act("conflict_signal")
 
         return SocialPolicyDecision(
             primary_act="request_for_advice" if "?" in text else "bid_for_connection",

--- a/src/familiar_neighbor/mind/social_policy.py
+++ b/src/familiar_neighbor/mind/social_policy.py
@@ -690,13 +690,21 @@ class SocialPolicyEngine:
         # ADR 0004 conflict arbitration: when the inversion-risk groups
         # co-match, branch order used to pick the winner; a valid hint from
         # the LLM arbitrates instead. Relationship state (a hurt previous
-        # response) still outranks the hint.
+        # response) still outranks the hint, and so do the deterministic
+        # delight guards — the hint arbitrates *order*, never a negation
+        # veto or the valence gate (うれしくない must never celebrate).
         if (
             llm_act_hint in _CONFLICT_HINT_ACTS
             and not previous_response_hurt
             and len(assess_classification(text).conflict_groups) >= 2
         ):
-            return _act(cast(str, llm_act_hint))
+            delight_vetoed = llm_act_hint == "delight_share" and (
+                _NEGATED_POSITIVE_RE.search(text.lower()) is not None
+                or _DELIGHT_VETO_JA_RE.search(text) is not None
+                or affect.valence < -0.1
+            )
+            if not delight_vetoed:
+                return _act(cast(str, llm_act_hint))
 
         if previous_response_hurt or _matches(text, _REPAIR_PATTERNS):
             return _act("repair_attempt")

--- a/tests/test_llm_act_fallback.py
+++ b/tests/test_llm_act_fallback.py
@@ -152,6 +152,26 @@ def test_previous_response_hurt_beats_conflict_hint():
     assert hinted.primary_act == "repair_attempt"
 
 
+def test_delight_hint_cannot_override_negation_veto():
+    """The hint arbitrates branch order, never the deterministic guards —
+    a negated positive must not celebrate, whatever the LLM says."""
+    text = "うれしくない、最悪や。ほんま今日はついてへんわ"
+    hinted = _decide(text, hint="delight_share")
+    assert hinted.primary_act != "delight_share"
+
+
+def test_delight_hint_blocked_by_negative_valence():
+    text = "最悪や、最高の誕生日になるはずやったのに"
+    hinted = _decide(text, hint="delight_share", affect=_affect(valence=-0.6))
+    assert hinted.primary_act != "delight_share"
+
+
+def test_correction_is_neither_fallthrough_nor_conflict():
+    a = assess_classification("いや、そうじゃなくて")
+    assert not a.is_pattern_fallthrough
+    assert a.conflict_groups == ()
+
+
 def test_no_hint_is_byte_stable():
     """Default-None hint must leave historical decisions untouched."""
     for text in ("おはよう", "むかつくわ、ほんまに最悪な一日や", "明日どうしたらええと思う？"):

--- a/tests/test_llm_act_fallback.py
+++ b/tests/test_llm_act_fallback.py
@@ -1,0 +1,223 @@
+"""ADR 0004: LLM fallback for speech-act classification.
+
+The regex layer stays the deterministic fast path. An LLM hint applies in
+exactly two zones — pattern fallthrough and the {delight, distress, repair,
+boundary} conflict zone — and is ignored everywhere else, so existing
+decisions stay byte-stable when no hint is supplied.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from familiar_neighbor.embodied_hook import _classify_speech_act_llm
+from familiar_neighbor.mind.interoception import InteroceptivePressure
+from familiar_neighbor.mind.mental_state import AffectiveState
+from familiar_neighbor.mind.social_policy import (
+    SPEECH_ACT_VOCABULARY,
+    SocialPolicyEngine,
+    assess_classification,
+)
+
+
+def _affect(**kwargs) -> AffectiveState:
+    defaults = dict(
+        valence=0.0,
+        arousal=0.3,
+        dominance=0.0,
+        attachment_pull=0.3,
+        tenderness=0.3,
+        threat=0.1,
+        uncertainty=0.2,
+        frustration=0.1,
+        loneliness=0.2,
+        summary="",
+    )
+    defaults.update(kwargs)
+    return AffectiveState(**defaults)
+
+
+def _intero() -> InteroceptivePressure:
+    return InteroceptivePressure(
+        need_rest=0.2,
+        caution=0.3,
+        expressivity=0.4,
+        social_receptivity=0.6,
+        frustration_bias=0.2,
+        quiet_mode=False,
+    )
+
+
+def _decide(text: str, *, hint: str | None = None, **kwargs):
+    engine = SocialPolicyEngine()
+    params = dict(
+        user_text=text,
+        affect=_affect(),
+        trust=0.6,
+        intimacy=0.6,
+        interoception=_intero(),
+    )
+    params.update(kwargs)
+    return engine.decide(llm_act_hint=hint, **params)
+
+
+# ── assess_classification ──
+
+
+def test_pure_delight_is_not_a_conflict():
+    a = assess_classification("やったー！ついに完成したで！")
+    assert a.conflict_groups == ()
+    assert not a.is_pattern_fallthrough
+
+
+def test_mixed_delight_and_distress_is_a_conflict():
+    a = assess_classification("最悪や、最高の誕生日になるはずやったのに")
+    assert "delight" in a.conflict_groups
+    assert "distress" in a.conflict_groups
+    assert a.wants_llm
+
+
+def test_neutral_substantive_text_is_fallthrough():
+    a = assess_classification("今日は新しいカメラの設定をいじっててん")
+    assert a.is_pattern_fallthrough
+    assert a.wants_llm
+
+
+def test_greeting_is_neither():
+    a = assess_classification("おはよう")
+    assert not a.is_pattern_fallthrough
+    assert a.conflict_groups == ()
+    assert not a.wants_llm
+
+
+def test_empty_text_is_not_fallthrough():
+    a = assess_classification("   ")
+    assert not a.is_pattern_fallthrough
+    assert not a.wants_llm
+
+
+# ── decide() with llm_act_hint ──
+
+
+def test_fallthrough_hint_adopts_act():
+    text = "今日は新しいカメラの設定をいじっててん"
+    without = _decide(text)
+    assert without.primary_act == "bid_for_connection"  # trailing default
+    with_hint = _decide(text, hint="venting")
+    assert with_hint.primary_act == "venting"
+    assert with_hint.response_mode == "validate"
+
+
+def test_fallthrough_hint_matches_pattern_branch_shape():
+    """A hinted act must produce the same decision shape as the pattern branch."""
+    hinted = _decide("今日は新しいカメラの設定をいじっててん", hint="grief_signal")
+    patterned = _decide("じいちゃんが亡くなってん")
+    assert patterned.primary_act == "grief_signal"
+    assert hinted.response_mode == patterned.response_mode
+    assert hinted.softness == patterned.softness
+    assert hinted.should_use_tom == patterned.should_use_tom
+
+
+def test_invalid_hint_keeps_default():
+    text = "今日は新しいカメラの設定をいじっててん"
+    assert _decide(text, hint="not_a_real_act").primary_act == "bid_for_connection"
+
+
+def test_hint_ignored_when_unique_pattern_matched():
+    decision = _decide("おはよう", hint="venting")
+    assert decision.primary_act == "greeting"
+
+
+def test_conflict_hint_arbitrates():
+    text = "最悪や、最高の誕生日になるはずやったのに"
+    baseline = _decide(text)
+    assert baseline.primary_act in {"venting", "grief_signal"}  # distress wins today
+    hinted = _decide(text, hint="delight_share")
+    assert hinted.primary_act == "delight_share"
+
+
+def test_conflict_hint_outside_conflict_set_ignored():
+    text = "最悪や、最高の誕生日になるはずやったのに"
+    hinted = _decide(text, hint="playful_probe")
+    assert hinted.primary_act in {"venting", "grief_signal"}
+
+
+def test_previous_response_hurt_beats_conflict_hint():
+    text = "最悪や、最高の誕生日になるはずやったのに"
+    hinted = _decide(text, hint="delight_share", previous_response_hurt=True)
+    assert hinted.primary_act == "repair_attempt"
+
+
+def test_no_hint_is_byte_stable():
+    """Default-None hint must leave historical decisions untouched."""
+    for text in ("おはよう", "むかつくわ、ほんまに最悪な一日や", "明日どうしたらええと思う？"):
+        assert _decide(text) == _decide(text, hint=None)
+
+
+# ── _classify_speech_act_llm ──
+
+
+def _agent_with_utility(reply):
+    if isinstance(reply, Exception):
+        complete = AsyncMock(side_effect=reply)
+    else:
+        complete = AsyncMock(return_value=reply)
+    return SimpleNamespace(_utility_backend=SimpleNamespace(complete=complete))
+
+
+@pytest.mark.asyncio
+async def test_classify_returns_vocabulary_act():
+    agent = _agent_with_utility("venting")
+    assert await _classify_speech_act_llm(agent, "なんか色々あってな…") == "venting"
+
+
+@pytest.mark.asyncio
+async def test_classify_normalizes_quotes_and_case():
+    agent = _agent_with_utility('  "Grief_Signal" ')
+    assert await _classify_speech_act_llm(agent, "x") == "grief_signal"
+
+
+@pytest.mark.asyncio
+async def test_classify_rejects_out_of_vocabulary():
+    agent = _agent_with_utility("I think this is venting because...")
+    assert await _classify_speech_act_llm(agent, "x") is None
+
+
+@pytest.mark.asyncio
+async def test_classify_backend_failure_returns_none():
+    agent = _agent_with_utility(RuntimeError("down"))
+    assert await _classify_speech_act_llm(agent, "x") is None
+
+
+@pytest.mark.asyncio
+async def test_classify_timeout_returns_none():
+    async def _slow(*args, **kwargs):
+        await asyncio.sleep(5)
+        return "venting"
+
+    agent = SimpleNamespace(_utility_backend=SimpleNamespace(complete=_slow))
+    assert await _classify_speech_act_llm(agent, "x", timeout_s=0.01) is None
+
+
+def test_vocabulary_covers_all_engine_acts():
+    assert {
+        "repair_attempt",
+        "boundary_assertion",
+        "delight_share",
+        "grief_signal",
+        "venting",
+        "fatigue_signal",
+        "request_for_action",
+        "request_for_advice",
+        "meta_conversation",
+        "playful_probe",
+        "bid_for_connection",
+        "greeting",
+        "acknowledgement",
+        "clarification",
+        "conflict_signal",
+    } <= SPEECH_ACT_VOCABULARY


### PR DESCRIPTION
## Summary

Implements **ADR 0004** (now Accepted): the four-round classifier audit fixed 51 wrong-register misfires but converged on failure classes regexes cannot close (unbounded lexicons, reported speech, transitivity, concession, sarcasm). The regex layer stays the deterministic fast path; one bounded utility call applies in exactly two zones:

- **Pattern fallthrough** — nothing lexical matched and the turn would land in the trailing attuned default: a valid hint from the fixed 15-act `SPEECH_ACT_VOCABULARY` is adopted there.
- **Conflict arbitration** — two or more of {delight, distress, repair, boundary} co-match (the inversion-risk zone): the hint replaces *branch order* as the tiebreak. A hurt previous response and the deterministic delight guards (negation vetoes, valence gate) still outrank it — うれしくない must never celebrate, whatever the LLM says.

### Design

- `assess_classification()` — cheap provenance probe gating the call; `decide()` gains `llm_act_hint` and stays synchronous, so the engine remains deterministic and testable (per the ADR's consequences section).
- Per-act decision shapes moved into `_build_act_decision()`, the **single source of truth** shared by the pattern branches and the hint dispatch — a hinted act is indistinguishable from the same act matched by pattern.
- Hook side: the call is spent only on substantive (≥12 chars) non-desire, non-brief turns when a **dedicated** utility backend exists; 2s timeout, bare-label prompt (`max_tokens=12`), strict vocabulary validation. Any failure leaves the regex verdict untouched.
- **Byte-stability**: with `llm_act_hint=None` every decision is byte-identical to the previous implementation. Review verified this exhaustively (5,376-combination sweep against HEAD~1, zero mismatches); the 51-misfire regression suite passes unchanged.

### Review

Adversarial review: no CRITICAL/HIGH. The one MEDIUM (a `delight_share` hint could bypass the negation veto in the conflict zone) is fixed — deterministic guards now outrank the hint, with pinning tests.

## Test plan

- [x] `assess_classification`: conflict detection on mixed utterances, fallthrough on neutral substantive text, greetings/corrections/empty are neither
- [x] `decide` + hint: fallthrough adoption (shape-identical to the pattern branch), invalid hint ignored, hint ignored on unique pattern match, conflict arbitration, `previous_response_hurt` precedence, negation-veto and valence-gate precedence, no-hint byte-stability
- [x] `_classify_speech_act_llm`: vocabulary validation, quote/case normalization, out-of-vocabulary rejection, backend failure, timeout
- [x] 51-misfire regression suite (`test_social_policy.py`) green and unchanged
- [x] Full gate: ruff check, ruff format, mypy (120 files), pytest **1213 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)