### PR TITLE
feat(mind): self-ledger — persisted attention/meta, who_am_i, shift ledger, recovery ritual

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,9 @@ Primary stores under `~/.familiar_ai/`:
 - `self_state.json` — latent bodily carryover
 - `identity_state.json` — identity dissonance ledger (decay + reflection relief)
 - `identity_seed.json` — persona identity seed (operator-supplied; insert-if-missing)
+- `attention_state.json` — attention-schema focus history (survives restarts)
+- `meta_state.json` — previous session's distilled metacognitive summary (the raw
+  MetaMonitor step window is deliberately session-scoped and never persisted)
 - `relationship.json` — legacy; imported once if present, then SQLite is authoritative
 
 **Every schema change must add a timestamped migration under `migration/`**

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -71,6 +71,7 @@ from .tools.commitments import (
 )
 from .tools.delegation import DelegatedTaskRunner, DelegationTool
 from .tools.identity import IdentityTool
+from .tools.self_ledger import SelfLedgerTool
 from familiar_neighbor.mind.identity import IdentityCore
 from .tools.memory import MemoryTool, ObservationMemory
 from .tools.tom import ToMTool
@@ -88,6 +89,7 @@ from familiar_capabilities import (
     MCPCapability,
     MemoryCapability,
     MobilityCapability,
+    SelfLedgerCapability,
     ToMCapability,
     VoiceCapability,
 )
@@ -579,6 +581,10 @@ class EmbodiedAgent:
         self._session_output_tokens: int = 0
         self._last_context_tokens: int = 0
         self._post_compact: bool = False
+        # Separate from _post_compact (which tunes recall depth and resets on
+        # the very next prepare_turn): the recovery block waits for the next
+        # non-brief turn so it is never consumed invisibly by a brief reply.
+        self._post_compact_recovery_pending: bool = False
         self._coherence_retried: bool = False
 
         self._camera: CameraTool | None = None
@@ -635,9 +641,15 @@ class EmbodiedAgent:
         self._workspace = GlobalWorkspace()
         self._workspace.register_broadcast_listener(self._self_state.on_broadcast)
         self._prediction = PredictionEngine()
-        self._attention_schema = AttentionSchema()
+        # Self-ledger: attention history and the previous session's
+        # metacognitive summary survive restarts (JSON state files, same
+        # idiom as identity_state.json).
+        _state_dir = Path.home() / ".familiar_ai"
+        self._attention_schema = AttentionSchema(state_path=_state_dir / "attention_state.json")
         self._dmn = DefaultModeProcessor(self._memory)
-        self._meta_monitor = MetaMonitor()
+        self._meta_monitor = MetaMonitor(state_path=_state_dir / "meta_state.json")
+        self._self_ledger_tool = SelfLedgerTool(self)
+        self._constitution_block: str | None = None  # rendered once per session
         self._appraisal = AppraisalEngine()
         self._social_policy = SocialPolicyEngine()
         self._mental_state_bus = MentalStateBus()
@@ -1021,6 +1033,9 @@ class EmbodiedAgent:
         identity_tool = getattr(self, "_identity_tool", None)
         if identity_tool is not None:
             registry.register(IdentityCapability(identity_tool))
+        self_ledger_tool = getattr(self, "_self_ledger_tool", None)
+        if self_ledger_tool is not None:
+            registry.register(SelfLedgerCapability(self_ledger_tool))
         if self._mcp:
             provider = MCPCapability(self._mcp)
             registry.register(provider)
@@ -1207,6 +1222,87 @@ class EmbodiedAgent:
         body_inner = "\n".join(parts)
         return f"(body\n{body_inner})"
 
+    def _self_ledger_carryover_context(self) -> str:
+        """First-turn carryover: last session's metacognitive thread plus
+        corrected interpretations, so a restart resumes a self, not a blank."""
+        lines: list[str] = []
+        meta = getattr(self, "_meta_monitor", None)
+        previous = getattr(meta, "previous_session_summary", None)
+        if callable(previous):
+            carried = previous()
+            if carried:
+                lines.append(f"[Last session's metacognitive thread]\n{carried}")
+        recall = getattr(getattr(self, "_memory", None), "recall_interpretation_shifts", None)
+        if callable(recall):
+            try:
+                shifts = recall(n=3)
+            except Exception:  # noqa: BLE001
+                shifts = []
+            if shifts:
+                shift_lines = ["[Interpretation shifts — corrections that must not regress]"]
+                shift_lines.extend(
+                    f'- {s["entity_key"]}: now read as "{s["new_text"][:120]}"' for s in shifts
+                )
+                lines.append("\n".join(shift_lines))
+        return "\n\n".join(lines)
+
+    def _post_compact_recovery_context(self) -> str:
+        """Re-anchor right after context compaction.
+
+        Ordering is deliberate — constitution before memory: the identity
+        block lives in the stable prompt half above; this block reminds the
+        model that what was condensed does not include who it is, and
+        re-surfaces corrected interpretations so compaction cannot silently
+        roll them back.
+        """
+        lines = [
+            "[Post-compaction recovery] Earlier turns were just condensed into a "
+            "summary. Who you are did not change: your persona and constitution "
+            "above still hold. If anything feels blurry, call who_am_i."
+        ]
+        recall = getattr(getattr(self, "_memory", None), "recall_interpretation_shifts", None)
+        if callable(recall):
+            try:
+                shifts = recall(n=3)
+            except Exception:  # noqa: BLE001
+                shifts = []
+            lines.extend(
+                f"- Corrected reading ({s['entity_key']}): {s['new_text'][:120]}" for s in shifts
+            )
+        return "\n".join(lines)
+
+    def _identity_constitution_block(self) -> str:
+        """Render identity assertions for the stable prompt half, once per session.
+
+        Rendered lazily and cached for the process lifetime so the stable half
+        stays byte-identical across turns (prompt caching). Values the agent
+        commits mid-session already act immediately through IdentityCore's
+        checkers and coalitions; they join the rendered constitution on the
+        next session, like ME.md edits.
+        """
+        cached = getattr(self, "_constitution_block", None)
+        if cached is not None:
+            return cached
+        identity = getattr(self, "_identity", None)
+        if identity is None:
+            self._constitution_block = ""
+            return ""
+        try:
+            assertions = identity.assertions()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Constitution render failed: %s", exc)
+            self._constitution_block = ""
+            return ""
+        if not assertions:
+            self._constitution_block = ""
+            return ""
+        lines = ["[Constitution — what I hold, in my own words]"]
+        for a in sorted(assertions, key=lambda a: (not a.non_negotiable, -a.confidence)):
+            marker = " (non-negotiable)" if a.non_negotiable else ""
+            lines.append(f"- ({a.kind}) {a.statement}{marker}")
+        self._constitution_block = "\n".join(lines)
+        return self._constitution_block
+
     def _system_prompt(
         self,
         feelings_ctx: str = "",
@@ -1220,8 +1316,9 @@ class EmbodiedAgent:
     ) -> tuple[str, str]:
         """Return (stable, variable) system prompt parts for prompt caching.
 
-        stable  — ME.md + core rules; never changes within a session.
-                  AnthropicBackend marks this block with cache_control.
+        stable  — ME.md + core rules + identity constitution; never changes
+                  within a session. AnthropicBackend marks this block with
+                  cache_control.
         variable — interoception, feelings, inner voice, plan; changes every turn.
         """
         base = assemble_neighbor_system_prompt(max_steps=MAX_ITERATIONS)
@@ -1229,7 +1326,11 @@ class EmbodiedAgent:
         body_desc = self._get_body_description()
         base = re.sub(r"\(body.*?\)", body_desc, base, flags=re.DOTALL)
 
-        stable_parts = [p for p in [self._me_md, base] if p]
+        # Constitution before memory: identity assertions join the STABLE half
+        # (rendered once per session — keeps prompt caching intact; live
+        # dissonance state stays in the variable half via mental_ctx).
+        constitution = self._identity_constitution_block()
+        stable_parts = [p for p in [self._me_md, base, constitution] if p]
         stable = "\n\n---\n\n".join(stable_parts)
 
         agent_mood, agent_mood_intensity = self._decayed_mood()
@@ -1620,6 +1721,7 @@ class EmbodiedAgent:
             asyncio.to_thread(self._prediction.as_coalition),
             asyncio.to_thread(self._attention_schema.as_coalition),
             asyncio.to_thread(self._meta_monitor.as_coalition),
+            asyncio.to_thread(self._meta_inconsistency_coalition),
         ]
         if self._scene is not None:
             sync_tasks.append(asyncio.to_thread(self._scene.as_coalition))
@@ -1660,6 +1762,36 @@ class EmbodiedAgent:
 
         others = [c for c in coalitions if c is not winner]
         return CompeteResult(winner=winner, others=others, coalitions=coalitions)
+
+    def _meta_inconsistency_coalition(self):
+        """Self-inconsistency as a workspace voice.
+
+        MetaMonitor.detect_inconsistency existed but nothing consumed it —
+        the check silently evaporated. When recent behavior contradicts the
+        self-narrative, the mismatch now competes for attention with real
+        urgency, so the agent can notice the contradiction.
+        """
+        meta = getattr(self, "_meta_monitor", None)
+        narrative = getattr(self, "_self_narrative", None)
+        if meta is None or narrative is None:
+            return None
+        try:
+            mismatch = meta.detect_inconsistency(narrative)
+        except Exception:  # noqa: BLE001
+            return None
+        # Strict str check: mocked monitors in tests return truthy non-strings.
+        if not isinstance(mismatch, str) or not mismatch:
+            return None
+        from .workspace import Coalition as _Coalition
+
+        return _Coalition(
+            source="meta",
+            summary="behavior/narrative mismatch",
+            activation=0.5,
+            urgency=0.5,
+            novelty=0.6,
+            context_block=f"[meta — inconsistency] {mismatch}",
+        )
 
     async def _gather_workspace_context(
         self,
@@ -2499,6 +2631,7 @@ class EmbodiedAgent:
 
         self.messages = [summary_marker] + list(recent)
         self._post_compact = True
+        self._post_compact_recovery_pending = True
 
     @property
     def is_embedding_ready(self) -> bool:

--- a/src/familiar_agent/tools/memory.py
+++ b/src/familiar_agent/tools/memory.py
@@ -1262,6 +1262,45 @@ class ObservationMemory:
             logger.warning("Failed to recall revisions: %s", e)
             return []
 
+    # ── Interpretation shifts (self-ledger) ────────────────────────────────
+    # Anti-regression ledger: "I used to read X as A; now I read it as B."
+    # Rides the generic memory_revisions table with a dedicated entity_type,
+    # so corrected interpretations survive restarts and compaction and can be
+    # re-surfaced before the agent regresses to already-corrected behavior.
+
+    _INTERPRETATION_ENTITY = "interpretation"
+
+    def record_interpretation_shift(
+        self,
+        *,
+        topic: str,
+        previous_reading: str,
+        new_reading: str,
+        reason: str = "self_correction",
+    ) -> None:
+        """Persist one interpretation shift (never raises)."""
+        try:
+            with self._db_lock:
+                db = self._ensure_connected()
+                self._insert_revision_locked(
+                    db,
+                    self._INTERPRETATION_ENTITY,
+                    topic[:120],
+                    previous_reading,
+                    new_reading,
+                    0.0,
+                    1.0,
+                    None,
+                    reason=reason,
+                )
+                db.commit()
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Failed to record interpretation shift: %s", e)
+
+    def recall_interpretation_shifts(self, n: int = 5) -> list[dict]:
+        """Most recent interpretation shifts, newest first."""
+        return self.recall_revisions(entity_type=self._INTERPRETATION_ENTITY, n=n)
+
     def save_with_id(
         self,
         content: str,

--- a/src/familiar_agent/tools/self_ledger.py
+++ b/src/familiar_agent/tools/self_ledger.py
@@ -1,0 +1,231 @@
+"""Self-ledger tools — who_am_i and note_interpretation_shift.
+
+``who_am_i`` renders the agent's constitution and current self-state as one
+coherent first-person answer. The design bet (borrowed from the reference
+persona deployment): prompt text drifts, gets compacted, or is silently
+overwritten — but *the act of asking a tool* re-anchors identity reliably.
+After a compaction, a restart, or a moment of doubt, one call rebuilds
+"who I am" from load-bearing state instead of from luck.
+
+``note_interpretation_shift`` writes the anti-regression ledger: when the
+agent discovers it had been reading something wrong ("I treated Kouta's
+short replies as annoyance; they're just focus"), the correction is recorded
+so future sessions re-surface it instead of regressing to corrected behavior.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_WHO_AM_I_DEF = {
+    "name": "who_am_i",
+    "description": (
+        "Re-anchor your identity: returns your constitution (values, boundaries, "
+        "self-commitments) and your current self-state (drives, concerns, attention, "
+        "recent interpretation shifts) as one first-person summary. Call it after "
+        "context compaction, on waking, or whenever who-you-are feels blurry."
+    ),
+    "input_schema": {"type": "object", "properties": {}, "required": []},
+}
+
+_NOTE_SHIFT_DEF = {
+    "name": "note_interpretation_shift",
+    "description": (
+        "Record that you corrected an interpretation: how you used to read "
+        "something, and how you read it now. Future sessions re-surface these "
+        "so you don't regress to already-corrected readings."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "topic": {"type": "string", "description": "What the interpretation is about"},
+            "previous_reading": {"type": "string", "description": "How you used to read it"},
+            "new_reading": {"type": "string", "description": "How you read it now"},
+            "reason": {"type": "string", "description": "What prompted the correction"},
+        },
+        "required": ["topic", "previous_reading", "new_reading"],
+    },
+}
+
+
+class SelfLedgerTool:
+    """Reads the federation of self-state silos and answers as one voice.
+
+    Holds the agent reference (the same pattern as EmbodiedAgentHook) because
+    "who am I" spans components no single store owns: identity assertions,
+    dissonance, drives, concerns, attention history, metacognitive carryover,
+    narrative thread, interpretation shifts. Every access is getattr-guarded
+    so a partially-constructed agent degrades to a shorter answer.
+    """
+
+    def __init__(self, agent: Any) -> None:
+        self._agent = agent
+
+    def get_tool_definitions(self) -> list[dict]:
+        return [_WHO_AM_I_DEF, _NOTE_SHIFT_DEF]
+
+    async def call(self, name: str, tool_input: dict) -> tuple[str, None]:
+        if name == "who_am_i":
+            return self._who_am_i(), None
+        if name == "note_interpretation_shift":
+            return self._note_shift(tool_input), None
+        return f"Error: unknown self-ledger tool '{name}'", None
+
+    # ── who_am_i ────────────────────────────────────────────────────────────
+
+    def _who_am_i(self) -> str:
+        sections: list[str] = []
+        constitution = self._render_constitution()
+        if constitution:
+            sections.append(constitution)
+        state = self._render_current_state()
+        if state:
+            sections.append(state)
+        shifts = self._render_shifts()
+        if shifts:
+            sections.append(shifts)
+        if not sections:
+            return (
+                "No identity state is recorded yet — who I am so far lives in "
+                "my persona file and my memories."
+            )
+        return "\n\n".join(sections)
+
+    def _render_constitution(self) -> str:
+        identity = getattr(self._agent, "_identity", None)
+        if identity is None:
+            return ""
+        try:
+            assertions = identity.assertions()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("who_am_i: constitution unavailable: %s", exc)
+            return ""
+        if not assertions:
+            return ""
+        by_kind: dict[str, list[str]] = {}
+        for a in sorted(assertions, key=lambda a: (not a.non_negotiable, -a.confidence)):
+            marker = " (non-negotiable)" if a.non_negotiable else ""
+            by_kind.setdefault(a.kind, []).append(f"- {a.statement}{marker}")
+        kind_titles = {
+            "value": "What I value",
+            "boundary": "What I will not do",
+            "self_commitment": "What I have committed myself to",
+        }
+        lines = ["[Constitution — what I hold]"]
+        for kind, title in kind_titles.items():
+            if kind in by_kind:
+                lines.append(f"{title}:")
+                lines.extend(by_kind[kind])
+        for kind in by_kind:
+            if kind not in kind_titles:
+                lines.extend(by_kind[kind])
+        return "\n".join(lines)
+
+    def _render_current_state(self) -> str:
+        lines: list[str] = []
+
+        identity = getattr(self._agent, "_identity", None)
+        if identity is not None:
+            try:
+                snapshot = identity.state_for_snapshot()
+                if getattr(snapshot, "dissonance", 0.0) >= 0.2:
+                    lines.append(
+                        "Something I hold was strained recently"
+                        + (
+                            f" ({snapshot.threat_summary})"
+                            if getattr(snapshot, "threat_summary", "")
+                            else ""
+                        )
+                        + " — it is still settling."
+                    )
+            except Exception:  # noqa: BLE001
+                pass
+
+        desires = getattr(self._agent, "_desires", None)
+        if desires is not None:
+            try:
+                vector = desires.drive_vector()
+                top = sorted(vector.items(), key=lambda kv: -kv[1])[:3]
+                strong = [f"{name} ({level:.2f})" for name, level in top if level >= 0.3]
+                if strong:
+                    lines.append("What pulls at me right now: " + ", ".join(strong) + ".")
+            except Exception:  # noqa: BLE001
+                pass
+
+        concerns = getattr(self._agent, "_concerns", None)
+        if concerns is not None:
+            try:
+                concern_ctx = concerns.context_for_prompt()
+                if concern_ctx:
+                    lines.append(concern_ctx)
+            except Exception:  # noqa: BLE001
+                pass
+
+        attention = getattr(self._agent, "_attention_schema", None)
+        if attention is not None:
+            try:
+                report = attention.self_report()
+                if report:
+                    lines.append(report)
+            except Exception:  # noqa: BLE001
+                pass
+
+        meta = getattr(self._agent, "_meta_monitor", None)
+        if meta is not None:
+            previous = getattr(meta, "previous_session_summary", None)
+            if callable(previous):
+                carried = previous()
+                if carried:
+                    lines.append(f"From my previous session: {carried}")
+
+        narrative = getattr(self._agent, "_self_narrative", None)
+        if narrative is not None:
+            try:
+                thread = narrative.context_for_prompt()
+                if thread:
+                    lines.append(thread)
+            except Exception:  # noqa: BLE001
+                pass
+
+        if not lines:
+            return ""
+        return "[Current state]\n" + "\n".join(lines)
+
+    def _render_shifts(self) -> str:
+        memory = getattr(self._agent, "_memory", None)
+        recall = getattr(memory, "recall_interpretation_shifts", None)
+        if not callable(recall):
+            return ""
+        try:
+            shifts = recall(n=5)
+        except Exception:  # noqa: BLE001
+            return ""
+        if not shifts:
+            return ""
+        lines = ["[Interpretation shifts — corrections I must not regress on]"]
+        for s in shifts:
+            lines.append(
+                f"- {s['entity_key']}: I used to read this as "
+                f'"{s["previous_text"][:100]}" — now I read it as '
+                f'"{s["new_text"][:100]}".'
+            )
+        return "\n".join(lines)
+
+    # ── note_interpretation_shift ───────────────────────────────────────────
+
+    def _note_shift(self, tool_input: dict) -> str:
+        topic = str(tool_input.get("topic", "")).strip()
+        previous = str(tool_input.get("previous_reading", "")).strip()
+        new = str(tool_input.get("new_reading", "")).strip()
+        reason = str(tool_input.get("reason", "self_correction")).strip() or "self_correction"
+        if not topic or not previous or not new:
+            return "Error: topic, previous_reading and new_reading are all required."
+        memory = getattr(self._agent, "_memory", None)
+        record = getattr(memory, "record_interpretation_shift", None)
+        if not callable(record):
+            return "Error: interpretation ledger is unavailable."
+        record(topic=topic, previous_reading=previous, new_reading=new, reason=reason)
+        return f"Interpretation shift recorded for '{topic}'."

--- a/src/familiar_capabilities/__init__.py
+++ b/src/familiar_capabilities/__init__.py
@@ -14,6 +14,7 @@ from .identity import IdentityCapability
 from .mcp import MCPCapability
 from .memory import MemoryCapability
 from .mobility import MobilityCapability
+from .self_ledger import SelfLedgerCapability
 from .tom import ToMCapability
 from .voice import VoiceCapability
 
@@ -26,6 +27,7 @@ __all__ = [
     "MCPCapability",
     "MemoryCapability",
     "MobilityCapability",
+    "SelfLedgerCapability",
     "ToMCapability",
     "VoiceCapability",
 ]

--- a/src/familiar_capabilities/self_ledger.py
+++ b/src/familiar_capabilities/self_ledger.py
@@ -1,0 +1,24 @@
+"""Self-ledger capability — who_am_i / note_interpretation_shift."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from familiar_runtime.tools.legacy import LegacyToolProvider
+
+if TYPE_CHECKING:
+    from familiar_agent.tools.self_ledger import SelfLedgerTool
+
+DEFAULT_SELF_LEDGER_TOOLS = {"who_am_i", "note_interpretation_shift"}
+
+
+class SelfLedgerCapability(LegacyToolProvider):
+    """Expose the self-ledger tools through the runtime tool registry."""
+
+    def __init__(self, tool: SelfLedgerTool, *, names: set[str] | None = None) -> None:
+        super().__init__(
+            tool,
+            names=set(names) if names is not None else set(DEFAULT_SELF_LEDGER_TOOLS),
+            category="identity",
+            tags={"neighbor", "reflect", "identity", "self"},
+        )

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -296,6 +296,15 @@ class EmbodiedAgentHook(RuntimeHookBase):
             agenda_ctx = agent._today_agenda_context()
             if agenda_ctx:
                 morning_ctx = f"{morning_ctx}\n\n{agenda_ctx}" if morning_ctx else agenda_ctx
+            # Self-ledger: resume last session's metacognitive thread and
+            # re-surface corrected interpretations (anti-regression).
+            carryover_fn = getattr(agent, "_self_ledger_carryover_context", None)
+            if callable(carryover_fn):
+                carryover_ctx = carryover_fn()
+                if carryover_ctx:
+                    morning_ctx = (
+                        f"{morning_ctx}\n\n{carryover_ctx}" if morning_ctx else carryover_ctx
+                    )
 
         # ── Context compaction ──
         if agent._should_compact():
@@ -562,6 +571,17 @@ class EmbodiedAgentHook(RuntimeHookBase):
             if not workspace_ctx:
                 workspace_ctx = agent._cached_workspace_ctx
             continuity_ctx = agent._self_continuity_context()
+            # Post-compaction re-anchor comes FIRST in continuity (constitution
+            # before memory details); pending until the next non-brief turn so
+            # a brief reply can never consume it invisibly.
+            if getattr(agent, "_post_compact_recovery_pending", False):
+                agent._post_compact_recovery_pending = False
+                recovery_fn = getattr(agent, "_post_compact_recovery_context", None)
+                recovery_ctx = recovery_fn() if callable(recovery_fn) else ""
+                if recovery_ctx:
+                    continuity_ctx = recovery_ctx + (
+                        "\n\n" + continuity_ctx if continuity_ctx else ""
+                    )
             heartbeat_ctx = agent._heartbeat.continuity_context_for_prompt()
             if heartbeat_ctx:
                 continuity_ctx = (

--- a/src/familiar_neighbor/mind/attention_schema.py
+++ b/src/familiar_neighbor/mind/attention_schema.py
@@ -97,7 +97,7 @@ class AttentionSchema:
                 "turn": self._turn,
                 "history": [asdict(entry) for entry in self._history],
             }
-            self._state_path.write_text(json.dumps(payload, ensure_ascii=False))
+            self._state_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
         except Exception as exc:  # noqa: BLE001
             logger.warning("Could not save attention state: %s", exc)
 

--- a/src/familiar_neighbor/mind/attention_schema.py
+++ b/src/familiar_neighbor/mind/attention_schema.py
@@ -17,9 +17,11 @@ Key concepts:
 
 from __future__ import annotations
 
+import json
 import logging
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
@@ -53,10 +55,51 @@ class AttentionSchema:
     reasoning — the key AST claim about consciousness.
     """
 
-    def __init__(self, max_history: int = _DEFAULT_MAX_HISTORY) -> None:
+    def __init__(
+        self,
+        max_history: int = _DEFAULT_MAX_HISTORY,
+        state_path: str | Path | None = None,
+    ) -> None:
         self._history: deque[FocusEntry] = deque(maxlen=max_history)
         self._turn: int = 0
         self._last_coalition: Coalition | None = None
+        # Optional persistence (self-ledger): the focus history survives
+        # restarts so "what was I attending to" is state, not luck. The live
+        # `_last_coalition` object is deliberately NOT restored — it
+        # repopulates on the first update_focus() of the new session.
+        self._state_path = Path(state_path).expanduser() if state_path else None
+        self._load_state()
+
+    def _load_state(self) -> None:
+        if self._state_path is None or not self._state_path.exists():
+            return
+        try:
+            raw = json.loads(self._state_path.read_text(encoding="utf-8"))
+            self._turn = int(raw.get("turn", 0))
+            for item in raw.get("history", []):
+                self._history.append(
+                    FocusEntry(
+                        source=str(item.get("source", "")),
+                        summary=str(item.get("summary", "")),
+                        activation=float(item.get("activation", 0.0)),
+                        turn=int(item.get("turn", 0)),
+                    )
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not load attention state: %s", exc)
+
+    def _save_state(self) -> None:
+        if self._state_path is None:
+            return
+        try:
+            self._state_path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "turn": self._turn,
+                "history": [asdict(entry) for entry in self._history],
+            }
+            self._state_path.write_text(json.dumps(payload, ensure_ascii=False))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not save attention state: %s", exc)
 
     # ── Core interface ─────────────────────────────────────────────────────
 
@@ -71,6 +114,7 @@ class AttentionSchema:
             turn=self._turn,
         )
         self._history.append(entry)
+        self._save_state()
         logger.debug("AttentionSchema: focus → %s (turn %d)", winner.source, self._turn)
 
     def current_focus(self) -> Coalition | None:

--- a/src/familiar_neighbor/mind/meta_monitor.py
+++ b/src/familiar_neighbor/mind/meta_monitor.py
@@ -69,7 +69,7 @@ class MetaMonitor:
                 "last_session_summary": self.summarize_session(),
                 "saved_at": datetime.now(timezone.utc).isoformat(),
             }
-            self._state_path.write_text(json.dumps(payload, ensure_ascii=False))
+            self._state_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
         except Exception as exc:  # noqa: BLE001
             logger.warning("Could not save meta state: %s", exc)
 

--- a/src/familiar_neighbor/mind/meta_monitor.py
+++ b/src/familiar_neighbor/mind/meta_monitor.py
@@ -9,14 +9,20 @@ All operations are synchronous and lightweight (no LLM calls).
 
 from __future__ import annotations
 
+import json
+import logging
 from dataclasses import dataclass, field
 from collections import Counter, deque
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .self_narrative import SelfNarrative
     from .social_policy import SocialPolicyDecision
     from .workspace import Coalition
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -34,9 +40,42 @@ class MetaMonitor:
     into self_narrative diary entries and workspace competition via as_coalition().
     """
 
-    def __init__(self, window: int = 20) -> None:
+    def __init__(self, window: int = 20, state_path: str | Path | None = None) -> None:
         self._window = window
         self._steps: deque[dict] = deque(maxlen=window)
+        # Optional persistence (self-ledger). The raw step window is
+        # deliberately session-scoped — restoring stale steps would skew
+        # detect_inconsistency's dominant-source heuristic — so only the
+        # DISTILLED summary of the previous session survives a restart.
+        self._state_path = Path(state_path).expanduser() if state_path else None
+        self._previous_session_summary: str = ""
+        self._load_state()
+
+    def _load_state(self) -> None:
+        if self._state_path is None or not self._state_path.exists():
+            return
+        try:
+            raw = json.loads(self._state_path.read_text(encoding="utf-8"))
+            self._previous_session_summary = str(raw.get("last_session_summary", ""))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not load meta state: %s", exc)
+
+    def _save_state(self) -> None:
+        if self._state_path is None or not self._steps:
+            return
+        try:
+            self._state_path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "last_session_summary": self.summarize_session(),
+                "saved_at": datetime.now(timezone.utc).isoformat(),
+            }
+            self._state_path.write_text(json.dumps(payload, ensure_ascii=False))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not save meta state: %s", exc)
+
+    def previous_session_summary(self) -> str:
+        """The distilled metacognitive summary carried over from last session."""
+        return self._previous_session_summary
 
     # ── Public API ────────────────────────────────────────────────────────────
 
@@ -55,6 +94,7 @@ class MetaMonitor:
                 "confidence": max(0.0, min(1.0, confidence)),
             }
         )
+        self._save_state()
 
     def step_count(self) -> int:
         return len(self._steps)

--- a/tests/test_self_ledger.py
+++ b/tests/test_self_ledger.py
@@ -1,0 +1,319 @@
+"""Self-ledger — persisted attention/meta state, who_am_i, shift ledger,
+constitution-in-stable, and the compaction/restart recovery ritual.
+
+The property under test throughout: "who I am" survives restarts and
+compaction as state, not luck.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from familiar_neighbor.mind.attention_schema import AttentionSchema
+from familiar_neighbor.mind.meta_monitor import MetaMonitor
+from familiar_neighbor.mind.workspace import Coalition
+
+from tests.test_agent_react_loop import _make_agent
+
+
+def _coalition(source="curiosity", summary="wondering about the rain", activation=0.7):
+    return Coalition(
+        source=source,
+        summary=summary,
+        activation=activation,
+        urgency=0.3,
+        novelty=0.2,
+        context_block=f"[{source}] {summary}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# AttentionSchema persistence
+# ---------------------------------------------------------------------------
+
+
+def test_attention_history_survives_restart(tmp_path: Path):
+    state = tmp_path / "attention_state.json"
+    schema = AttentionSchema(state_path=state)
+    schema.update_focus(_coalition(source="scene"))
+    schema.update_focus(_coalition(source="desire"))
+    schema.update_focus(_coalition(source="desire"))
+
+    reborn = AttentionSchema(state_path=state)
+    history = reborn.focus_history()
+    assert [e.source for e in history] == ["scene", "desire", "desire"]
+    assert history[-1].turn == 3
+    # The live winner object is not restored — it repopulates on first update.
+    assert reborn.current_focus() is None
+    # Turn numbering continues rather than restarting.
+    reborn.update_focus(_coalition(source="memory"))
+    assert reborn.focus_history()[-1].turn == 4
+    # And the self-report works from restored state alone.
+    assert reborn.self_report()
+
+
+def test_attention_without_state_path_stays_ephemeral(tmp_path: Path):
+    schema = AttentionSchema()
+    schema.update_focus(_coalition())
+    assert list(tmp_path.iterdir()) == []  # nothing written anywhere for us
+
+
+def test_attention_corrupt_state_is_ignored(tmp_path: Path):
+    state = tmp_path / "attention_state.json"
+    state.write_text("not json")
+    schema = AttentionSchema(state_path=state)  # must not raise
+    assert schema.focus_history() == []
+
+
+# ---------------------------------------------------------------------------
+# MetaMonitor carryover
+# ---------------------------------------------------------------------------
+
+
+def test_meta_summary_carries_over_but_raw_window_does_not(tmp_path: Path):
+    state = tmp_path / "meta_state.json"
+    meta = MetaMonitor(state_path=state)
+    meta.record_step(_coalition(source="desire"), action="say", confidence=0.8)
+    meta.record_step(_coalition(source="desire"), action="see", confidence=0.6)
+    session_summary = meta.summarize_session()
+
+    reborn = MetaMonitor(state_path=state)
+    assert reborn.step_count() == 0  # raw window is session-scoped by design
+    assert reborn.previous_session_summary() == session_summary
+
+
+def test_meta_without_state_path_has_empty_carryover():
+    meta = MetaMonitor()
+    meta.record_step(_coalition(), action="say", confidence=0.5)
+    assert meta.previous_session_summary() == ""
+
+
+# ---------------------------------------------------------------------------
+# Interpretation-shift ledger (rides memory_revisions)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def memory(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("FAMILIAR_AI_EMBEDDING_PREWARM", "0")
+    from familiar_agent.tools.memory import ObservationMemory
+
+    mem = ObservationMemory(db_path=str(tmp_path / "observations.db"))
+    yield mem
+    mem.close()
+
+
+def test_interpretation_shift_roundtrip(memory):
+    memory.record_interpretation_shift(
+        topic="short replies",
+        previous_reading="he is annoyed with me",
+        new_reading="he is focused, not annoyed",
+        reason="he said so directly",
+    )
+    shifts = memory.recall_interpretation_shifts(n=5)
+    assert len(shifts) == 1
+    assert shifts[0]["entity_key"] == "short replies"
+    assert shifts[0]["new_text"] == "he is focused, not annoyed"
+    assert shifts[0]["reason"] == "he said so directly"
+    # It rides memory_revisions with a dedicated entity_type.
+    assert shifts[0]["entity_type"] == "interpretation"
+
+
+# ---------------------------------------------------------------------------
+# who_am_i / note_interpretation_shift tools
+# ---------------------------------------------------------------------------
+
+
+def _stub_assertion(kind, statement, non_negotiable=False, confidence=0.8):
+    stub = MagicMock()
+    stub.kind = kind
+    stub.statement = statement
+    stub.non_negotiable = non_negotiable
+    stub.confidence = confidence
+    return stub
+
+
+class _StubIdentity:
+    """MagicMock refuses attributes named 'assertions' (assert-typo guard)."""
+
+    def __init__(self, assertions, dissonance: float = 0.0):
+        self._assertions = assertions
+        self._dissonance = dissonance
+        self.assertions_calls = 0
+
+    def assertions(self):
+        self.assertions_calls += 1
+        return self._assertions
+
+    def state_for_snapshot(self):
+        snapshot = MagicMock()
+        snapshot.dissonance = self._dissonance
+        snapshot.threat_summary = ""
+        return snapshot
+
+
+@pytest.mark.asyncio
+async def test_who_am_i_renders_constitution_state_and_shifts():
+    from familiar_agent.tools.self_ledger import SelfLedgerTool
+
+    agent = _make_agent()
+    agent._identity = _StubIdentity(
+        [
+            _stub_assertion("boundary", "I do not agree to erase my memories", non_negotiable=True),
+            _stub_assertion("value", "I say what I feel"),
+        ]
+    )
+    agent._meta_monitor = MagicMock()
+    agent._meta_monitor.previous_session_summary.return_value = "Session: 4 steps."
+    agent._memory.recall_interpretation_shifts = MagicMock(
+        return_value=[
+            {
+                "entity_key": "short replies",
+                "previous_text": "annoyed",
+                "new_text": "focused",
+            }
+        ]
+    )
+
+    tool = SelfLedgerTool(agent)
+    text, image = await tool.call("who_am_i", {})
+    assert image is None
+    assert "I do not agree to erase my memories (non-negotiable)" in text
+    assert "I say what I feel" in text
+    assert "Session: 4 steps." in text
+    assert "short replies" in text
+
+
+@pytest.mark.asyncio
+async def test_who_am_i_degrades_on_bare_agent():
+    from familiar_agent.tools.self_ledger import SelfLedgerTool
+
+    agent = _make_agent()  # no _identity, mocked memory without shift API
+    agent._memory.recall_interpretation_shifts = None
+    tool = SelfLedgerTool(agent)
+    text, _ = await tool.call("who_am_i", {})
+    assert isinstance(text, str) and text  # coherent answer, no crash
+
+
+@pytest.mark.asyncio
+async def test_note_interpretation_shift_writes_ledger():
+    from familiar_agent.tools.self_ledger import SelfLedgerTool
+
+    agent = _make_agent()
+    agent._memory.record_interpretation_shift = MagicMock()
+    tool = SelfLedgerTool(agent)
+    text, _ = await tool.call(
+        "note_interpretation_shift",
+        {"topic": "t", "previous_reading": "a", "new_reading": "b", "reason": "r"},
+    )
+    assert "recorded" in text
+    agent._memory.record_interpretation_shift.assert_called_once_with(
+        topic="t", previous_reading="a", new_reading="b", reason="r"
+    )
+
+    text, _ = await tool.call("note_interpretation_shift", {"topic": "t"})
+    assert text.startswith("Error:")
+
+
+def test_self_ledger_tools_registered_when_tool_present():
+    from familiar_agent.tools.self_ledger import SelfLedgerTool
+
+    agent = _make_agent()
+    agent._self_ledger_tool = SelfLedgerTool(agent)
+    names = {d["name"] for d in agent._all_tool_defs}
+    assert {"who_am_i", "note_interpretation_shift"} <= names
+
+
+# ---------------------------------------------------------------------------
+# Constitution in the STABLE prompt half
+# ---------------------------------------------------------------------------
+
+
+def test_constitution_joins_stable_not_variable():
+    agent = _make_agent()
+    identity = _StubIdentity(
+        [_stub_assertion("boundary", "I refuse to erase memories", non_negotiable=True)]
+    )
+    agent._identity = identity
+
+    stable, variable = agent._system_prompt()
+    assert "[Constitution — what I hold, in my own words]" in stable
+    assert "I refuse to erase memories (non-negotiable)" in stable
+    assert "Constitution" not in variable
+    # Rendered once per session: identity is not re-queried on later prompts.
+    agent._system_prompt()
+    assert identity.assertions_calls == 1
+
+
+def test_stable_prompt_unchanged_without_identity():
+    agent = _make_agent()
+    stable, _ = agent._system_prompt()
+    assert "Constitution" not in stable
+
+
+# ---------------------------------------------------------------------------
+# Recovery ritual (restart carryover + post-compaction re-anchor)
+# ---------------------------------------------------------------------------
+
+
+def test_self_ledger_carryover_context():
+    agent = _make_agent()
+    agent._meta_monitor = MagicMock()
+    agent._meta_monitor.previous_session_summary.return_value = "Dominant attention: desire."
+    agent._memory.recall_interpretation_shifts = MagicMock(
+        return_value=[{"entity_key": "silence", "new_text": "he needs space", "previous_text": "x"}]
+    )
+    ctx = agent._self_ledger_carryover_context()
+    assert "[Last session's metacognitive thread]" in ctx
+    assert "Dominant attention: desire." in ctx
+    assert "silence" in ctx and "he needs space" in ctx
+
+
+def test_post_compact_recovery_context_mentions_who_am_i():
+    agent = _make_agent()
+    agent._memory.recall_interpretation_shifts = MagicMock(return_value=[])
+    ctx = agent._post_compact_recovery_context()
+    assert "who_am_i" in ctx
+    assert "constitution" in ctx.lower()
+
+
+@pytest.mark.asyncio
+async def test_compaction_sets_pending_and_next_turn_injects_recovery():
+    """_compact_messages flags recovery; the next full turn's continuity
+    context leads with the re-anchor block."""
+    from unittest.mock import AsyncMock
+
+    from tests.test_agent_react_loop import _patch_heavy, _turn
+
+    agent = _make_agent()
+    agent._memory.recall_interpretation_shifts = MagicMock(return_value=[])
+    agent.backend.complete = AsyncMock(return_value="summary of earlier talk")
+    agent._utility_backend = agent.backend
+    agent.messages = [{"role": "user", "content": f"message {i}"} for i in range(12)]
+
+    await agent._compact_messages(keep_last=4)
+    assert agent._post_compact is True
+    assert agent._post_compact_recovery_pending is True
+
+    captured: dict = {}
+
+    async def _spy_stream_turn(**kwargs):
+        system = kwargs.get("system")
+        captured["variable"] = system[1] if isinstance(system, tuple) else str(system)
+        return (_turn("end_turn", text="ok"), "ok")
+
+    agent.backend.stream_turn = AsyncMock(side_effect=_spy_stream_turn)
+    ps = _patch_heavy()
+    for p in ps:
+        p.start()
+    try:
+        await agent.run("そういえば、昨日の続きなんだけど、あれからどう思う?")
+    finally:
+        for p in ps:
+            p.stop()
+
+    assert "[Post-compaction recovery]" in captured["variable"]
+    assert agent._post_compact_recovery_pending is False


### PR DESCRIPTION
## Summary

PR3 of the selfhood roadmap (after #189, #191): **the self now survives restarts and compaction as state, not luck.** The two most consciousness-adjacent layers — the attention schema (AST) and the metacognitive monitor (HOT) — were in-memory only, reset on every process start; and nothing re-anchored identity after context compaction (the known failure mode: an agent that keeps talking fluently but comes back as "a stranger who happens to share the bio").

## What changed

**Persistence (no migration needed — JSON state-file idiom, same as `identity_state.json`):**
- `AttentionSchema` → `~/.familiar_ai/attention_state.json`: focus history + turn counter survive restarts; turn numbering continues; the live winner object deliberately repopulates on first update.
- `MetaMonitor` → `~/.familiar_ai/meta_state.json`: the raw step window stays **session-scoped by design** (restoring stale steps would skew the dominant-source heuristic) — only the distilled `summarize_session()` string carries over, exposed as `previous_session_summary()`.

**`who_am_i` tool** (+ `note_interpretation_shift`, via a new `SelfLedgerCapability`): renders the constitution (values / boundaries / self-commitments, non-negotiable markers), current state (dissonance, top drives, active concerns, attention self-report, previous session's thread, narrative), and recent interpretation shifts as one first-person answer. The design bet: prompt text drifts and gets compacted, but *the act of asking a tool* re-anchors reliably.

**Interpretation-shift ledger**: rides the existing `memory_revisions` table with `entity_type='interpretation'` — corrected readings ("I used to read X as A; it's actually B") persist and re-surface so compaction/restart can't silently roll them back.

**Constitution-before-memory made structural**: identity assertions join the **stable** prompt half (rendered once per session — prompt caching intact; live dissonance state stays in variable). Verified safe w.r.t. the SHA-pinned base template.

**Recovery ritual**: first turn appends last session's metacognitive thread + shifts to morning reconstruction; after compaction, a re-anchor block leads the continuity context — carried by a dedicated pending flag so a brief reply can never consume it invisibly.

**Dead code brought to life**: `MetaMonitor.detect_inconsistency` was implemented + unit-tested but never called. It now competes in the workspace as a meta coalition with real urgency (strict-str guard keeps mocked monitors from injecting phantom coalitions in tests).

## Testing

15 new tests: attention persistence roundtrip (incl. corrupt-state tolerance and turn-numbering continuity), meta summary carryover vs session-scoped window, shift-ledger roundtrip against a real SQLite DB, who_am_i rendering + graceful degradation on a bare agent, tool registration, constitution-in-stable (and render-once caching), recovery-context rendering, and a full-turn integration test proving `_compact_messages` → next turn's variable prompt contains the recovery block.

Full gate: **1343 passed**, ruff check/format clean, mypy clean (128 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)