### PR TITLE
feat(daemon): familiard body daemon v1 — interoception, wake events, offline decay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -185,6 +185,21 @@ REALTIME_STT=false
 # FAMILIAR_AUTO_DESIRE=1        # enable desire-driven idle turns only
 # FAMILIAR_AUTO_SAY=1           # enable auto-say (fallback vocalization) only
 
+# ── Body daemon: familiard (optional, default OFF) ────────────────────────────
+# An always-on process that keeps the body alive between sessions:
+# interoception sampling (CPU/memory/time → body signal), wake scheduling
+# (due commitments / desire pressure / schedule bands), and offline affect
+# decay (feelings settle toward baseline while the app is closed).
+#
+#   1. Run the daemon:            uv run familiard
+#   2. Let the app listen to it:  FAMILIAR_DAEMON=1
+#
+# FAMILIAR_DAEMON=1
+# FAMILIAR_DAEMON_SOCKET=~/.familiar_ai/familiard.sock   # default
+#
+# Daemon configuration: ~/.familiar_ai/familiard.conf (key = value lines)
+# or FAMILIARD_* env overrides — e.g. FAMILIARD_ACTIVE_BANDS=07:00-09:00,18:00-24:00
+
 # ── Performance tuning (optional) ─────────────────────────────────────────────
 # FAMILIAR_TAPE_LLM_REPLAN=1   # use LLM for TAPE replanning (default: heuristic)
 # FAMILIAR_COHERENCE_CHECK=1   # enable response coherence check (extra LLM call)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,12 +108,28 @@ status, auto-say, `commit_after_end_turn`) and the forced final response on
 max-iterations remain in `run()`. The `run()` public signature is unchanged
 and must stay that way.
 
-**Inner loop (scaffolding, dark by default).** `familiar_agent/inner_loop.py`
-drives a sub-verbal idle workspace between turns; gated by `FAMILIAR_INNER_LOOP`
+**Inner loop (live, dark by default).** `familiar_agent/inner_loop.py` drives a
+sub-verbal idle workspace between turns; gated by `FAMILIAR_INNER_LOOP`
 (default OFF, interval `FAMILIAR_INNER_LOOP_INTERVAL`). `agent._compete_once(cheap=...)`
 is the shared workspace-cycle seam — `cheap=True` skips embedding-backed sources
 (memory recall + DMN wander) for zero-LLM idle cycles; `_gather_workspace_context`
-is now a thin wrapper over it.
+is a thin wrapper over it. The tick feeds `TrainOfThought`; a sustained salient
+focus escalates by **boosting a drive** (`_INNER_SOURCE_TO_DRIVE`, streak+salience
+gate, per-source cooldown) consumed by the UI-owned idle chain — the tick never
+calls `run()` (no turn lock exists; single-flight is UI-owned). `bind_desires()`
+late-binds the UI's DesireSystem; the loop lazy-starts in `prepare_turn`.
+
+**Body daemon (familiard, separate process, dark by default).**
+`familiar_agent/familiard.py` (`uv run familiard`) owns interoception sampling
+(payload consumed via the existing `MCPInteroceptionProvider` path), wake
+scheduling (due commitments / desire pressure / schedule bands → Unix-socket
+wake events), and offline self-state decay (only while no cortex is connected).
+**Read-only toward cortex state**: never writes `desires.json`, opens
+`commitments.db` in SQLite read-only URI mode, never opens `observations.db`.
+Cortex side: `familiar_agent/wake.py` (`WakeListener`, `wait_input_or_wake`) —
+gated by `FAMILIAR_DAEMON` (default OFF); a wake only accelerates the idle poll,
+every behavioral gate re-checks in the cortex. Daemon config:
+`~/.familiar_ai/familiard.conf` + `FAMILIARD_*` env.
 
 ### Turn flow (conceptual)
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,33 @@ MODEL=llm -m gemma3 {}        # llm CLI (https://llm.datasette.io) — {} = prom
 
 ---
 
+## Body daemon (familiard)
+
+familiar-ai can run with an always-on body: `familiard` is a small separate
+process that keeps living while the app is closed.
+
+```bash
+uv run familiard        # start the body daemon
+FAMILIAR_DAEMON=1 ./run.sh   # the app now feels it and wakes on its nudges
+```
+
+What it owns (zero LLM calls, a few hertz):
+
+- **Interoception** — samples CPU / memory / time of day into a body signal the
+  agent feels each turn (energy, cognitive load, stress)
+- **Wake events** — due commitments, rising desires, and schedule-band pulses
+  nudge the app instantly instead of waiting for its next idle poll; every
+  behavioral gate stays in the app, so a wake is never more than an early poll
+- **Offline affect decay** — feelings settle toward baseline on wall-clock time
+  while the app is closed, instead of freezing mid-emotion
+
+Configuration lives in `~/.familiar_ai/familiard.conf` (`key = value` lines,
+`FAMILIARD_*` env overrides), e.g. `active_bands = 07:00-09:00,18:00-24:00`.
+Without the daemon (the default), nothing changes — the app keeps its plain
+idle polling.
+
+---
+
 ## MCP Servers
 
 familiar-ai can connect to any [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server. This lets you plug in external memory, filesystem access, web search, or any other tool.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ all = [
 [project.scripts]
 familiar = "familiar_agent.main:main"
 familiar-discover-cameras = "familiar_agent.camera_discovery:main"
+familiard = "familiar_agent.familiard:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -1388,6 +1388,13 @@ class EmbodiedAgent:
 
     def _collect_interoception(self):
         mcp_path = os.environ.get("FAMILIAR_INTEROCEPTION_MCP_PATH", "").strip()
+        if not mcp_path and getattr(self.config, "daemon", False) is True:
+            # familiard writes its body payload to a well-known path; adopt it
+            # automatically when the daemon is enabled and has produced one.
+            # (`is True` keeps MagicMock configs in tests from flipping this.)
+            candidate = Path.home() / ".familiar_ai" / "interoception.json"
+            if candidate.exists():
+                mcp_path = str(candidate)
         if mcp_path:
             max_staleness = int(
                 os.environ.get("FAMILIAR_INTEROCEPTION_MCP_MAX_STALENESS", "45").strip() or "45"

--- a/src/familiar_agent/config.py
+++ b/src/familiar_agent/config.py
@@ -231,6 +231,12 @@ class AgentConfig:
     inner_loop_interval: float = field(
         default_factory=lambda: float(os.environ.get("FAMILIAR_INNER_LOOP_INTERVAL", "20") or "20")
     )
+    # Body daemon (familiard): FAMILIAR_DAEMON=1 makes the UIs listen for wake
+    # events from a running `familiard` process (socket override:
+    # FAMILIAR_DAEMON_SOCKET) and auto-adopts its interoception payload.
+    # Default OFF; without the daemon everything degrades to the 10s idle poll.
+    daemon: bool = field(default_factory=lambda: _bool_env("FAMILIAR_DAEMON", default=False))
+    daemon_socket: str = field(default_factory=lambda: os.environ.get("FAMILIAR_DAEMON_SOCKET", ""))
 
     max_tokens: int = 4096
     camera: CameraConfig = field(default_factory=CameraConfig)

--- a/src/familiar_agent/familiard.py
+++ b/src/familiar_agent/familiard.py
@@ -1,0 +1,624 @@
+"""familiard — the always-on body daemon (Loop 0 of the nervous system).
+
+The LLM cortex runs turns; *this* process keeps the body alive between and
+without them. It owns, at a few hertz and with zero LLM calls:
+
+- **Interoception sampling**: CPU / memory / time-of-day → a semantic body
+  signal written where ``MCPInteroceptionProvider`` already reads it, so the
+  cortex needs no new code to feel it.
+- **Wake scheduling**: due commitments, desire threshold crossings, and
+  schedule-band pulses become wake events pushed over a Unix socket. A wake
+  only *accelerates* the cortex's own idle poll — every behavioral gate
+  (reminder backoff, quiet hours, auto_desire, precedence) stays in the
+  cortex, which re-checks them on wake. The daemon never decides, it nudges.
+- **Offline affect decay**: while no cortex is connected, ``self_state.json``
+  settles toward baseline on wall-clock time — feelings fade during sleep
+  instead of freezing.
+
+Read-only by design toward cortex-owned state: desires.json and
+commitments.db are only ever read (the desire file has 18 cortex-side write
+sites and a non-atomic saver; two writers would corrupt it), and
+observations.db is never opened at all (its single connection sets no
+busy_timeout). The daemon's only writes are its own payload file and the
+offline self-state settle, which is gated on "no cortex connected".
+
+Run with ``uv run familiard``; stop with SIGINT/SIGTERM. Configuration comes
+from ``~/.familiar_ai/familiard.conf`` (key = value lines) with env
+overrides; see ``FamiliardConfig``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import random
+import signal
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_STATE_DIR = Path.home() / ".familiar_ai"
+_DEFAULT_CONF_PATH = _STATE_DIR / "familiard.conf"
+
+# Desire threshold mirrors familiar_neighbor.mind.desires.TRIGGER_THRESHOLD.
+# Kept as a literal on purpose: the daemon must not import the cortex's mind
+# packages (it reads their *files*, not their code), and the cortex re-checks
+# the real threshold on wake anyway — a stale mirror only costs a spare nudge.
+_DESIRE_WAKE_THRESHOLD = 0.6
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def _parse_bands(raw: str) -> list[tuple[int, int]]:
+    """Parse "07:00-09:00,18:00-24:00" into [(start_minute, end_minute)]."""
+    bands: list[tuple[int, int]] = []
+    for part in raw.split(","):
+        part = part.strip()
+        if not part or "-" not in part:
+            continue
+        try:
+            start_s, end_s = part.split("-", 1)
+            sh, sm = (start_s.strip().split(":") + ["0"])[:2]
+            eh, em = (end_s.strip().split(":") + ["0"])[:2]
+            start = int(sh) * 60 + int(sm)
+            end = int(eh) * 60 + int(em)
+        except ValueError:
+            continue
+        if 0 <= start < end <= 24 * 60:
+            bands.append((start, end))
+    return bands
+
+
+@dataclass(slots=True)
+class FamiliardConfig:
+    interoception_path: Path = _STATE_DIR / "interoception.json"
+    socket_path: Path = _STATE_DIR / "familiard.sock"
+    self_state_path: Path = _STATE_DIR / "self_state.json"
+    desires_path: Path = _STATE_DIR / "desires.json"
+    commitments_db_path: Path = _STATE_DIR / "commitments.db"
+
+    sample_interval_sec: float = 10.0
+    scheduler_interval_sec: float = 5.0
+
+    # Active bands: within these local-time windows the daemon emits a
+    # band_tick pulse every band_interval_sec. Outside them, at most one
+    # probabilistic pulse per hour (day/night chance), kokone-style.
+    active_bands: list[tuple[int, int]] = field(
+        default_factory=lambda: _parse_bands("07:00-09:00,12:00-13:00,18:00-24:00")
+    )
+    band_interval_sec: float = 1200.0
+    offband_chance_day: float = 0.5
+    offband_chance_night: float = 0.1
+    night_start_hour: int = 0
+    night_end_hour: int = 7
+
+    # Quiet hours for the interoception signal (mirrors the cortex default).
+    quiet_start_hour: int = 23
+    quiet_end_hour: int = 7
+
+    # Wake rate limits per reason.
+    reminder_wake_cooldown_sec: float = 60.0
+    desire_wake_cooldown_sec: float = 120.0
+
+    # Offline decay: apply one settle step toward baseline per this many
+    # seconds of no-cortex wall-clock (matches SelfState's per-event 0.08
+    # step at a "several times an hour" cadence).
+    offline_decay: bool = True
+    offline_decay_step_sec: float = 600.0
+    offline_grace_sec: float = 60.0
+
+    @classmethod
+    def load(cls, conf_path: Path | None = None) -> FamiliardConfig:
+        """Read key=value config with env overrides (FAMILIARD_<KEY>)."""
+        cfg = cls()
+        path = conf_path or Path(os.environ.get("FAMILIARD_CONF", "").strip() or _DEFAULT_CONF_PATH)
+        raw: dict[str, str] = {}
+        if path.exists():
+            try:
+                for line in path.read_text(encoding="utf-8").splitlines():
+                    line = line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    key, value = line.split("=", 1)
+                    raw[key.strip().lower()] = value.strip()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("familiard.conf unreadable (%s); using defaults", exc)
+        for key in list(raw):
+            env = os.environ.get(f"FAMILIARD_{key.upper()}")
+            if env is not None:
+                raw[key] = env
+        # Env-only overrides for keys absent from the file.
+        for env_key, value in os.environ.items():
+            if env_key.startswith("FAMILIARD_"):
+                raw.setdefault(env_key[len("FAMILIARD_") :].lower(), value)
+
+        def _f(key: str, current: float) -> float:
+            try:
+                return float(raw[key]) if key in raw else current
+            except ValueError:
+                return current
+
+        def _i(key: str, current: int) -> int:
+            try:
+                return int(raw[key]) if key in raw else current
+            except ValueError:
+                return current
+
+        def _p(key: str, current: Path) -> Path:
+            return Path(raw[key]).expanduser() if raw.get(key) else current
+
+        cfg.interoception_path = _p("interoception_path", cfg.interoception_path)
+        cfg.socket_path = _p("socket_path", cfg.socket_path)
+        cfg.self_state_path = _p("self_state_path", cfg.self_state_path)
+        cfg.desires_path = _p("desires_path", cfg.desires_path)
+        cfg.commitments_db_path = _p("commitments_db_path", cfg.commitments_db_path)
+        cfg.sample_interval_sec = _f("sample_interval_sec", cfg.sample_interval_sec)
+        cfg.scheduler_interval_sec = _f("scheduler_interval_sec", cfg.scheduler_interval_sec)
+        if "active_bands" in raw:
+            cfg.active_bands = _parse_bands(raw["active_bands"])
+        cfg.band_interval_sec = _f("band_interval_sec", cfg.band_interval_sec)
+        cfg.offband_chance_day = _f("offband_chance_day", cfg.offband_chance_day)
+        cfg.offband_chance_night = _f("offband_chance_night", cfg.offband_chance_night)
+        cfg.night_start_hour = _i("night_start_hour", cfg.night_start_hour)
+        cfg.night_end_hour = _i("night_end_hour", cfg.night_end_hour)
+        cfg.quiet_start_hour = _i("quiet_start_hour", cfg.quiet_start_hour)
+        cfg.quiet_end_hour = _i("quiet_end_hour", cfg.quiet_end_hour)
+        cfg.reminder_wake_cooldown_sec = _f(
+            "reminder_wake_cooldown_sec", cfg.reminder_wake_cooldown_sec
+        )
+        cfg.desire_wake_cooldown_sec = _f("desire_wake_cooldown_sec", cfg.desire_wake_cooldown_sec)
+        if "offline_decay" in raw:
+            cfg.offline_decay = raw["offline_decay"].strip().lower() in ("1", "true", "yes", "on")
+        cfg.offline_decay_step_sec = _f("offline_decay_step_sec", cfg.offline_decay_step_sec)
+        cfg.offline_grace_sec = _f("offline_grace_sec", cfg.offline_grace_sec)
+        return cfg
+
+
+# ---------------------------------------------------------------------------
+# Interoception sampling
+# ---------------------------------------------------------------------------
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _read_cpu_load_fraction() -> float:
+    """1-minute load average normalized by core count; 0.0 when unavailable."""
+    try:
+        load1 = os.getloadavg()[0]
+        cores = os.cpu_count() or 1
+        return max(0.0, load1 / cores)
+    except (OSError, AttributeError):  # Windows has no getloadavg
+        return 0.0
+
+
+def _read_mem_free_fraction() -> float:
+    """MemAvailable/MemTotal from /proc/meminfo; 0.5 when unavailable."""
+    try:
+        total = available = None
+        for line in Path("/proc/meminfo").read_text().splitlines():
+            if line.startswith("MemTotal:"):
+                total = float(line.split()[1])
+            elif line.startswith("MemAvailable:"):
+                available = float(line.split()[1])
+            if total and available:
+                return _clamp01(available / total)
+    except Exception:  # noqa: BLE001
+        pass
+    return 0.5
+
+
+def _in_hour_window(hour: int, start: int, end: int) -> bool:
+    """True when ``hour`` falls in [start, end), wrapping over midnight."""
+    if start <= end:
+        return start <= hour < end
+    return hour >= start or hour < end
+
+
+def build_interoception_payload(
+    *,
+    cpu_load: float,
+    mem_free: float,
+    now: datetime,
+    quiet_start: int,
+    quiet_end: int,
+) -> dict:
+    """Map raw body metrics to the MCPInteroceptionProvider signal shape."""
+    hour = now.hour
+    quiet = _in_hour_window(hour, quiet_start, quiet_end)
+    arousal = _clamp01(cpu_load)
+    mem_pressure = 1.0 - _clamp01(mem_free)
+    energy = _clamp01(0.85 - 0.35 * arousal - (0.23 if quiet else 0.0))
+    cognitive_load = _clamp01(0.6 * arousal + 0.4 * mem_pressure)
+    body_stress = _clamp01(0.5 * arousal + 0.35 * mem_pressure)
+    social_openness = _clamp01(0.6 - (0.18 if quiet else 0.0) - 0.25 * body_stress)
+    return {
+        "signal": {
+            "observed_at": now.astimezone(timezone.utc).isoformat(),
+            "local_hour": hour,
+            "quiet_hours": quiet,
+            "energy": energy,
+            "cognitive_load": cognitive_load,
+            "body_stress": body_stress,
+            "social_openness": social_openness,
+            "raw_metrics": {
+                "cpu_load_fraction": round(arousal, 4),
+                "mem_free_fraction": round(_clamp01(mem_free), 4),
+            },
+        }
+    }
+
+
+def _write_json_atomic(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+# ---------------------------------------------------------------------------
+# Wake scheduling (pure decision logic — clock/rng injected for tests)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class BandSchedulerState:
+    last_band_pulse: float = 0.0
+    last_offband_hour: int = -1
+
+
+def decide_band_pulse(
+    *,
+    config: FamiliardConfig,
+    state: BandSchedulerState,
+    now: datetime,
+    monotonic_now: float,
+    rng: random.Random,
+) -> bool:
+    """One scheduling decision: should a band_tick pulse fire right now?
+
+    In an active band: fire every ``band_interval_sec``. Off-band: at most one
+    probabilistic attempt per hour (day/night chance), kokone-style.
+    """
+    minute_of_day = now.hour * 60 + now.minute
+    in_band = any(start <= minute_of_day < end for start, end in config.active_bands)
+    if in_band:
+        if monotonic_now - state.last_band_pulse >= config.band_interval_sec:
+            state.last_band_pulse = monotonic_now
+            return True
+        return False
+    # Off-band: single roll at the top of each hour window.
+    if state.last_offband_hour == now.hour:
+        return False
+    state.last_offband_hour = now.hour
+    night = _in_hour_window(now.hour, config.night_start_hour, config.night_end_hour)
+    chance = config.offband_chance_night if night else config.offband_chance_day
+    if rng.random() < chance:
+        state.last_band_pulse = monotonic_now
+        return True
+    return False
+
+
+def read_desire_pressure(desires_path: Path, threshold: float = _DESIRE_WAKE_THRESHOLD) -> bool:
+    """True when any persisted desire level sits at/above the wake threshold.
+
+    Read-only. The cortex re-derives the *effective* dominant desire with its
+    own affordances/cooldowns — this is only "worth waking up for a look".
+    """
+    try:
+        raw = json.loads(desires_path.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return False
+    levels = raw.get("desires", raw) if isinstance(raw, dict) else {}
+    if not isinstance(levels, dict):
+        return False
+    return any(isinstance(v, (int, float)) and float(v) >= threshold for v in levels.values())
+
+
+def read_due_commitments(db_path: Path, *, now: float) -> bool:
+    """True when any active commitment is due (read-only; never writes).
+
+    Opens commitments.db in SQLite read-only URI mode — the store sets WAL +
+    busy_timeout on its own connection, so a reader is safe. All reminder
+    semantics (backoff, caps, quiet hours) stay in the cortex; this is only
+    the "there might be something" accelerator.
+    """
+    if not db_path.exists():
+        return False
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
+        try:
+            row = conn.execute(
+                """
+                SELECT COUNT(*) FROM runtime_commitments
+                WHERE status IN ('open', 'snoozed')
+                  AND due_at IS NOT NULL AND due_at <= ?
+                  AND (snooze_until IS NULL OR snooze_until <= ?)
+                """,
+                (now, now),
+            ).fetchone()
+            return bool(row and row[0] > 0)
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Offline self-state decay
+# ---------------------------------------------------------------------------
+
+# Baselines mirror familiar_neighbor.mind.self_state._BASELINES; kept as data
+# (not an import) so the daemon never loads cortex packages. Drift here is
+# cosmetic: the cortex re-settles on its next turn anyway.
+_SELF_STATE_BASELINES: dict[str, float] = {
+    "arousal": 0.35,
+    "fatigue": 0.2,
+    "social_pull": 0.35,
+    "sensor_confidence": 0.7,
+    "unresolved_tension": 0.2,
+    "focus_stability": 0.5,
+}
+_SETTLE_RATE = 0.08  # one SelfState settle step
+
+
+def apply_offline_settle(path: Path, *, steps: int) -> bool:
+    """Settle self_state.json toward baseline by ``steps`` decay steps.
+
+    Returns True when the file was updated. Only called while no cortex is
+    connected — the cortex is the sole writer whenever it is alive.
+    """
+    if steps <= 0 or not path.exists():
+        return False
+    try:
+        values = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(values, dict):
+            return False
+        changed = False
+        for key, baseline in _SELF_STATE_BASELINES.items():
+            current = values.get(key, baseline)
+            if not isinstance(current, (int, float)):
+                continue
+            settled = float(current)
+            for _ in range(min(steps, 200)):
+                settled = settled + (baseline - settled) * _SETTLE_RATE
+            if abs(settled - float(current)) > 1e-9:
+                values[key] = max(0.0, min(1.0, settled))
+                changed = True
+        if changed:
+            _write_json_atomic(path, values)
+        return changed
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("offline settle skipped: %s", exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# The daemon
+# ---------------------------------------------------------------------------
+
+
+class Familiard:
+    """Owns the sampler, scheduler, wake socket, and offline decay loops."""
+
+    def __init__(self, config: FamiliardConfig | None = None) -> None:
+        self.config = config or FamiliardConfig.load()
+        self._clients: set[asyncio.StreamWriter] = set()
+        self._server: asyncio.base_events.Server | None = None
+        self._tasks: list[asyncio.Task] = []
+        self._band_state = BandSchedulerState()
+        self._last_wake_at: dict[str, float] = {}
+        self._last_client_seen = time.monotonic()
+        self._last_decay_applied = time.monotonic()
+        self._rng = random.Random()
+        self._stopping = asyncio.Event()
+
+    # ── wake socket ──
+
+    @property
+    def client_count(self) -> int:
+        return len(self._clients)
+
+    async def _handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        self._clients.add(writer)
+        self._last_client_seen = time.monotonic()
+        logger.info("cortex connected (%d client(s))", len(self._clients))
+        try:
+            while not reader.at_eof():
+                data = await reader.read(1024)
+                if not data:
+                    break
+        except (ConnectionError, asyncio.CancelledError):
+            pass
+        finally:
+            self._clients.discard(writer)
+            self._last_client_seen = time.monotonic()
+            with contextlib.suppress(Exception):
+                writer.close()
+            logger.info("cortex disconnected (%d client(s))", len(self._clients))
+
+    def _emit_wake(self, reason: str) -> None:
+        """Rate-limited push of a wake event to all connected cortices.
+
+        No clients → no emit AND no cooldown burn: an event nobody heard
+        doesn't count, so a cortex connecting later gets woken promptly.
+        """
+        if not self._clients:
+            return
+        cooldowns = {
+            "reminder": self.config.reminder_wake_cooldown_sec,
+            "desire": self.config.desire_wake_cooldown_sec,
+        }
+        now = time.monotonic()
+        last = self._last_wake_at.get(reason, 0.0)
+        if now - last < cooldowns.get(reason, 30.0):
+            return
+        self._last_wake_at[reason] = now
+        line = json.dumps({"type": "wake", "reason": reason, "ts": time.time()}) + "\n"
+        payload = line.encode("utf-8")
+        for writer in list(self._clients):
+            try:
+                writer.write(payload)
+            except Exception:  # noqa: BLE001
+                self._clients.discard(writer)
+        logger.info("wake emitted: %s -> %d client(s)", reason, len(self._clients))
+
+    # ── loops ──
+
+    async def _sampler_loop(self) -> None:
+        while not self._stopping.is_set():
+            try:
+                payload = build_interoception_payload(
+                    cpu_load=_read_cpu_load_fraction(),
+                    mem_free=_read_mem_free_fraction(),
+                    now=datetime.now().astimezone(),
+                    quiet_start=self.config.quiet_start_hour,
+                    quiet_end=self.config.quiet_end_hour,
+                )
+                _write_json_atomic(self.config.interoception_path, payload)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("interoception sample failed: %s", exc)
+            await self._sleep(self.config.sample_interval_sec)
+
+    async def _scheduler_loop(self) -> None:
+        while not self._stopping.is_set():
+            try:
+                if read_due_commitments(self.config.commitments_db_path, now=time.time()):
+                    self._emit_wake("reminder")
+                if read_desire_pressure(self.config.desires_path):
+                    self._emit_wake("desire")
+                if decide_band_pulse(
+                    config=self.config,
+                    state=self._band_state,
+                    now=datetime.now(),
+                    monotonic_now=time.monotonic(),
+                    rng=self._rng,
+                ):
+                    self._emit_wake("band_tick")
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("scheduler tick failed: %s", exc)
+            await self._sleep(self.config.scheduler_interval_sec)
+
+    def _decay_tick(self, *, monotonic_now: float) -> int:
+        """One offline-decay decision. Returns the number of settle steps applied.
+
+        Feelings settle toward baseline only while NO cortex is connected
+        (plus a grace period) — whenever a cortex is alive, it is the sole
+        writer of self_state.json and the decay clock just tracks along.
+        """
+        cortex_offline = (
+            not self._clients
+            and monotonic_now - self._last_client_seen >= self.config.offline_grace_sec
+        )
+        if not cortex_offline:
+            self._last_decay_applied = monotonic_now
+            return 0
+        steps = int(
+            (monotonic_now - self._last_decay_applied) // self.config.offline_decay_step_sec
+        )
+        if steps <= 0:
+            return 0
+        applied = apply_offline_settle(self.config.self_state_path, steps=steps)
+        self._last_decay_applied = monotonic_now
+        if applied:
+            logger.info("offline settle applied (%d step(s))", steps)
+        return steps if applied else 0
+
+    async def _decay_loop(self) -> None:
+        if not self.config.offline_decay:
+            return
+        while not self._stopping.is_set():
+            try:
+                self._decay_tick(monotonic_now=time.monotonic())
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("decay tick failed: %s", exc)
+            await self._sleep(min(60.0, self.config.offline_decay_step_sec))
+
+    async def _sleep(self, seconds: float) -> None:
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(self._stopping.wait(), timeout=max(0.05, seconds))
+
+    # ── lifecycle ──
+
+    async def start(self) -> None:
+        if sys.platform == "win32":
+            logger.warning("wake socket unavailable on Windows; running sampler/decay only")
+        else:
+            sock = self.config.socket_path
+            sock.parent.mkdir(parents=True, exist_ok=True)
+            if sock.exists():
+                # A live daemon would be listening; a stale socket must go.
+                try:
+                    reader_writer = await asyncio.wait_for(
+                        asyncio.open_unix_connection(str(sock)), timeout=1.0
+                    )
+                    reader_writer[1].close()
+                    raise RuntimeError(f"familiard already running on {sock}")
+                except (ConnectionError, asyncio.TimeoutError, FileNotFoundError, OSError):
+                    sock.unlink(missing_ok=True)
+            self._server = await asyncio.start_unix_server(self._handle_client, path=str(sock))
+            logger.info("wake socket listening at %s", sock)
+
+        self._tasks = [
+            asyncio.create_task(self._sampler_loop(), name="familiard-sampler"),
+            asyncio.create_task(self._scheduler_loop(), name="familiard-scheduler"),
+            asyncio.create_task(self._decay_loop(), name="familiard-decay"),
+        ]
+
+    async def stop(self) -> None:
+        self._stopping.set()
+        for task in self._tasks:
+            task.cancel()
+        for task in self._tasks:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+        if self._server is not None:
+            self._server.close()
+            with contextlib.suppress(Exception):
+                await self._server.wait_closed()
+        with contextlib.suppress(Exception):
+            if sys.platform != "win32":
+                self.config.socket_path.unlink(missing_ok=True)
+        for writer in list(self._clients):
+            with contextlib.suppress(Exception):
+                writer.close()
+        self._clients.clear()
+
+    async def run_forever(self) -> None:
+        await self.start()
+        loop = asyncio.get_running_loop()
+        if sys.platform != "win32":
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                with contextlib.suppress(NotImplementedError):
+                    loop.add_signal_handler(sig, self._stopping.set)
+        await self._stopping.wait()
+        await self.stop()
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s familiard: %(message)s",
+    )
+    config = FamiliardConfig.load()
+    daemon = Familiard(config)
+    try:
+        asyncio.run(daemon.run_forever())
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/familiar_agent/gui.py
+++ b/src/familiar_agent/gui.py
@@ -1521,10 +1521,23 @@ class FamiliarWindow(QMainWindow):
 
     async def _process_queue(self) -> None:
         """Dequeue user messages and run the agent; fire desires when idle."""
+        from .wake import WakeListener, wait_input_or_wake
+
+        window_config = getattr(self, "_config", None)
+        wake_listener = WakeListener(
+            getattr(window_config, "daemon_socket", "") or None,
+            enabled=getattr(window_config, "daemon", False) is True,
+        )
         last_interaction = time.time()
         while True:
             try:
-                text = await asyncio.wait_for(self._input_queue.get(), timeout=IDLE_CHECK_INTERVAL)
+                kind, text = await wait_input_or_wake(
+                    self._input_queue, wake_listener, IDLE_CHECK_INTERVAL
+                )
+                if kind != "input":
+                    # A familiard wake takes the same path as the poll timeout:
+                    # it is only an early poll — every idle gate re-checks below.
+                    raise asyncio.TimeoutError
             except asyncio.TimeoutError:
                 now = time.time()
                 if self._closing:

--- a/src/familiar_agent/main.py
+++ b/src/familiar_agent/main.py
@@ -17,6 +17,7 @@ from .config import AgentConfig
 from .desires import DesireSystem
 from .realtime_stt_session import create_realtime_stt_session
 from .setup import run_cli_setup_wizard
+from .wake import WakeListener, wait_input_or_wake
 from ._i18n import BANNER, _t
 from ._ui_helpers import (
     DESIRE_COOLDOWN,
@@ -91,6 +92,13 @@ async def repl(agent: EmbodiedAgent, desires: DesireSystem, debug: bool = False)
     if callable(start_mcp_early):
         start_mcp_early()
 
+    # familiard wake events accelerate the idle poll when the daemon runs;
+    # disabled (the default) this changes nothing about the wait below.
+    wake_listener = WakeListener(
+        getattr(agent.config, "daemon_socket", "") or None,
+        enabled=getattr(agent.config, "daemon", False) is True,
+    )
+
     # Persistent input queue — stdin reader runs as a background task
     # so user input is captured even while the agent is busy.
     input_queue: asyncio.Queue[str | None] = asyncio.Queue()
@@ -148,15 +156,12 @@ async def repl(agent: EmbodiedAgent, desires: DesireSystem, debug: bool = False)
                     )
                 continue
 
-            # No pending input — show prompt and wait briefly
+            # No pending input — show prompt and wait briefly. A familiard
+            # wake short-circuits the wait; the idle gates below re-check
+            # everything, so a wake is never more than an early poll.
             print("\n> ", end="", flush=True)
-            queued_input: str | None
-            try:
-                queued_input = await asyncio.wait_for(
-                    input_queue.get(), timeout=IDLE_CHECK_INTERVAL
-                )
-            except asyncio.TimeoutError:
-                queued_input = None
+            kind, item = await wait_input_or_wake(input_queue, wake_listener, IDLE_CHECK_INTERVAL)
+            queued_input: str | None = item if kind == "input" else None
 
             if queued_input is None and input_queue.empty():
                 # Proactive commitment reminders fire independently of auto_desire

--- a/src/familiar_agent/tui.py
+++ b/src/familiar_agent/tui.py
@@ -251,6 +251,9 @@ class FamiliarApp(App):
         self._log_system(_t("startup", log_path=str(self._log_path)))
         self.set_interval(IDLE_CHECK_INTERVAL, self._reminder_tick)
         self.set_interval(IDLE_CHECK_INTERVAL, self._desire_tick)
+        # familiard wake events accelerate the idle ticks when the daemon runs.
+        if getattr(self.agent.config, "daemon", False) is True:
+            self.run_worker(self._wake_listener_loop(), exclusive=False)
         # Start the MCP handshake now so tools are ready by the first turn (#188).
         start_mcp_early = getattr(self.agent, "start_mcp_early", None)
         if callable(start_mcp_early):
@@ -552,6 +555,29 @@ class FamiliarApp(App):
             return
         self._last_interaction = time.time()
         await self._run_agent("", inner_voice=commitment_reminder_prompt(reminders))
+
+    async def _wake_listener_loop(self) -> None:
+        """Consume familiard wake events; each one is just an early idle tick.
+
+        The tick methods re-check every gate themselves (agent running,
+        pending input, cooldowns, quiet hours), so a wake can never bypass
+        the idle precedence contract — it only removes poll latency.
+        """
+        from .wake import WakeListener
+
+        listener = WakeListener(
+            getattr(self.agent.config, "daemon_socket", "") or None,
+            enabled=True,  # the caller gates on config.daemon
+        )
+        try:
+            while not self._closing:
+                event = await listener.wait(60.0)
+                if event is None or self._closing:
+                    continue
+                await self._reminder_tick()
+                await self._desire_tick()
+        finally:
+            listener.close()
 
     async def _desire_tick(self) -> None:
         """Check desires and fire autonomous actions when idle."""

--- a/src/familiar_agent/wake.py
+++ b/src/familiar_agent/wake.py
@@ -1,0 +1,185 @@
+"""Cortex-side client for familiard's wake socket.
+
+A wake event only *accelerates* the idle poll: whichever UI loop receives one
+runs exactly the same gate checks it would have run at its next 10-second
+tick (reminder backoff, quiet hours, auto_desire, input precedence). The
+daemon cannot know cortex-local state, so it never decides — it nudges.
+
+Degrades to nothing: when the daemon is off, absent, or the platform has no
+Unix sockets, ``wait()`` behaves like a plain timeout and the UI loops keep
+their historical polling behavior byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_SOCKET_PATH = Path.home() / ".familiar_ai" / "familiard.sock"
+_RECONNECT_MIN_SEC = 5.0
+_RECONNECT_MAX_SEC = 300.0
+
+
+@dataclass(slots=True, frozen=True)
+class WakeEvent:
+    reason: str
+    ts: float
+
+
+class WakeListener:
+    """Reads newline-delimited JSON wake events from the familiard socket.
+
+    Lazily connects on first ``wait()``; reconnects with exponential backoff
+    while the daemon is down. Safe to construct unconditionally — when
+    ``enabled`` is False every call is a cheap no-op.
+    """
+
+    def __init__(
+        self,
+        socket_path: str | Path | None = None,
+        *,
+        enabled: bool | None = None,
+    ) -> None:
+        if enabled is None:
+            enabled = os.environ.get("FAMILIAR_DAEMON", "").strip().lower() in (
+                "1",
+                "true",
+                "yes",
+                "on",
+            )
+        self._enabled = bool(enabled) and sys.platform != "win32"
+        raw_path = socket_path or os.environ.get("FAMILIAR_DAEMON_SOCKET", "").strip() or None
+        self._path = Path(raw_path).expanduser() if raw_path else _DEFAULT_SOCKET_PATH
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._next_connect_at = 0.0
+        self._backoff = _RECONNECT_MIN_SEC
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def connected(self) -> bool:
+        return self._reader is not None and not self._reader.at_eof()
+
+    async def _try_connect(self) -> bool:
+        if self.connected:
+            return True
+        now = time.monotonic()
+        if now < self._next_connect_at:
+            return False
+        try:
+            self._reader, self._writer = await asyncio.wait_for(
+                asyncio.open_unix_connection(str(self._path)), timeout=1.0
+            )
+            self._backoff = _RECONNECT_MIN_SEC
+            logger.info("connected to familiard at %s", self._path)
+            return True
+        except (ConnectionError, FileNotFoundError, OSError, asyncio.TimeoutError):
+            self._reader = None
+            self._writer = None
+            self._next_connect_at = now + self._backoff
+            self._backoff = min(self._backoff * 2, _RECONNECT_MAX_SEC)
+            return False
+
+    async def wait(self, timeout: float) -> WakeEvent | None:
+        """Wait up to ``timeout`` seconds for one wake event.
+
+        Returns None on timeout, when disabled, or while the daemon is
+        unreachable — indistinguishable from a plain idle-poll timeout,
+        which is exactly the degradation contract.
+        """
+        if not self._enabled:
+            await asyncio.sleep(timeout)
+            return None
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            if not await self._try_connect():
+                await asyncio.sleep(min(remaining, 1.0))
+                continue
+            assert self._reader is not None
+            try:
+                line = await asyncio.wait_for(self._reader.readline(), timeout=remaining)
+            except asyncio.TimeoutError:
+                return None
+            except (ConnectionError, OSError):
+                self._drop_connection()
+                continue
+            if not line:  # EOF — daemon went away
+                self._drop_connection()
+                continue
+            try:
+                payload = json.loads(line.decode("utf-8"))
+            except Exception:  # noqa: BLE001
+                continue
+            if isinstance(payload, dict) and payload.get("type") == "wake":
+                return WakeEvent(
+                    reason=str(payload.get("reason", "unknown")),
+                    ts=float(payload.get("ts", time.time())),
+                )
+
+    def _drop_connection(self) -> None:
+        if self._writer is not None:
+            with contextlib.suppress(Exception):
+                self._writer.close()
+        self._reader = None
+        self._writer = None
+
+    def close(self) -> None:
+        self._drop_connection()
+
+
+async def wait_input_or_wake(
+    input_queue: asyncio.Queue,
+    wake: WakeListener | None,
+    timeout: float,
+) -> tuple[str, Any]:
+    """Wait for user input, a wake event, or the poll timeout — in that order.
+
+    Returns ``(kind, item)`` with kind in {"input", "wake", "timeout"}.
+    "input" carries the dequeued item verbatim — including a queue's None
+    shutdown sentinel, which must stay distinguishable from a timeout. With
+    no listener (or a disabled one) this is exactly
+    ``wait_for(queue.get(), timeout)`` — the historical idle-poll behavior.
+    """
+    if wake is None or not wake.enabled:
+        try:
+            item = await asyncio.wait_for(input_queue.get(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return "timeout", None
+        return "input", item
+
+    queue_task = asyncio.ensure_future(input_queue.get())
+    wake_task = asyncio.ensure_future(wake.wait(timeout))
+    try:
+        done, _ = await asyncio.wait(
+            {queue_task, wake_task},
+            timeout=timeout,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        # Input wins whenever both raced to completion (idle precedence).
+        if queue_task in done:
+            return "input", queue_task.result()
+        if wake_task in done and wake_task.result() is not None:
+            return "wake", wake_task.result()
+        return "timeout", None
+    finally:
+        for task in (queue_task, wake_task):
+            if not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await task

--- a/tests/test_familiard.py
+++ b/tests/test_familiard.py
@@ -1,0 +1,319 @@
+"""familiard body daemon — config, sampler, scheduler, decay, wake socket.
+
+The daemon's contract: read-only toward cortex-owned state (desires.json,
+commitments.db), writes only its own payload + the offline self-state settle,
+and wake events are nudges — every behavioral gate stays in the cortex.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import sys
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from familiar_agent.familiard import (
+    BandSchedulerState,
+    Familiard,
+    FamiliardConfig,
+    _parse_bands,
+    apply_offline_settle,
+    build_interoception_payload,
+    decide_band_pulse,
+    read_desire_pressure,
+    read_due_commitments,
+)
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def test_parse_bands_valid_and_garbage():
+    assert _parse_bands("07:00-09:00,18:30-24:00") == [(420, 540), (1110, 1440)]
+    assert _parse_bands("") == []
+    assert _parse_bands("garbage,25:00-26:00,09:00-08:00") == []
+
+
+def test_config_load_from_file_with_env_override(tmp_path: Path, monkeypatch):
+    conf = tmp_path / "familiard.conf"
+    conf.write_text(
+        "\n".join(
+            [
+                "# comment",
+                "band_interval_sec = 600",
+                "active_bands = 08:00-10:00",
+                "offband_chance_day = 0.25",
+                "offline_decay = off",
+            ]
+        )
+    )
+    monkeypatch.setenv("FAMILIARD_BAND_INTERVAL_SEC", "300")
+    cfg = FamiliardConfig.load(conf)
+    assert cfg.band_interval_sec == 300.0  # env beats file
+    assert cfg.active_bands == [(480, 600)]
+    assert cfg.offband_chance_day == 0.25
+    assert cfg.offline_decay is False
+
+
+def test_config_defaults_without_file(tmp_path: Path):
+    cfg = FamiliardConfig.load(tmp_path / "missing.conf")
+    assert cfg.sample_interval_sec == 10.0
+    assert cfg.active_bands  # non-empty defaults
+
+
+# ---------------------------------------------------------------------------
+# Interoception payload
+# ---------------------------------------------------------------------------
+
+
+def test_payload_roundtrips_through_mcp_provider(tmp_path: Path):
+    """The daemon's payload must be consumable by the cortex's existing
+    MCPInteroceptionProvider with zero cortex changes."""
+    from familiar_neighbor.mind.interoception import MCPInteroceptionProvider
+
+    payload = build_interoception_payload(
+        cpu_load=0.5,
+        mem_free=0.6,
+        now=datetime.now().astimezone(),
+        quiet_start=23,
+        quiet_end=7,
+    )
+    path = tmp_path / "interoception.json"
+    path.write_text(json.dumps(payload))
+
+    signal = MCPInteroceptionProvider(path).collect()
+    assert signal.provider == "mcp"
+    assert 0.0 <= signal.energy <= 1.0
+    assert 0.0 <= signal.cognitive_load <= 1.0
+    assert signal.raw_metrics["cpu_load_fraction"] == pytest.approx(0.5)
+
+
+def test_payload_quiet_hours_wrap_midnight():
+    payload_night = build_interoception_payload(
+        cpu_load=0.1,
+        mem_free=0.8,
+        now=datetime.now().astimezone().replace(hour=2),
+        quiet_start=23,
+        quiet_end=7,
+    )
+    payload_day = build_interoception_payload(
+        cpu_load=0.1,
+        mem_free=0.8,
+        now=datetime.now().astimezone().replace(hour=14),
+        quiet_start=23,
+        quiet_end=7,
+    )
+    assert payload_night["signal"]["quiet_hours"] is True
+    assert payload_day["signal"]["quiet_hours"] is False
+    assert payload_night["signal"]["energy"] < payload_day["signal"]["energy"]
+
+
+def test_stale_payload_rejected_fresh_accepted(tmp_path: Path):
+    """Staleness gating still works end-to-end (45s default in the provider)."""
+    from familiar_neighbor.mind.interoception import MCPInteroceptionProvider
+
+    payload = build_interoception_payload(
+        cpu_load=0.2,
+        mem_free=0.5,
+        now=datetime.now().astimezone(),
+        quiet_start=23,
+        quiet_end=7,
+    )
+    payload["signal"]["observed_at"] = "2020-01-01T00:00:00+00:00"
+    path = tmp_path / "interoception.json"
+    path.write_text(json.dumps(payload))
+    assert MCPInteroceptionProvider(path).collect().provider == "noop"
+
+
+# ---------------------------------------------------------------------------
+# Band scheduler
+# ---------------------------------------------------------------------------
+
+
+def _cfg(**kw) -> FamiliardConfig:
+    cfg = FamiliardConfig()
+    for key, value in kw.items():
+        setattr(cfg, key, value)
+    return cfg
+
+
+def _at(hour: int, minute: int = 0) -> datetime:
+    return datetime(2026, 7, 2, hour, minute, 0)
+
+
+def test_band_pulse_fires_on_interval_inside_band():
+    cfg = _cfg(active_bands=[(8 * 60, 10 * 60)], band_interval_sec=100.0)
+    state = BandSchedulerState()
+    rng = random.Random(0)
+
+    assert decide_band_pulse(config=cfg, state=state, now=_at(8), monotonic_now=1000.0, rng=rng)
+    # 50s later: not yet.
+    assert not decide_band_pulse(
+        config=cfg, state=state, now=_at(8, 1), monotonic_now=1050.0, rng=rng
+    )
+    # 100s after the first: fires again.
+    assert decide_band_pulse(config=cfg, state=state, now=_at(8, 2), monotonic_now=1100.0, rng=rng)
+
+
+def test_offband_rolls_once_per_hour_with_day_night_chance():
+    cfg = _cfg(
+        active_bands=[(8 * 60, 9 * 60)],
+        offband_chance_day=1.0,
+        offband_chance_night=0.0,
+        night_start_hour=0,
+        night_end_hour=7,
+    )
+    state = BandSchedulerState()
+    rng = random.Random(0)
+
+    # Daytime off-band with chance 1.0: first check of the hour fires...
+    assert decide_band_pulse(config=cfg, state=state, now=_at(14), monotonic_now=0.0, rng=rng)
+    # ...but not twice within the same hour.
+    assert not decide_band_pulse(
+        config=cfg, state=state, now=_at(14, 30), monotonic_now=10.0, rng=rng
+    )
+    # Night hour with chance 0.0: never fires.
+    assert not decide_band_pulse(config=cfg, state=state, now=_at(3), monotonic_now=20.0, rng=rng)
+
+
+# ---------------------------------------------------------------------------
+# Read-only cortex-state probes
+# ---------------------------------------------------------------------------
+
+
+def test_desire_pressure_threshold(tmp_path: Path):
+    path = tmp_path / "desires.json"
+    path.write_text(json.dumps({"desires": {"curiosity": 0.3, "reflect": 0.2}}))
+    assert read_desire_pressure(path) is False
+    path.write_text(json.dumps({"desires": {"curiosity": 0.7}}))
+    assert read_desire_pressure(path) is True
+    assert read_desire_pressure(tmp_path / "missing.json") is False
+    (tmp_path / "garbage.json").write_text("not json")
+    assert read_desire_pressure(tmp_path / "garbage.json") is False
+
+
+def test_due_commitments_read_only_probe(tmp_path: Path):
+    """The daemon reads the real store's DB (created by the store itself)
+    without ever opening a write connection."""
+    from familiar_runtime.commitments.store import SQLiteCommitmentStore
+
+    db = tmp_path / "commitments.db"
+    store = SQLiteCommitmentStore(db)
+    now = time.time()
+    assert read_due_commitments(db, now=now) is False
+
+    store.create(summary="water the plants", due_at=now - 60)
+    assert read_due_commitments(db, now=now) is True
+
+    # Missing DB → quietly False, never an error.
+    assert read_due_commitments(tmp_path / "nope.db", now=now) is False
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# Offline self-state decay
+# ---------------------------------------------------------------------------
+
+
+def test_offline_settle_moves_toward_baseline(tmp_path: Path):
+    path = tmp_path / "self_state.json"
+    path.write_text(json.dumps({"arousal": 0.9, "unresolved_tension": 0.8, "fatigue": 0.2}))
+
+    assert apply_offline_settle(path, steps=3) is True
+    values = json.loads(path.read_text())
+    # arousal decays toward baseline 0.35, tension toward 0.2.
+    assert 0.35 < values["arousal"] < 0.9
+    assert 0.2 < values["unresolved_tension"] < 0.8
+    # fatigue already at baseline: unchanged.
+    assert values["fatigue"] == pytest.approx(0.2)
+
+
+def test_offline_settle_noops_safely(tmp_path: Path):
+    assert apply_offline_settle(tmp_path / "missing.json", steps=5) is False
+    path = tmp_path / "self_state.json"
+    path.write_text(json.dumps({"arousal": 0.35}))
+    assert apply_offline_settle(path, steps=0) is False
+    path.write_text("not json")
+    assert apply_offline_settle(path, steps=2) is False
+
+
+# ---------------------------------------------------------------------------
+# Wake socket (POSIX only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix sockets unavailable on Windows")
+@pytest.mark.asyncio
+async def test_wake_roundtrip_daemon_to_listener():
+    """Daemon emits → WakeListener receives; rate limit collapses repeats."""
+    from familiar_agent.wake import WakeListener
+
+    # AF_UNIX paths are length-limited (~104 bytes); pytest tmp_path can
+    # exceed that, so use a short mkdtemp under /tmp.
+    short_dir = Path(tempfile.mkdtemp(prefix="fam-", dir="/tmp"))
+    cfg = FamiliardConfig()
+    cfg.socket_path = short_dir / "familiard.sock"
+    cfg.interoception_path = short_dir / "interoception.json"
+    cfg.self_state_path = short_dir / "self_state.json"
+    cfg.desires_path = short_dir / "desires.json"
+    cfg.commitments_db_path = short_dir / "commitments.db"
+    cfg.reminder_wake_cooldown_sec = 0.05
+
+    daemon = Familiard(cfg)
+    await daemon.start()
+    try:
+        listener = WakeListener(cfg.socket_path, enabled=True)
+        # Establish the connection (no event yet → returns None on timeout).
+        assert await listener.wait(0.3) is None
+        assert daemon.client_count == 1
+
+        daemon._emit_wake("reminder")
+        event = await listener.wait(2.0)
+        assert event is not None and event.reason == "reminder"
+
+        # Within the cooldown the second emit is swallowed.
+        daemon._emit_wake("reminder")
+        daemon._emit_wake("reminder")
+        first = await listener.wait(0.5)
+        second = await listener.wait(0.3)
+        assert (first is None) or (second is None)
+
+        listener.close()
+    finally:
+        await daemon.stop()
+    assert not cfg.socket_path.exists()  # socket cleaned up
+
+
+def test_decay_tick_gated_on_connected_cortex(tmp_path: Path):
+    """No settle while a cortex is connected (or within grace); steps apply
+    only after real offline wall-clock has accumulated."""
+    cfg = _cfg(
+        self_state_path=tmp_path / "self_state.json",
+        offline_grace_sec=60.0,
+        offline_decay_step_sec=600.0,
+    )
+    cfg.self_state_path.write_text(json.dumps({"arousal": 0.9}))
+    daemon = Familiard(cfg)
+
+    # A connected cortex pins the decay clock: no steps, clock tracks along.
+    daemon._clients.add(object())  # type: ignore[arg-type]
+    daemon._last_client_seen = 0.0
+    daemon._last_decay_applied = 0.0
+    assert daemon._decay_tick(monotonic_now=10_000.0) == 0
+    assert daemon._last_decay_applied == 10_000.0
+
+    # Disconnected but within grace: still nothing.
+    daemon._clients.clear()
+    daemon._last_client_seen = 10_000.0
+    assert daemon._decay_tick(monotonic_now=10_030.0) == 0
+
+    # Past grace with 2 step-intervals of offline time: 2 settle steps apply.
+    steps = daemon._decay_tick(monotonic_now=11_260.0)
+    assert steps == 2
+    assert json.loads(cfg.self_state_path.read_text())["arousal"] < 0.9

--- a/tests/test_wake.py
+++ b/tests/test_wake.py
@@ -1,0 +1,115 @@
+"""WakeListener + wait_input_or_wake — precedence and degradation contracts.
+
+The invariants pinned here: input always beats wake; a wake is
+indistinguishable from an early poll (kind only, no side effects); a missing
+or disabled daemon leaves the historical wait_for(queue.get(), timeout)
+behavior fully intact — including the None shutdown sentinel staying
+distinguishable from a timeout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from familiar_agent.wake import WakeListener, wait_input_or_wake
+
+
+@pytest.mark.asyncio
+async def test_disabled_listener_behaves_like_plain_timeout():
+    queue: asyncio.Queue = asyncio.Queue()
+    listener = WakeListener(enabled=False)
+
+    kind, item = await wait_input_or_wake(queue, listener, 0.05)
+    assert (kind, item) == ("timeout", None)
+
+    await queue.put("hello")
+    kind, item = await wait_input_or_wake(queue, listener, 0.05)
+    assert (kind, item) == ("input", "hello")
+
+
+@pytest.mark.asyncio
+async def test_none_sentinel_stays_distinguishable_from_timeout():
+    """The queue's None shutdown sentinel must arrive as kind='input'."""
+    queue: asyncio.Queue = asyncio.Queue()
+    await queue.put(None)
+    kind, item = await wait_input_or_wake(queue, None, 0.05)
+    assert kind == "input"
+    assert item is None
+
+
+@pytest.mark.asyncio
+async def test_no_listener_argument_is_plain_wait():
+    queue: asyncio.Queue = asyncio.Queue()
+    kind, item = await wait_input_or_wake(queue, None, 0.05)
+    assert (kind, item) == ("timeout", None)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix sockets unavailable on Windows")
+@pytest.mark.asyncio
+async def test_enabled_listener_missing_socket_degrades_to_timeout():
+    """Daemon enabled but not running: wait() must degrade to a timeout."""
+    missing = Path(tempfile.mkdtemp(prefix="fam-", dir="/tmp")) / "nope.sock"
+    queue: asyncio.Queue = asyncio.Queue()
+    listener = WakeListener(missing, enabled=True)
+
+    kind, item = await wait_input_or_wake(queue, listener, 0.3)
+    assert (kind, item) == ("timeout", None)
+
+    # Input still wins while the connection keeps failing.
+    await queue.put("typed")
+    kind, item = await wait_input_or_wake(queue, listener, 0.3)
+    assert (kind, item) == ("input", "typed")
+    listener.close()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix sockets unavailable on Windows")
+@pytest.mark.asyncio
+async def test_wake_event_reported_and_input_beats_wake():
+    """A pushed wake surfaces as kind='wake'; racing input takes precedence."""
+    short_dir = Path(tempfile.mkdtemp(prefix="fam-", dir="/tmp"))
+    sock = short_dir / "wake.sock"
+
+    writers: list[asyncio.StreamWriter] = []
+
+    async def _on_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        writers.append(writer)
+        while not reader.at_eof():
+            data = await reader.read(64)
+            if not data:
+                break
+
+    server = await asyncio.start_unix_server(_on_client, path=str(sock))
+    try:
+        queue: asyncio.Queue = asyncio.Queue()
+        listener = WakeListener(sock, enabled=True)
+
+        # Connect (first wait times out with no event).
+        assert await listener.wait(0.2) is None
+        assert writers
+
+        writers[0].write(b'{"type": "wake", "reason": "reminder", "ts": 1.0}\n')
+        kind, event = await wait_input_or_wake(queue, listener, 2.0)
+        assert kind == "wake"
+        assert event.reason == "reminder"
+
+        # Input queued before the call wins over a simultaneous wake.
+        await queue.put("user says hi")
+        writers[0].write(b'{"type": "wake", "reason": "desire", "ts": 2.0}\n')
+        kind, item = await wait_input_or_wake(queue, listener, 2.0)
+        assert (kind, item) == ("input", "user says hi")
+
+        # Garbage lines are skipped, valid events still arrive.
+        writers[0].write(b"not json\n")
+        writers[0].write(b'{"type": "wake", "reason": "band_tick", "ts": 3.0}\n')
+        event2 = await listener.wait(2.0)
+        assert event2 is not None and event2.reason == "band_tick"
+
+        listener.close()
+    finally:
+        server.close()
+        await server.wait_closed()


### PR DESCRIPTION
## Summary

**Loop 0 of the three-timescale nervous system** (PR2 of the selfhood roadmap, after #189): `familiard` is an always-on body process that keeps living between and without cortex sessions — zero LLM calls, a few hertz. This is the substrate that makes between-turn existence real without paying a frontier-model turn per heartbeat tick.

```bash
uv run familiard             # the body
FAMILIAR_DAEMON=1 ./run.sh   # the app feels it and wakes on its nudges
```

## What the daemon owns

- **Interoception sampling** — CPU / memory / time-of-day → semantic body signal (energy, cognitive load, stress), written where `MCPInteroceptionProvider` already reads. Zero cortex code for consumption; with `FAMILIAR_DAEMON=1` the cortex auto-adopts the payload (staleness-gated, Runtime fallback intact).
- **Wake scheduling** — due commitments (SQLite **read-only URI mode**), desire pressure (**read-only** `desires.json`), and schedule-band pulses (active bands + probabilistic off-band with day/night chances, kokone-style) become wake events over a Unix socket. **A wake only accelerates the idle poll**: every behavioral gate (reminder backoff/caps, quiet hours, `auto_desire`, input precedence) re-checks in the cortex. The daemon never decides — it nudges.
- **Offline affect decay** — `self_state.json` settles toward baseline on wall-clock time **only while no cortex is connected** (grace period): feelings fade during sleep instead of freezing mid-emotion.

## Hard constraints (from the roadmap stress-test)

- Never writes `desires.json` (18 cortex-side write sites, non-atomic saver — two writers would corrupt; ownership transfer is explicit follow-up work).
- Never opens `observations.db` (single connection, no busy_timeout).
- EventBus is not used for IPC (it's in-process pub/sub) — the Unix socket is the wake path; wake slots don't burn while nobody listens.

## Cortex side

`familiar_agent/wake.py`: `WakeListener` (lazy connect, exponential backoff, EOF-safe) + `wait_input_or_wake()` returning `(kind, item)` so the queue's `None` shutdown sentinel stays distinguishable from a timeout. Wired into all three idle loops with minimal diffs (REPL/GUI wait swap; TUI wake worker reusing the tick methods). **Default OFF** — without `FAMILIAR_DAEMON=1` the idle loops keep their historical polling behavior byte-for-byte.

## Testing

- 19 new tests: config/bands parsing, band scheduler decisions (injected clock+rng), interoception payload **roundtrip through the real `MCPInteroceptionProvider`**, staleness gating, desire-pressure and commitments-due read-only probes (against a store-created DB), offline-settle math + connected-cortex gating, wake socket roundtrip + rate limiting (POSIX), input-beats-wake precedence, sentinel-vs-timeout distinction, missing-daemon degradation. Windows: socket tests skipped; sampler/decay paths platform-guarded.
- Live smoke: real `familiard` process → `WakeEvent(reason='desire')` delivered to a real listener, payload consumed (`provider=mcp`), SIGTERM → clean exit, socket removed.
- Full gate: **1328 passed**, ruff check/format clean, mypy clean (126 files).

## Next in series

PR3 self-ledger (persisted attention/meta, `who_am_i`, compaction recovery ritual); later increments move desire write-ownership into the daemon (outbox pattern) and add headless cortex launch on wake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)