### PR TITLE
feat(agent): micro-thoughts — INNER_* backend role, verbal monologue, body-modulated cadence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -185,6 +185,18 @@ REALTIME_STT=false
 # FAMILIAR_AUTO_DESIRE=1        # enable desire-driven idle turns only
 # FAMILIAR_AUTO_SAY=1           # enable auto-say (fallback vocalization) only
 
+# ── Inner backend: micro-thoughts (optional) ──────────────────────────────────
+# A small model that verbalizes the inner loop's idle thoughts (one short
+# completion per crystallized focus; requires FAMILIAR_INNER_LOOP=1). The
+# natural fit is a small local model. Without this, the inner loop still runs
+# sub-verbally; with only a separate UTILITY_* backend, that is used instead.
+# Idle cycles never burn main-model calls.
+#
+#   INNER_PLATFORM=openai
+#   INNER_MODEL=gemma3:4b                     # required for openai platform
+#   INNER_BASE_URL=http://localhost:11434/v1  # default (local Ollama)
+#   INNER_API_KEY=                            # not needed for local models
+
 # ── Body daemon: familiard (optional, default OFF) ────────────────────────────
 # An always-on process that keeps the body alive between sessions:
 # interoception sampling (CPU/memory/time → body signal), wake scheduling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,13 @@ focus escalates by **boosting a drive** (`_INNER_SOURCE_TO_DRIVE`, streak+salien
 gate, per-source cooldown) consumed by the UI-owned idle chain — the tick never
 calls `run()` (no turn lock exists; single-flight is UI-owned). `bind_desires()`
 late-binds the UI's DesireSystem; the loop lazy-starts in `prepare_turn`.
+Micro-thoughts: a crystallized focus may be verbalized by a dedicated small
+model (`INNER_PLATFORM`/`INNER_MODEL`/`INNER_BASE_URL`, local-friendly; falls
+back to the utility backend only when separate from main — idle cycles never
+burn main-model calls). The monologue re-competes as a `monologue` coalition
+with TTL-faded salience; recurrence sources (`train_of_thought`/`monologue`)
+never re-crystallize (feedback-loop guard). Cadence is body-modulated
+(interoceptive energy scales the tick interval, clamped 5–120 s).
 
 **Body daemon (familiard, separate process, dark by default).**
 `familiar_agent/familiard.py` (`uv run familiard`) owns interoception sampling

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -19,7 +19,12 @@ from ._runtime_helpers import (
     _MORNING_CONTEXT_MAX_CHARS,
     _noop_str,
 )
-from .backend import create_backend, create_scene_backend, create_utility_backend
+from .backend import (
+    create_backend,
+    create_inner_backend,
+    create_scene_backend,
+    create_utility_backend,
+)
 from .appraisal import AppraisalEngine
 from .config import AgentConfig
 from .desires import DesireSystem, detect_worry_signal
@@ -563,6 +568,23 @@ _INNER_ESCALATION_BOOST = 0.25
 _INNER_ESCALATION_COOLDOWN_SEC = 600.0
 # A thought must win twice in a row before it crystallizes into the monologue.
 _INNER_CRYSTALLIZE_MIN_STREAK = 2
+# Micro-thoughts (Phase 2 PR4): a crystallized focus may be verbalized by a
+# small dedicated model. Budget floor of 256 — reasoning models spend their
+# first tokens thinking and return empty text on smaller budgets.
+_INNER_MICRO_THOUGHT_MIN_INTERVAL_SEC = 120.0
+_INNER_MICRO_THOUGHT_MAX_TOKENS = 256
+# Idle thoughts fade from the competing monologue after this long.
+_INNER_MONOLOGUE_TTL_SEC = 1800.0
+_INNER_CADENCE_MIN_SEC = 5.0
+_INNER_CADENCE_MAX_SEC = 120.0
+
+_MICRO_THOUGHT_PROMPT = (
+    "You are the sub-verbal inner voice of {agent_name}. Continue the train of "
+    "thought below as ONE short first-person sentence — a passing thought, not "
+    "a message to anyone. Match the language of the focus content. No quotes, "
+    "no preamble.\n\nRecent thoughts:\n{recent}\n\nCurrent focus:\n{focus}\n\n"
+    "Thought:"
+)
 
 
 class EmbodiedAgent:
@@ -629,6 +651,11 @@ class EmbodiedAgent:
         self._inner_escalated_at: dict[str, float] = {}
         self._inner_loop_config = InnerLoopConfig(interval_sec=config.inner_loop_interval)
         self._inner_loop = InnerLoop(self._inner_loop_tick, self._inner_loop_config)
+        # Micro-thoughts: verbalized by a dedicated small model (INNER_*), or
+        # the utility backend when that is separate from the main model —
+        # idle cycles must never burn main-model calls.
+        self._inner_backend = create_inner_backend(config) or self._tape_backend()
+        self._last_micro_thought_at = 0.0
         self._exploration = ExplorationTracker()
         self._scene: SceneTracker | None = None  # initialized after DB ready in _init_tools
 
@@ -1643,6 +1670,7 @@ class EmbodiedAgent:
         if self._turn_active:
             return
         self._inner_tick_count += 1
+        self._modulate_inner_cadence()
         full_every = max(self._inner_loop_config.full_cycle_every, 1)
         cheap = self._inner_tick_count % full_every != 0
 
@@ -1659,10 +1687,16 @@ class EmbodiedAgent:
 
         self._train_of_thought.observe(winner)
         streak = self._train_of_thought.streak
-        if streak >= _INNER_CRYSTALLIZE_MIN_STREAK:
+        # Recurrence sources never re-crystallize — the monologue echoing its
+        # own contents back into itself would be a feedback loop, not thought.
+        if streak >= _INNER_CRYSTALLIZE_MIN_STREAK and winner.source not in (
+            "train_of_thought",
+            "monologue",
+        ):
+            verbalized = await self._maybe_micro_thought(winner)
             self._inner_monologue.append(
                 InnerThought(
-                    summary=winner.summary,
+                    summary=verbalized or winner.summary,
                     source=winner.source,
                     ts=time.time(),
                     score=winner.activation,
@@ -1697,6 +1731,83 @@ class EmbodiedAgent:
         self._train_of_thought.reset()
         logger.info("Inner loop: sustained focus on %r escalated to drive %r", winner.source, drive)
 
+    async def _maybe_micro_thought(self, winner) -> str | None:
+        """Verbalize a crystallized focus as one short first-person thought.
+
+        Only runs with a dedicated small backend and under a rate limit — the
+        sub-verbal monologue works fine without it; this just gives the train
+        of thought words. Failures degrade to the raw coalition summary.
+        """
+        backend = getattr(self, "_inner_backend", None)
+        if backend is None:
+            return None
+        now = time.time()
+        last = getattr(self, "_last_micro_thought_at", 0.0)
+        if now - last < _INNER_MICRO_THOUGHT_MIN_INTERVAL_SEC:
+            return None
+        self._last_micro_thought_at = now
+        recent = "\n".join(f"- {t.summary[:100]}" for t in list(self._inner_monologue)[-3:])
+        prompt = _MICRO_THOUGHT_PROMPT.format(
+            agent_name=self.config.agent_name,
+            recent=recent or "(none)",
+            focus=(winner.context_block or winner.summary)[:400],
+        )
+        try:
+            text = await backend.complete(prompt, max_tokens=_INNER_MICRO_THOUGHT_MAX_TOKENS)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Micro-thought generation failed: %s", exc)
+            return None
+        text = (text or "").strip().strip('"')
+        if not text:
+            return None
+        return text.splitlines()[0][:200]
+
+    def _inner_monologue_coalition(self):
+        """Recent idle thoughts compete back into the workspace.
+
+        This is how between-turn thought reaches the next conversation: the
+        monologue surfaces as one modest coalition whose salience fades as the
+        thoughts age (TTL), so stale idle musings don't haunt hours later.
+        """
+        monologue = getattr(self, "_inner_monologue", None)
+        if not monologue:
+            return None
+        now = time.time()
+        fresh = [t for t in monologue if now - t.ts < _INNER_MONOLOGUE_TTL_SEC]
+        if not fresh:
+            return None
+        from .workspace import Coalition as _Coalition
+
+        lines = ["[Inner monologue — my own recent idle thoughts]"]
+        lines.extend(f"- {t.summary[:140]}" for t in fresh[-4:])
+        freshness = max(0.0, 1.0 - (now - fresh[-1].ts) / _INNER_MONOLOGUE_TTL_SEC)
+        return _Coalition(
+            source="monologue",
+            summary=f"idle thoughts ({len(fresh)})",
+            activation=0.3 + 0.15 * freshness,
+            urgency=0.15,
+            novelty=0.2 + 0.3 * freshness,
+            context_block="\n".join(lines),
+        )
+
+    def _modulate_inner_cadence(self) -> None:
+        """Body-modulated thought tempo.
+
+        A lively body (high interoceptive energy) quickens idle cycles; a
+        tired or quiet-hours body slows them — the same self-regulation a
+        person does at 3 AM. Best-effort: any failure leaves the cadence
+        untouched.
+        """
+        try:
+            signal, _ = self._collect_interoception()
+            base = float(self.config.inner_loop_interval)
+            factor = 1.6 - 0.8 * float(signal.energy)  # energy 1.0 → 0.8x; 0.0 → 1.6x
+            self._inner_loop_config.interval_sec = min(
+                _INNER_CADENCE_MAX_SEC, max(_INNER_CADENCE_MIN_SEC, base * factor)
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
     async def _compete_once(
         self,
         *,
@@ -1722,6 +1833,7 @@ class EmbodiedAgent:
             asyncio.to_thread(self._attention_schema.as_coalition),
             asyncio.to_thread(self._meta_monitor.as_coalition),
             asyncio.to_thread(self._meta_inconsistency_coalition),
+            asyncio.to_thread(self._inner_monologue_coalition),
         ]
         if self._scene is not None:
             sync_tasks.append(asyncio.to_thread(self._scene.as_coalition))

--- a/src/familiar_agent/backend.py
+++ b/src/familiar_agent/backend.py
@@ -59,6 +59,7 @@ __all__ = [
     # factories
     "create_backend",
     "create_utility_backend",
+    "create_inner_backend",
     "create_scene_backend",
 ]
 
@@ -174,6 +175,61 @@ def create_utility_backend(
         )
 
     logger.warning("Unknown UTILITY_PLATFORM: %s, falling back to main backend", platform)
+    return None
+
+
+def create_inner_backend(
+    config: AgentConfig,
+) -> AnthropicBackend | OpenAICompatibleBackend | KimiBackend | GLMBackend | GeminiBackend | None:
+    """Create a separate backend for inner-loop micro-thoughts.
+
+    One short completion per crystallized idle thought — the natural fit is a
+    small LOCAL model, so unlike the utility factory the openai path honors
+    INNER_BASE_URL (default: local Ollama) and needs no API key. Returns None
+    when INNER_PLATFORM is unset; the agent then falls back to the utility
+    backend only if it is separate from the main model (cost philosophy:
+    idle cycles must never burn main-model calls).
+    """
+    if not config.inner_platform:
+        return None
+
+    platform = config.inner_platform
+    api_key = config.inner_api_key
+    model = config.inner_model
+
+    if platform == "openai":
+        if not model:
+            logger.warning("INNER_PLATFORM=openai needs INNER_MODEL; micro-thoughts disabled")
+            return None
+        base_url = config.inner_base_url or "http://localhost:11434/v1"
+        logger.info("Using OpenAI-compatible inner backend: %s @ %s", model, base_url)
+        return OpenAICompatibleBackend(
+            api_key=api_key or "local",
+            model=model,
+            base_url=base_url,
+            tools_mode="prompt",
+        )
+    if not api_key:
+        logger.warning("INNER_PLATFORM=%s needs INNER_API_KEY; micro-thoughts disabled", platform)
+        return None
+    if platform == "anthropic":
+        model = model or "claude-haiku-4-5-20251001"
+        logger.info("Using Anthropic inner backend: %s", model)
+        return AnthropicBackend(api_key=api_key, model=model, thinking_mode="disabled")
+    if platform == "gemini":
+        model = model or "gemini-2.5-flash"
+        logger.info("Using Gemini inner backend: %s", model)
+        return GeminiBackend(api_key=api_key, model=model)
+    if platform == "kimi":
+        model = model or "kimi-k2.5"
+        logger.info("Using Kimi inner backend: %s", model)
+        return KimiBackend(api_key=api_key, model=model)
+    if platform == "glm":
+        model = model or "glm-4.6v"
+        logger.info("Using GLM inner backend: %s", model)
+        return GLMBackend(api_key=api_key, model=model)
+
+    logger.warning("Unknown INNER_PLATFORM: %s; micro-thoughts disabled", platform)
     return None
 
 

--- a/src/familiar_agent/config.py
+++ b/src/familiar_agent/config.py
@@ -199,6 +199,16 @@ class AgentConfig:
     scene_api_key: str = field(default_factory=lambda: os.environ.get("SCENE_API_KEY", ""))
     scene_model: str = field(default_factory=lambda: os.environ.get("SCENE_MODEL", ""))
 
+    # ── Inner backend (optional) ────────────────────────────────────────
+    # Separate small/local model for inner-loop micro-thoughts (one short
+    # completion per crystallized idle thought). Falls back to the utility
+    # backend only when that is separate from the main model; micro-thoughts
+    # stay disabled otherwise — idle cycles never burn main-model calls.
+    inner_platform: str = field(default_factory=lambda: os.environ.get("INNER_PLATFORM", ""))
+    inner_api_key: str = field(default_factory=lambda: os.environ.get("INNER_API_KEY", ""))
+    inner_model: str = field(default_factory=lambda: os.environ.get("INNER_MODEL", ""))
+    inner_base_url: str = field(default_factory=lambda: os.environ.get("INNER_BASE_URL", ""))
+
     # ── Autonomous behavior ───────────────────────────────────────
     # Desire-driven idle turns are OFF by default.
     # Auto-say (speak text responses aloud) is ON by default.

--- a/tests/test_agent_react_loop.py
+++ b/tests/test_agent_react_loop.py
@@ -167,6 +167,8 @@ def _make_agent(*, with_tts: bool = False, with_camera: bool = False, with_mcp: 
     agent._inner_tick_count = 0
     agent._inner_escalated_at = {}
     agent._inner_loop_config = InnerLoopConfig()
+    agent._inner_backend = None
+    agent._last_micro_thought_at = 0.0
 
     # Per-turn cognition pipeline (PR3 runtime reorg).  __new__ skipped
     # the EmbodiedAgent.__init__ that normally wires the hook, so attach

--- a/tests/test_micro_thoughts.py
+++ b/tests/test_micro_thoughts.py
@@ -1,0 +1,257 @@
+"""Micro-thoughts (Phase 2 PR4) — inner backend role, verbalization,
+monologue re-competition, body-modulated cadence.
+
+Cost contract under test throughout: idle cycles never burn main-model calls.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from familiar_agent.inner_loop import InnerThought
+from familiar_neighbor.mind.workspace import Coalition
+
+from tests.test_agent_react_loop import _make_agent
+
+
+def _coalition(source="curiosity", activation=0.8, urgency=0.5, summary="thinking about rain"):
+    return Coalition(
+        source=source,
+        summary=summary,
+        activation=activation,
+        urgency=urgency,
+        novelty=0.3,
+        context_block=f"[{source}] {summary}",
+    )
+
+
+def _tick_result(winner):
+    from familiar_agent.inner_loop import CompeteResult
+
+    return CompeteResult(winner=winner, others=[], coalitions=[winner] if winner else [])
+
+
+# ---------------------------------------------------------------------------
+# create_inner_backend
+# ---------------------------------------------------------------------------
+
+
+def _config(**env_fields):
+    cfg = MagicMock()
+    cfg.inner_platform = env_fields.get("inner_platform", "")
+    cfg.inner_api_key = env_fields.get("inner_api_key", "")
+    cfg.inner_model = env_fields.get("inner_model", "")
+    cfg.inner_base_url = env_fields.get("inner_base_url", "")
+    return cfg
+
+
+def test_inner_backend_none_without_platform():
+    from familiar_agent.backend import create_inner_backend
+
+    assert create_inner_backend(_config()) is None
+
+
+def test_inner_backend_openai_local_defaults():
+    from familiar_agent.backend import create_inner_backend
+    from familiar_runtime.models import OpenAICompatibleBackend
+
+    backend = create_inner_backend(_config(inner_platform="openai", inner_model="gemma3:4b"))
+    assert isinstance(backend, OpenAICompatibleBackend)
+    assert backend.model == "gemma3:4b"
+    assert "localhost:11434" in str(backend.client.base_url)  # local by default
+    assert backend.tools_mode == "prompt"
+
+
+def test_inner_backend_openai_requires_model():
+    from familiar_agent.backend import create_inner_backend
+
+    assert create_inner_backend(_config(inner_platform="openai")) is None
+
+
+def test_inner_backend_cloud_platforms_require_key():
+    from familiar_agent.backend import create_inner_backend
+
+    assert create_inner_backend(_config(inner_platform="anthropic")) is None
+    assert create_inner_backend(_config(inner_platform="nonsense", inner_api_key="k")) is None
+
+
+def test_config_reads_inner_env(monkeypatch):
+    monkeypatch.setenv("INNER_PLATFORM", "openai")
+    monkeypatch.setenv("INNER_MODEL", "qwen3:4b")
+    monkeypatch.setenv("INNER_BASE_URL", "http://box:11434/v1")
+    from familiar_agent.config import AgentConfig
+
+    cfg = AgentConfig()
+    assert cfg.inner_platform == "openai"
+    assert cfg.inner_model == "qwen3:4b"
+    assert cfg.inner_base_url == "http://box:11434/v1"
+
+
+# ---------------------------------------------------------------------------
+# Micro-thought verbalization in the tick
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_crystallization_uses_verbalized_thought():
+    agent = _make_agent()
+    agent._inner_backend = MagicMock()
+    agent._inner_backend.complete = AsyncMock(return_value="the rain sounds like static today")
+    winner = _coalition(source="narrative")
+    agent._compete_once = AsyncMock(return_value=_tick_result(winner))
+
+    await agent._inner_loop_tick()
+    await agent._inner_loop_tick()  # streak 2 → crystallize + verbalize
+
+    assert len(agent._inner_monologue) == 1
+    assert agent._inner_monologue[0].summary == "the rain sounds like static today"
+    agent._inner_backend.complete.assert_awaited_once()
+    # Reasoning-model-aware budget floor.
+    assert agent._inner_backend.complete.call_args.kwargs["max_tokens"] >= 256
+
+
+@pytest.mark.asyncio
+async def test_micro_thought_rate_limited_and_degrades_to_summary():
+    agent = _make_agent()
+    agent._inner_backend = MagicMock()
+    agent._inner_backend.complete = AsyncMock(return_value="a verbal thought")
+    winner = _coalition(source="narrative", summary="raw focus summary")
+    agent._compete_once = AsyncMock(return_value=_tick_result(winner))
+
+    for _ in range(4):  # crystallizes on ticks 2,3,4 — but only one LLM call
+        await agent._inner_loop_tick()
+
+    assert agent._inner_backend.complete.await_count == 1
+    summaries = [t.summary for t in agent._inner_monologue]
+    assert summaries[0] == "a verbal thought"
+    assert all(s == "raw focus summary" for s in summaries[1:])  # rate-limited → raw
+
+
+@pytest.mark.asyncio
+async def test_no_backend_keeps_subverbal_monologue():
+    agent = _make_agent()
+    assert agent._inner_backend is None
+    winner = _coalition(source="narrative", summary="quiet focus")
+    agent._compete_once = AsyncMock(return_value=_tick_result(winner))
+
+    await agent._inner_loop_tick()
+    await agent._inner_loop_tick()
+    assert agent._inner_monologue[0].summary == "quiet focus"
+
+
+@pytest.mark.asyncio
+async def test_backend_failure_or_empty_degrades():
+    agent = _make_agent()
+    agent._inner_backend = MagicMock()
+    agent._inner_backend.complete = AsyncMock(side_effect=RuntimeError("model gone"))
+    winner = _coalition(source="narrative", summary="fallback me")
+    agent._compete_once = AsyncMock(return_value=_tick_result(winner))
+
+    await agent._inner_loop_tick()
+    await agent._inner_loop_tick()
+    assert agent._inner_monologue[0].summary == "fallback me"
+
+
+@pytest.mark.asyncio
+async def test_recurrence_sources_never_crystallize():
+    """The monologue echoing itself back into itself is a feedback loop."""
+    agent = _make_agent()
+    winner = _coalition(source="monologue", summary="echo")
+    agent._compete_once = AsyncMock(return_value=_tick_result(winner))
+
+    for _ in range(4):
+        await agent._inner_loop_tick()
+    assert len(agent._inner_monologue) == 0
+
+
+def test_inner_backend_defaults_to_none_when_utility_is_main():
+    """Cost contract: without INNER_* and without a separate utility backend,
+    micro-thoughts stay off — idle cycles never touch the main model."""
+    agent = _make_agent()
+    # _make_agent sets _utility_backend = backend (same object) → tape None.
+    assert agent._tape_backend() is None
+
+
+# ---------------------------------------------------------------------------
+# Monologue re-competition
+# ---------------------------------------------------------------------------
+
+
+def test_monologue_coalition_renders_fresh_thoughts():
+    agent = _make_agent()
+    now = time.time()
+    agent._inner_monologue.append(
+        InnerThought(summary="rain again", source="scene", ts=now - 60, score=0.6)
+    )
+    agent._inner_monologue.append(
+        InnerThought(summary="he seemed tired", source="tom", ts=now - 10, score=0.7)
+    )
+    coalition = agent._inner_monologue_coalition()
+    assert coalition is not None
+    assert coalition.source == "monologue"
+    assert "rain again" in coalition.context_block
+    assert "he seemed tired" in coalition.context_block
+
+
+def test_monologue_coalition_fades_out_when_stale():
+    agent = _make_agent()
+    agent._inner_monologue.append(
+        InnerThought(summary="old musing", source="scene", ts=time.time() - 7200, score=0.6)
+    )
+    assert agent._inner_monologue_coalition() is None
+    agent._inner_monologue.clear()
+    assert agent._inner_monologue_coalition() is None
+
+
+@pytest.mark.asyncio
+async def test_monologue_competes_in_workspace():
+    agent = _make_agent()
+    agent._inner_monologue.append(
+        InnerThought(summary="fresh idle thought", source="scene", ts=time.time(), score=0.9)
+    )
+    result = await agent._compete_once(cheap=True)
+    assert any(c.source == "monologue" for c in result.coalitions)
+
+
+# ---------------------------------------------------------------------------
+# Body-modulated cadence
+# ---------------------------------------------------------------------------
+
+
+def _signal(energy: float):
+    signal = MagicMock()
+    signal.energy = energy
+    return signal
+
+
+def test_cadence_quickens_with_energy_and_clamps():
+    agent = _make_agent()
+    agent.config.inner_loop_interval = 20.0
+
+    agent._collect_interoception = MagicMock(return_value=(_signal(1.0), None))
+    agent._modulate_inner_cadence()
+    lively = agent._inner_loop_config.interval_sec
+
+    agent._collect_interoception = MagicMock(return_value=(_signal(0.0), None))
+    agent._modulate_inner_cadence()
+    tired = agent._inner_loop_config.interval_sec
+
+    assert lively < 20.0 < tired
+    assert 5.0 <= lively and tired <= 120.0
+
+    # Clamping at the extremes.
+    agent.config.inner_loop_interval = 2.0
+    agent._collect_interoception = MagicMock(return_value=(_signal(1.0), None))
+    agent._modulate_inner_cadence()
+    assert agent._inner_loop_config.interval_sec == 5.0
+
+
+def test_cadence_failure_leaves_interval_untouched():
+    agent = _make_agent()
+    agent._inner_loop_config.interval_sec = 20.0
+    agent._collect_interoception = MagicMock(side_effect=RuntimeError("no body"))
+    agent._modulate_inner_cadence()
+    assert agent._inner_loop_config.interval_sec == 20.0


### PR DESCRIPTION
## Summary

PR4 of the selfhood roadmap (after #189/#191/#192): **the inner loop gets a quiet voice.** Between turns the agent already cycled a sub-verbal train of thought; now a crystallized focus can be verbalized by a small dedicated model, the resulting monologue competes back into the next conversation's workspace, and the whole cadence follows the body.

## What changed

- **`create_inner_backend()`** — a dedicated INNER_* model role for idle verbalization. Local-friendly where the utility factory is not: the `openai` path honors `INNER_BASE_URL` (default local Ollama) and needs no API key. Fallback: the utility backend **only when it is separate from the main model** — the cost contract is that idle cycles never burn main-model calls (same philosophy as TAPE).
- **Micro-thoughts** — a focus that wins twice in a row may be verbalized as one short first-person sentence. Rate-limited (120 s), `max_tokens` floor of 256 (reasoning models return empty text on smaller budgets — measured), and every failure degrades to the raw coalition summary.
- **Monologue re-competition** — recent idle thoughts surface as one `monologue` coalition with TTL-faded salience (30 min), so between-turn thought reaches the next conversation without stale musings haunting hours later. Recurrence sources (`train_of_thought`/`monologue`) never re-crystallize — feedback-loop guard.
- **Body-modulated cadence** — interoceptive energy scales the tick interval (lively → quicker idle cycles, tired/quiet hours → slower; clamped 5–120 s). With familiard (#191) running, the daemon's body signal directly paces the tempo of thought.

## Testing

16 new tests: factory matrix (local defaults, missing-model/key guards), verbalization + rate limit + degradation paths, feedback-loop guard, monologue TTL/competition, cadence scaling + clamps + failure isolation, and the cost-contract check. All 28 existing inner-loop tests pass unchanged.

Full gate: **1359 passed**, ruff check/format clean, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)