### PR TITLE
fix(mcp): TUI-safe stderr for stdio servers + handshake timeout + eager start

### DIFF
--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -687,6 +687,21 @@ class EmbodiedAgent:
         """
         self._desires = desires
 
+    def start_mcp_early(self) -> None:
+        """Kick off the MCP handshake in the background (issue #188).
+
+        Callable from any running event loop — the UIs invoke it at mount so
+        MCP tools are registered by the first turn instead of the second;
+        ``prepare_turn`` calls it as the fallback for other entry points.
+        Idempotent: at most one in-flight handshake.
+        """
+        if self._mcp is None or self._mcp.is_started:
+            return
+        task = getattr(self, "_mcp_start_task", None)
+        if task is not None and not task.done():
+            return
+        self._mcp_start_task = asyncio.ensure_future(self._mcp.start())
+
     def _spawn_background_task(self, coro: Coroutine[Any, Any, None], *, name: str) -> None:
         """Run non-critical post-turn work off the response critical path."""
         tasks = getattr(self, "_background_tasks", None)

--- a/src/familiar_agent/gui.py
+++ b/src/familiar_agent/gui.py
@@ -1776,6 +1776,10 @@ class FamiliarWindow(QMainWindow):
 
             agent = await asyncio.to_thread(EmbodiedAgent, self._config)
             agent.bind_desires(self._desires)
+            # Start the MCP handshake now so tools are ready by the first turn (#188).
+            start_mcp_early = getattr(agent, "start_mcp_early", None)
+            if callable(start_mcp_early):
+                start_mcp_early()
             self._agent = agent
             if not agent.is_embedding_ready:
                 self._set_startup_status(f"{_t('initializing')} memory...")

--- a/src/familiar_agent/main.py
+++ b/src/familiar_agent/main.py
@@ -86,6 +86,11 @@ async def repl(agent: EmbodiedAgent, desires: DesireSystem, debug: bool = False)
 
     loop = asyncio.get_event_loop()
 
+    # Start the MCP handshake now so tools are ready by the first turn (#188).
+    start_mcp_early = getattr(agent, "start_mcp_early", None)
+    if callable(start_mcp_early):
+        start_mcp_early()
+
     # Persistent input queue — stdin reader runs as a background task
     # so user input is captured even while the agent is busy.
     input_queue: asyncio.Queue[str | None] = asyncio.Queue()

--- a/src/familiar_agent/mcp_client.py
+++ b/src/familiar_agent/mcp_client.py
@@ -29,16 +29,24 @@ Example config:
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import logging
 import os
 from contextlib import AsyncExitStack
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_CONFIG = Path.home() / ".familiar-ai.json"
+# MCP server stderr goes to a real file, never to sys.stderr: under the Textual
+# TUI sys.stderr is replaced by an object without a usable fileno(), which
+# breaks anyio's subprocess spawn inside stdio_client (issue #188) — and even
+# when it works, server banners scribble over the TUI screen.
+_DEFAULT_ERRLOG_PATH = Path.home() / ".familiar_ai" / "logs" / "mcp-stderr.log"
+_DEFAULT_CONNECT_TIMEOUT_SEC = 45.0
 
 
 def _resolve_config_path() -> Path:
@@ -65,7 +73,13 @@ def _load_servers(config_path: Path) -> dict[str, dict[str, Any]]:
 class MCPClientManager:
     """Manages MCP server connections (stdio and SSE) for the duration of the agent session."""
 
-    def __init__(self, config_path: Path | None = None) -> None:
+    def __init__(
+        self,
+        config_path: Path | None = None,
+        *,
+        errlog_path: str | Path | None = None,
+        connect_timeout_seconds: float | None = None,
+    ) -> None:
         self._config_path = config_path or _resolve_config_path()
         self._servers = _load_servers(self._config_path)
         self._sessions: dict[str, Any] = {}  # server_name → ClientSession
@@ -75,10 +89,40 @@ class MCPClientManager:
         self._tool_defs: list[dict[str, Any]] = []
         self._exit_stack = AsyncExitStack()
         self._started = False
+        self._errlog_path = Path(errlog_path).expanduser() if errlog_path else _DEFAULT_ERRLOG_PATH
+        self._errlog: IO[str] | None = None
+        if connect_timeout_seconds is None:
+            raw = os.environ.get("MCP_CONNECT_TIMEOUT", "").strip()
+            connect_timeout_seconds = float(raw) if raw else _DEFAULT_CONNECT_TIMEOUT_SEC
+        self._connect_timeout = max(1.0, float(connect_timeout_seconds))
 
     @property
     def is_started(self) -> bool:
         return self._started
+
+    def _ensure_errlog(self) -> IO[str]:
+        """Open the stderr sink for stdio servers — a real file, always.
+
+        stdio_client's default errlog is sys.stderr, which the Textual TUI
+        replaces with an object lacking a usable fileno(); anyio's subprocess
+        spawn then fails with 'fileno' and the server silently never registers
+        (issue #188). A dedicated log file fixes that and keeps server noise
+        off the screen; devnull is the fallback if the file can't be opened.
+        """
+        if self._errlog is None or self._errlog.closed:
+            try:
+                self._errlog_path.parent.mkdir(parents=True, exist_ok=True)
+                self._errlog = self._errlog_path.open("a", encoding="utf-8", errors="replace")
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("MCP errlog file unavailable (%s); using devnull", exc)
+                self._errlog = open(os.devnull, "w", encoding="utf-8")  # noqa: SIM115
+        return self._errlog
+
+    @staticmethod
+    async def _close_quietly(stack: AsyncExitStack) -> None:
+        """Best-effort cleanup of a failed server's contexts, bounded in time."""
+        with contextlib.suppress(Exception, asyncio.TimeoutError):
+            await asyncio.wait_for(stack.aclose(), timeout=5.0)
 
     async def _register_tools(self, name: str, session: Any) -> int:
         """Register tools from a connected session. Returns count of registered tools."""
@@ -134,49 +178,78 @@ class MCPClientManager:
         for name, cfg in self._servers.items():
             server_type = cfg.get("type", "stdio")
 
+            if server_type == "stdio" and not cfg.get("command", ""):
+                logger.warning("MCP server '%s': missing 'command', skipping", name)
+                continue
+            if server_type == "sse" and not cfg.get("url", ""):
+                logger.warning("MCP server '%s': missing 'url' for sse type, skipping", name)
+                continue
+            if server_type not in ("stdio", "sse"):
+                logger.warning(
+                    "MCP server '%s': unsupported type '%s', skipping", name, server_type
+                )
+                continue
+
+            # Per-server stack: a failed/hung server is cleaned up immediately
+            # and never wedges the others (or the whole start()) with it.
+            server_stack = AsyncExitStack()
+            await server_stack.__aenter__()
             try:
-                if server_type == "stdio":
-                    command = cfg.get("command", "")
-                    args: list[str] = cfg.get("args", [])
-                    env: dict[str, str] | None = cfg.get("env") or None
-
-                    if not command:
-                        logger.warning("MCP server '%s': missing 'command', skipping", name)
-                        continue
-
-                    params = StdioServerParameters(command=command, args=args, env=env)
-                    read, write = await self._exit_stack.enter_async_context(stdio_client(params))
-                    session: Any = await self._exit_stack.enter_async_context(
-                        ClientSession(read, write)
-                    )
-                    await session.initialize()
-
-                elif server_type == "sse":
-                    from mcp.client.sse import sse_client
-
-                    url = cfg.get("url", "")
-                    if not url:
-                        logger.warning(
-                            "MCP server '%s': missing 'url' for sse type, skipping", name
-                        )
-                        continue
-
-                    read, write = await self._exit_stack.enter_async_context(sse_client(url=url))
-                    session = await self._exit_stack.enter_async_context(ClientSession(read, write))
-                    await session.initialize()
-
-                else:
-                    logger.warning(
-                        "MCP server '%s': unsupported type '%s', skipping", name, server_type
-                    )
-                    continue
-
+                session, count = await asyncio.wait_for(
+                    self._connect_and_register(
+                        server_stack,
+                        name,
+                        cfg,
+                        server_type,
+                        ClientSession,
+                        StdioServerParameters,
+                        stdio_client,
+                    ),
+                    timeout=self._connect_timeout,
+                )
                 self._sessions[name] = session
-                count = await self._register_tools(name, session)
+                self._exit_stack.push_async_callback(server_stack.aclose)
                 logger.info("Connected to MCP server '%s' (%d tools)", name, count)
-
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "MCP server '%s': handshake timed out after %.0fs, skipping",
+                    name,
+                    self._connect_timeout,
+                )
+                await self._close_quietly(server_stack)
             except Exception as e:
                 logger.warning("Failed to connect to MCP server '%s': %s", name, e)
+                await self._close_quietly(server_stack)
+
+    async def _connect_and_register(
+        self,
+        stack: AsyncExitStack,
+        name: str,
+        cfg: dict[str, Any],
+        server_type: str,
+        client_session_cls: Any,
+        stdio_params_cls: Any,
+        stdio_client_fn: Any,
+    ) -> tuple[Any, int]:
+        """Enter transport + session contexts on ``stack``, handshake, register."""
+        if server_type == "stdio":
+            params = stdio_params_cls(
+                command=cfg.get("command", ""),
+                args=cfg.get("args", []),
+                env=cfg.get("env") or None,
+            )
+            read, write = await stack.enter_async_context(
+                stdio_client_fn(params, errlog=self._ensure_errlog())
+            )
+        else:  # sse — validated by the caller
+            from mcp.client.sse import sse_client
+
+            read, write = await stack.enter_async_context(sse_client(url=cfg.get("url", "")))
+
+        session: Any = await stack.enter_async_context(client_session_cls(read, write))
+        await session.initialize()
+        count = await self._register_tools(name, session)
+        return session, count
 
     async def stop(self) -> None:
         """Close all MCP connections."""
@@ -186,6 +259,10 @@ class MCPClientManager:
             await self._exit_stack.__aexit__(None, None, None)
         except Exception as e:
             logger.debug("MCP cleanup error: %s", e)
+        if self._errlog is not None:
+            with contextlib.suppress(Exception):
+                self._errlog.close()
+            self._errlog = None
 
     def get_tool_definitions(self) -> list[dict[str, Any]]:
         """Return Anthropic-format tool definitions from all connected servers."""

--- a/src/familiar_agent/tui.py
+++ b/src/familiar_agent/tui.py
@@ -251,6 +251,10 @@ class FamiliarApp(App):
         self._log_system(_t("startup", log_path=str(self._log_path)))
         self.set_interval(IDLE_CHECK_INTERVAL, self._reminder_tick)
         self.set_interval(IDLE_CHECK_INTERVAL, self._desire_tick)
+        # Start the MCP handshake now so tools are ready by the first turn (#188).
+        start_mcp_early = getattr(self.agent, "start_mcp_early", None)
+        if callable(start_mcp_early):
+            start_mcp_early()
         self.run_worker(self._process_queue(), exclusive=False)
         # Start realtime STT if configured
         if self._realtime_stt:

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -255,7 +255,10 @@ class EmbodiedAgentHook(RuntimeHookBase):
             on_phase("startup" if startup_phase else "thinking")
 
         # ── Background tasks (MCP connections, memory worker, inner loop) ──
-        if agent._mcp and not agent._mcp.is_started:
+        start_mcp_early = getattr(agent, "start_mcp_early", None)
+        if callable(start_mcp_early):
+            start_mcp_early()
+        elif agent._mcp and not agent._mcp.is_started:  # legacy agents
             agent._mcp_start_task = asyncio.ensure_future(agent._mcp.start())
         if memory_worker and not memory_worker.is_running:
             await memory_worker.start()

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -366,6 +366,160 @@ async def test_call_routes_to_correct_server_and_returns_text(tmp_path: Path) ->
     sess.call_tool.assert_awaited_once_with("remember", arguments={"text": "hello"})
 
 
+# ---------------------------------------------------------------------------
+# Issue #188 — TUI-safe stderr handling + hung-server containment
+# ---------------------------------------------------------------------------
+
+
+_FASTMCP_SERVER = """\
+import sys
+from mcp.server.fastmcp import FastMCP
+
+print("Test MCP server running on stdio", file=sys.stderr, flush=True)
+mcp = FastMCP("test-server")
+
+
+@mcp.tool()
+def echo_tool(text: str) -> str:
+    \"\"\"Echo the input text back.\"\"\"
+    return f"echo: {text}"
+
+
+if __name__ == "__main__":
+    mcp.run()
+"""
+
+
+def _stdio_config(tmp_path: Path, command: str, args: list[str]) -> Path:
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(
+        json.dumps({"mcpServers": {"test": {"type": "stdio", "command": command, "args": args}}})
+    )
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_stdio_registers_tools_when_stderr_has_no_fileno(tmp_path: Path) -> None:
+    """Regression for #188: under Textual, sys.stderr lacks a usable fileno and
+    stdio_client's default errlog broke the subprocess spawn — tools silently
+    never registered. The explicit errlog file must make this work."""
+    import io
+
+    server = tmp_path / "server.py"
+    server.write_text(_FASTMCP_SERVER)
+    cfg = _stdio_config(tmp_path, sys.executable, [str(server)])
+
+    from familiar_agent.mcp_client import MCPClientManager
+
+    real_stderr = sys.stderr
+    sys.stderr = io.StringIO()  # Textual-like stderr replacement
+    try:
+        mgr = MCPClientManager(
+            config_path=cfg,
+            errlog_path=tmp_path / "mcp-stderr.log",
+            connect_timeout_seconds=30,
+        )
+        await mgr.start()
+    finally:
+        sys.stderr = real_stderr
+
+    try:
+        names = {d["name"] for d in mgr.get_tool_definitions()}
+        assert names == {"echo_tool"}
+        text, image = await mgr.call("echo_tool", {"text": "hi"})
+        assert text == "echo: hi"
+        assert image is None
+        # The server's stderr banner landed in the log file, not on screen.
+        assert "running on stdio" in (tmp_path / "mcp-stderr.log").read_text()
+    finally:
+        await mgr.stop()
+
+
+@pytest.mark.asyncio
+async def test_hung_server_times_out_and_is_skipped(tmp_path: Path) -> None:
+    """A server that never completes the MCP handshake must not wedge start()."""
+    import time as _time
+
+    cfg = _stdio_config(tmp_path, sys.executable, ["-c", "import time; time.sleep(60)"])
+
+    from familiar_agent.mcp_client import MCPClientManager
+
+    mgr = MCPClientManager(
+        config_path=cfg,
+        errlog_path=tmp_path / "mcp-stderr.log",
+        connect_timeout_seconds=1.5,
+    )
+    started = _time.monotonic()
+    await mgr.start()
+    elapsed = _time.monotonic() - started
+
+    try:
+        assert mgr.get_tool_definitions() == []
+        # 1.5s handshake budget + bounded cleanup — far below the 60s sleep.
+        assert elapsed < 15
+    finally:
+        await mgr.stop()
+
+
+@pytest.mark.asyncio
+async def test_stdio_client_receives_real_file_errlog(tmp_path: Path) -> None:
+    """The mocked transport must be invoked with an errlog that has a fileno."""
+    cfg = _stdio_config(tmp_path, "some-command", [])
+    sess = _session(_tool("t"))
+
+    from unittest.mock import patch
+
+    from familiar_agent.mcp_client import MCPClientManager
+
+    modules = _patch_mcp([sess])
+    with patch.dict(sys.modules, modules):
+        mgr = MCPClientManager(config_path=cfg, errlog_path=tmp_path / "err.log")
+        await mgr.start()
+
+    stdio_mock = modules["mcp.client.stdio"].stdio_client
+    assert stdio_mock.call_count == 1
+    errlog = stdio_mock.call_args.kwargs["errlog"]
+    errlog.fileno()  # must not raise — a real file, never sys.stderr
+
+
+@pytest.mark.asyncio
+async def test_start_mcp_early_is_idempotent() -> None:
+    """start_mcp_early creates at most one in-flight handshake task."""
+    import asyncio
+
+    from tests.test_agent_react_loop import _make_agent
+
+    agent = _make_agent()
+    mcp = MagicMock()
+    mcp.is_started = False
+    started = asyncio.Event()
+
+    async def _slow_start():
+        await started.wait()
+
+    mcp.start = _slow_start
+    agent._mcp = mcp
+    agent._mcp_start_task = None
+
+    agent.start_mcp_early()
+    task1 = agent._mcp_start_task
+    assert task1 is not None
+    agent.start_mcp_early()
+    assert agent._mcp_start_task is task1  # no second task while in flight
+
+    started.set()
+    await task1
+    mcp.is_started = True
+    agent.start_mcp_early()
+    assert agent._mcp_start_task is task1  # started manager → no new task
+
+    # Without an MCP manager it is a no-op.
+    agent._mcp = None
+    agent._mcp_start_task = None
+    agent.start_mcp_early()
+    assert agent._mcp_start_task is None
+
+
 @pytest.mark.asyncio
 async def test_call_extracts_image_from_content(tmp_path: Path) -> None:
     """call() extracts base64 image data when content includes an image block."""


### PR DESCRIPTION
## Summary

Fixes #188 — MCP tools silently never registered in TUI mode.

## Root cause (reproduced, not theorized)

The issue's static analysis was close but the lazy-start *does* run (`prepare_turn` has fired `ensure_future(mcp.start())` since #152). The real failure, reproduced with a live FastMCP stdio server:

Under the Textual TUI, `sys.stderr` is replaced by an object **without a usable `fileno()`**. `mcp`'s `stdio_client` defaults `errlog=sys.stderr`, so anyio's subprocess spawn fails with `'fileno'`; the per-server `try/except` swallows it, `_started` is already `True` (set on entry), and nothing ever retries. Symptom matches the report exactly: subprocess visibly launches, handshake never completes, zero tools, forever.

```
WARNING familiar_agent.mcp_client: Failed to connect to MCP server 'test': fileno
```

## Fix

1. **TUI-safe errlog**: stdio servers always get an explicit `errlog` backed by a real file (`~/.familiar_ai/logs/mcp-stderr.log`, devnull fallback) — never `sys.stderr`. Bonus: server banners stop scribbling over the TUI, and connect failures are now debuggable from the log.
2. **Handshake containment**: per-server connect+initialize+list_tools timeout (45 s default, `MCP_CONNECT_TIMEOUT` override) on a per-server `AsyncExitStack` with bounded cleanup — a hung or broken server is skipped and can no longer wedge `start()` silently.
3. **Eager start** (the issue's suggested improvement): `EmbodiedAgent.start_mcp_early()` — idempotent, at most one in-flight handshake — called at TUI `on_mount`, REPL entry, and GUI agent-init so tools are registered by the **first** turn; `prepare_turn` keeps it as the fallback for other entry points.

## Testing

- New regression tests drive a **real stdio MCP subprocess** (FastMCP): tool registration under Textual-like stderr replacement, hung-server timeout containment (returns in ~2 s, not 60), errlog-kwarg fileno assertion, `start_mcp_early` idempotency.
- Original repro script: scenario B (StringIO stderr) went from `tool defs: []` → `tool defs: ['echo_tool']`.
- Full gate green: 1309 passed, ruff check/format clean, mypy clean (4 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)