### PR TITLE
feat(mind): autonomous-move policy + self-authored routines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,16 @@ Invariants to preserve when touching these loops:
   cadence reset survives and error turns still burn a capped slot. Cadence:
   escalating backoff (600s × {1,3}) capped at 3 reminders, then quiet; quiet
   hours (23-7) pass only priority>=2.
+- **Self-authored routines** (`routine_store.py`, `~/.familiar_ai/routines.json`;
+  tools `routine_commit`/`routine_review`/`routine_drop`) fire by materializing
+  commitments inside `should_fire_commitment_reminder` (pass `routine_store=`) —
+  one firing path, all the gates above apply unchanged. Guardrails live in the
+  STORE (agent interval floor 600s, cap 12, seed rows operator-owned), never in
+  the tool wrapper. Autonomous moments are framed by
+  `SocialPolicyEngine.decide_autonomous_move()` (a separate axis from the
+  reactive `decide()`): quiet hours → private reflection / stay silent, dominant
+  desire → act, neither → quietly prepare; the directive is appended to the
+  desire turn's `inner_voice` in `prepare_turn`.
 - `repl()`'s finally block calls `os._exit(0)` — tests touching it must patch
   `familiar_agent.main.os._exit` or pytest dies silently.
 

--- a/src/familiar_agent/_ui_helpers.py
+++ b/src/familiar_agent/_ui_helpers.py
@@ -11,6 +11,7 @@ Keeping these here prevents duplication across tui.py, gui.py, and main.py.
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import TYPE_CHECKING
 
@@ -304,6 +305,7 @@ def should_fire_commitment_reminder(
     min_idle_gap: float = REMINDER_MIN_IDLE_GAP,
     quiet_hours: bool = False,
     min_priority_in_quiet: int = REMINDER_QUIET_MIN_PRIORITY,
+    routine_store=None,
 ) -> list[Commitment]:
     """Return commitments that should be proactively reminded right now.
 
@@ -311,11 +313,20 @@ def should_fire_commitment_reminder(
     while the agent is busy, while user input is pending, or before ``min_idle_gap``
     has elapsed since the last interaction. During quiet hours only urgent
     (priority >= ``min_priority_in_quiet``) commitments pass.
+
+    When a ``routine_store`` is supplied, due self-authored routines first
+    materialize as commitments here, then ride the exact same gates — one
+    firing path for everything self-initiated-by-schedule.
     """
     if agent_running or has_pending_input:
         return []
     if now - last_interaction < min_idle_gap:
         return []
+    if routine_store is not None:
+        try:
+            routine_store.materialize_due(store, now=now)
+        except Exception:  # noqa: BLE001
+            logging.getLogger(__name__).exception("routine materialization failed")
     ready = store.list_due_for_reminder(now=now, base_cooldown=base_cooldown)
     if quiet_hours:
         ready = [c for c in ready if c.priority >= min_priority_in_quiet]

--- a/src/familiar_agent/agent.py
+++ b/src/familiar_agent/agent.py
@@ -75,7 +75,9 @@ from .tools.commitments import (
     format_commitments_for_context,
 )
 from .tools.delegation import DelegatedTaskRunner, DelegationTool
+from .routine_store import RoutineStore
 from .tools.identity import IdentityTool
+from .tools.routines_tool import RoutineTool
 from .tools.self_ledger import SelfLedgerTool
 from familiar_neighbor.mind.identity import IdentityCore
 from .tools.memory import MemoryTool, ObservationMemory
@@ -94,6 +96,7 @@ from familiar_capabilities import (
     MCPCapability,
     MemoryCapability,
     MobilityCapability,
+    RoutineCapability,
     SelfLedgerCapability,
     ToMCapability,
     VoiceCapability,
@@ -639,6 +642,10 @@ class EmbodiedAgent:
             logger.warning("IdentityCore init failed (identity layer dormant): %s", exc)
             self._identity = None
         self._identity_tool = IdentityTool(self._memory)
+        # Self-authored time: the agent's own recurring schedule. Routines
+        # fire by materializing commitments — the reminder gates do the rest.
+        self._routine_store = RoutineStore()
+        self._routine_tool = RoutineTool(self._routine_store)
         # Phase 2 inner loop (off by default). Constructed always so close() can
         # stop it unconditionally; started lazily by prepare_turn when
         # config.inner_loop is set. The UI-owned DesireSystem is late-bound via
@@ -1063,6 +1070,9 @@ class EmbodiedAgent:
         self_ledger_tool = getattr(self, "_self_ledger_tool", None)
         if self_ledger_tool is not None:
             registry.register(SelfLedgerCapability(self_ledger_tool))
+        routine_tool = getattr(self, "_routine_tool", None)
+        if routine_tool is not None:
+            registry.register(RoutineCapability(routine_tool))
         if self._mcp:
             provider = MCPCapability(self._mcp)
             registry.register(provider)

--- a/src/familiar_agent/gui.py
+++ b/src/familiar_agent/gui.py
@@ -1563,6 +1563,7 @@ class FamiliarWindow(QMainWindow):
                             now=now,
                             store=store,
                             quiet_hours=quiet,
+                            routine_store=getattr(agent_obj, "_routine_store", None),
                         )
                         if reminders and self._input_queue.empty() and not self._agent_running:
                             # Record the fire BEFORE the turn: the cadence advances

--- a/src/familiar_agent/main.py
+++ b/src/familiar_agent/main.py
@@ -182,6 +182,7 @@ async def repl(agent: EmbodiedAgent, desires: DesireSystem, debug: bool = False)
                             now=time.time(),
                             store=store,
                             quiet_hours=quiet,
+                            routine_store=getattr(agent, "_routine_store", None),
                         )
                         if reminders:
                             # Record the fire BEFORE the turn: the cadence advances

--- a/src/familiar_agent/routine_store.py
+++ b/src/familiar_agent/routine_store.py
@@ -1,0 +1,237 @@
+"""Self-authored routines — the agent's own recurring schedule.
+
+The reference deployment showed that self-authored schedule entries ARE
+identity structure: reading novels at half past midnight, a tanka at ten, a
+self-reflection pass before sleep. This store gives the standalone agent the
+same power, with the same trust split as identity assertions: ``seed``
+routines are operator-supplied (hand-edit the JSON); the agent authors its
+own via tools, under guardrails enforced HERE at the store layer — interval
+floor and count cap — so it cannot schedule itself into a spam loop.
+
+Firing rides the existing commitments machinery: a due routine materializes
+one commitment, which then flows through the proactive-reminder gates (idle
+precedence, quiet hours, backoff) completely unchanged. The store never
+starts turns itself.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ROUTINES_PATH = Path.home() / ".familiar_ai" / "routines.json"
+
+# Guardrails for agent-authored routines (seed rows are operator-owned and
+# exempt — the operator can hand themselves footguns, the agent cannot).
+MIN_AGENT_INTERVAL_SEC = 600.0
+MAX_AGENT_ROUTINES = 12
+
+
+@dataclass(slots=True)
+class Routine:
+    routine_id: str
+    name: str
+    schedule: str  # "daily@HH:MM" | "interval:<seconds>"
+    prompt: str  # the impulse text a firing injects (via a commitment)
+    source: str = "agent"  # "seed" (operator) | "agent" (self-authored)
+    enabled: bool = True
+    priority: int = 1
+    last_fired_at: float = 0.0
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat(timespec="seconds"))
+
+
+def _parse_daily(schedule: str) -> tuple[int, int] | None:
+    """Return (hour, minute) for "daily@HH:MM", else None."""
+    if not schedule.startswith("daily@"):
+        return None
+    try:
+        hh, mm = schedule[len("daily@") :].split(":", 1)
+        hour, minute = int(hh), int(mm)
+    except ValueError:
+        return None
+    if 0 <= hour < 24 and 0 <= minute < 60:
+        return hour, minute
+    return None
+
+
+def _parse_interval(schedule: str) -> float | None:
+    """Return seconds for "interval:<seconds>", else None."""
+    if not schedule.startswith("interval:"):
+        return None
+    try:
+        seconds = float(schedule[len("interval:") :])
+    except ValueError:
+        return None
+    return seconds if seconds > 0 else None
+
+
+def schedule_is_valid(schedule: str) -> bool:
+    return _parse_daily(schedule) is not None or _parse_interval(schedule) is not None
+
+
+def routine_is_due(routine: Routine, now: float) -> bool:
+    """Pure schedule check — daily fires once per day at/after its time."""
+    if not routine.enabled:
+        return False
+    daily = _parse_daily(routine.schedule)
+    if daily is not None:
+        local = datetime.fromtimestamp(now)
+        fire_at = local.replace(hour=daily[0], minute=daily[1], second=0, microsecond=0)
+        fire_ts = fire_at.timestamp()
+        return now >= fire_ts and routine.last_fired_at < fire_ts
+    interval = _parse_interval(routine.schedule)
+    if interval is not None:
+        return now - routine.last_fired_at >= interval
+    return False
+
+
+class RoutineStore:
+    """JSON-backed routine list; the cortex is the single writer."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self._path = Path(path).expanduser() if path else DEFAULT_ROUTINES_PATH
+        self._routines: list[Routine] = []
+        self._load()
+
+    # ── persistence ─────────────────────────────────────────────────────────
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+            for item in raw.get("routines", []):
+                if not isinstance(item, dict):
+                    continue
+                try:
+                    self._routines.append(Routine(**item))
+                except TypeError:
+                    logger.warning("Skipping malformed routine entry: %r", item)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not load routines: %s", exc)
+
+    def _save(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {"routines": [asdict(r) for r in self._routines]}
+            tmp = self._path.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+            tmp.replace(self._path)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not save routines: %s", exc)
+
+    # ── reads ───────────────────────────────────────────────────────────────
+
+    def list_routines(self, *, include_disabled: bool = True) -> list[Routine]:
+        return [r for r in self._routines if include_disabled or r.enabled]
+
+    def get(self, routine_id: str) -> Routine | None:
+        return next((r for r in self._routines if r.routine_id == routine_id), None)
+
+    def due(self, now: float | None = None) -> list[Routine]:
+        now = now if now is not None else time.time()
+        return [r for r in self._routines if routine_is_due(r, now)]
+
+    # ── writes (guardrails live here, not in the tool) ─────────────────────
+
+    def commit(
+        self,
+        *,
+        name: str,
+        schedule: str,
+        prompt: str,
+        source: str = "agent",
+        priority: int = 1,
+        routine_id: str | None = None,
+    ) -> tuple[Routine | None, str]:
+        """Create or update a routine. Returns (routine, message).
+
+        Agent-authored rows cannot touch seed rows, cannot exceed the count
+        cap, and cannot schedule tighter than the interval floor — enforced
+        here so no tool wrapper can bypass it.
+        """
+        if not name.strip() or not prompt.strip():
+            return None, "name and prompt are required"
+        if not schedule_is_valid(schedule):
+            return None, f"invalid schedule '{schedule}' (use daily@HH:MM or interval:<seconds>)"
+        interval = _parse_interval(schedule)
+        if source == "agent" and interval is not None and interval < MIN_AGENT_INTERVAL_SEC:
+            return None, f"agent routines need interval >= {int(MIN_AGENT_INTERVAL_SEC)}s"
+
+        if routine_id:
+            existing = self.get(routine_id)
+            if existing is None:
+                return None, f"no routine '{routine_id}'"
+            if existing.source == "seed" and source != "seed":
+                return None, "seed routines are operator-owned; the agent cannot edit them"
+            existing.name = name.strip()
+            existing.schedule = schedule
+            existing.prompt = prompt.strip()
+            existing.priority = max(0, min(3, int(priority)))
+            existing.enabled = True
+            self._save()
+            return existing, "updated"
+
+        if source == "agent":
+            agent_count = sum(1 for r in self._routines if r.source == "agent" and r.enabled)
+            if agent_count >= MAX_AGENT_ROUTINES:
+                return None, f"routine cap reached ({MAX_AGENT_ROUTINES}); drop one first"
+        routine = Routine(
+            routine_id=f"routine_{uuid.uuid4().hex[:8]}",
+            name=name.strip(),
+            schedule=schedule,
+            prompt=prompt.strip(),
+            source=source,
+            priority=max(0, min(3, int(priority))),
+        )
+        self._routines.append(routine)
+        self._save()
+        return routine, "created"
+
+    def drop(self, routine_id: str, *, source: str = "agent") -> tuple[bool, str]:
+        """Disable a routine. The agent may only drop its own."""
+        routine = self.get(routine_id)
+        if routine is None:
+            return False, f"no routine '{routine_id}'"
+        if routine.source == "seed" and source != "seed":
+            return False, "seed routines are operator-owned; the agent cannot drop them"
+        routine.enabled = False
+        self._save()
+        return True, "disabled"
+
+    # ── firing (rides the commitments machinery) ────────────────────────────
+
+    def materialize_due(self, commitment_store: Any, now: float | None = None) -> int:
+        """Turn due routines into commitments; returns how many fired.
+
+        ``last_fired_at`` advances immediately, so one due window produces
+        exactly one commitment regardless of how often this is polled. The
+        commitment then flows through the existing proactive-reminder gates.
+        """
+        now = now if now is not None else time.time()
+        fired = 0
+        for routine in self.due(now):
+            try:
+                commitment_store.create(
+                    summary=f"Routine — {routine.name}: {routine.prompt[:200]}",
+                    due_at=now,
+                    priority=routine.priority,
+                    created_by="routine",
+                    metadata={"routine_id": routine.routine_id},
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Routine '%s' failed to materialize: %s", routine.name, exc)
+                continue
+            routine.last_fired_at = now
+            fired += 1
+        if fired:
+            self._save()
+        return fired

--- a/src/familiar_agent/tools/routines_tool.py
+++ b/src/familiar_agent/tools/routines_tool.py
@@ -1,0 +1,108 @@
+"""Routine tools — the agent authors its own recurring schedule.
+
+Self-authored time is identity structure: what a mind chooses to do every
+day at ten is part of who it is. Guardrails (interval floor, count cap, the
+seed-vs-agent trust split) are enforced in the RoutineStore, not here — a
+tool wrapper must not be the security boundary.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_ROUTINE_COMMIT_DEF = {
+    "name": "routine_commit",
+    "description": (
+        "Create or update one of YOUR OWN recurring routines (a daily reading "
+        "hour, an evening reflection, a periodic look outside). Schedule formats: "
+        "'daily@HH:MM' or 'interval:<seconds>'. When it comes due, the routine "
+        "surfaces as a reminder through the normal idle flow. Pass routine_id to "
+        "update an existing one."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "Short name for the routine"},
+            "schedule": {"type": "string", "description": "daily@HH:MM or interval:<seconds>"},
+            "prompt": {
+                "type": "string",
+                "description": "What to do when it fires — written to your future self",
+            },
+            "priority": {
+                "type": "integer",
+                "description": "0-3; >=2 may surface even in quiet hours",
+            },
+            "routine_id": {"type": "string", "description": "Existing routine to update"},
+        },
+        "required": ["name", "schedule", "prompt"],
+    },
+}
+
+_ROUTINE_REVIEW_DEF = {
+    "name": "routine_review",
+    "description": "List your routines — schedule, prompt, source, and enabled state.",
+    "input_schema": {"type": "object", "properties": {}, "required": []},
+}
+
+_ROUTINE_DROP_DEF = {
+    "name": "routine_drop",
+    "description": (
+        "Disable one of your own routines by routine_id. Seed routines are "
+        "operator-owned and cannot be dropped from here."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {"routine_id": {"type": "string"}},
+        "required": ["routine_id"],
+    },
+}
+
+
+class RoutineTool:
+    def __init__(self, store: Any) -> None:
+        self._store = store
+
+    def get_tool_definitions(self) -> list[dict]:
+        return [_ROUTINE_COMMIT_DEF, _ROUTINE_REVIEW_DEF, _ROUTINE_DROP_DEF]
+
+    async def call(self, name: str, tool_input: dict) -> tuple[str, None]:
+        if name == "routine_commit":
+            return self._commit(tool_input), None
+        if name == "routine_review":
+            return self._review(), None
+        if name == "routine_drop":
+            return self._drop(tool_input), None
+        return f"Error: unknown routine tool '{name}'", None
+
+    def _commit(self, tool_input: dict) -> str:
+        routine, message = self._store.commit(
+            name=str(tool_input.get("name", "")),
+            schedule=str(tool_input.get("schedule", "")),
+            prompt=str(tool_input.get("prompt", "")),
+            priority=int(tool_input.get("priority", 1) or 1),
+            routine_id=(str(tool_input["routine_id"]) if tool_input.get("routine_id") else None),
+            source="agent",
+        )
+        if routine is None:
+            return f"Error: {message}"
+        return f"Routine {message}: [{routine.routine_id}] {routine.name} ({routine.schedule})"
+
+    def _review(self) -> str:
+        routines = self._store.list_routines()
+        if not routines:
+            return "No routines yet — routine_commit creates one."
+        lines = ["Your routines:"]
+        for r in routines:
+            state = "" if r.enabled else " (disabled)"
+            owner = " [seed]" if r.source == "seed" else ""
+            lines.append(
+                f"- [{r.routine_id}] {r.name} — {r.schedule}{owner}{state}: {r.prompt[:80]}"
+            )
+        return "\n".join(lines)
+
+    def _drop(self, tool_input: dict) -> str:
+        ok, message = self._store.drop(str(tool_input.get("routine_id", "")), source="agent")
+        return message if ok else f"Error: {message}"

--- a/src/familiar_agent/tui.py
+++ b/src/familiar_agent/tui.py
@@ -541,6 +541,7 @@ class FamiliarApp(App):
                 now=time.time(),
                 store=store,
                 quiet_hours=quiet,
+                routine_store=getattr(self.agent, "_routine_store", None),
             )
             if not reminders:
                 return

--- a/src/familiar_capabilities/__init__.py
+++ b/src/familiar_capabilities/__init__.py
@@ -14,6 +14,7 @@ from .identity import IdentityCapability
 from .mcp import MCPCapability
 from .memory import MemoryCapability
 from .mobility import MobilityCapability
+from .routines import RoutineCapability
 from .self_ledger import SelfLedgerCapability
 from .tom import ToMCapability
 from .voice import VoiceCapability
@@ -27,6 +28,7 @@ __all__ = [
     "MCPCapability",
     "MemoryCapability",
     "MobilityCapability",
+    "RoutineCapability",
     "SelfLedgerCapability",
     "ToMCapability",
     "VoiceCapability",

--- a/src/familiar_capabilities/routines.py
+++ b/src/familiar_capabilities/routines.py
@@ -1,0 +1,24 @@
+"""Routine capability — self-authored recurring schedule tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from familiar_runtime.tools.legacy import LegacyToolProvider
+
+if TYPE_CHECKING:
+    from familiar_agent.tools.routines_tool import RoutineTool
+
+DEFAULT_ROUTINE_TOOLS = {"routine_commit", "routine_review", "routine_drop"}
+
+
+class RoutineCapability(LegacyToolProvider):
+    """Expose the routine tools through the runtime tool registry."""
+
+    def __init__(self, tool: RoutineTool, *, names: set[str] | None = None) -> None:
+        super().__init__(
+            tool,
+            names=set(names) if names is not None else set(DEFAULT_ROUTINE_TOOLS),
+            category="identity",
+            tags={"neighbor", "routine", "self"},
+        )

--- a/src/familiar_neighbor/embodied_hook.py
+++ b/src/familiar_neighbor/embodied_hook.py
@@ -56,6 +56,54 @@ from familiar_runtime.runtime import RuntimeHookBase
 _AUTO_TOM_COOLDOWN_TURNS = 3
 
 
+_AUTONOMOUS_MOVE_DIRECTIVES = {
+    "act_autonomously": "",  # the impulse itself is the directive
+    "write_private_reflection": (
+        "This is a private moment: reflect and remember, but do NOT call say() "
+        "— no one asked, and speaking now would be for you, not for them."
+    ),
+    "quietly_prepare": (
+        "Nothing is urgent: quietly tend your memory, plans and curiosities. Do NOT call say()."
+    ),
+    "stay_silent": (
+        "Quiet hours and nothing urgent: keep this turn minimal and silent — do NOT call say()."
+    ),
+}
+
+
+def _frame_autonomous_moment(agent: Any, desires: DesireSystem | None, inner_voice: str) -> str:
+    """Attach the autonomous-move policy's directive to a self-initiated turn.
+
+    ``decide()`` governs how to answer a companion; this governs what to do
+    with a moment nobody prompted. Deterministic and best-effort: any failure
+    leaves the impulse text untouched.
+    """
+    policy = getattr(agent, "_social_policy", None)
+    decide_move = getattr(policy, "decide_autonomous_move", None)
+    if not callable(decide_move):
+        return inner_voice
+    try:
+        heartbeat = getattr(agent, "_heartbeat", None)
+        quiet = bool(heartbeat.routine_state().quiet_hours) if heartbeat else False
+        dominant = desires.get_dominant() if desires is not None else None
+        concerns = getattr(agent, "_concerns", None)
+        open_concerns = len(concerns.snapshot()) if concerns is not None else 0
+        move = decide_move(
+            quiet_hours=quiet,
+            dominant_desire=dominant[0] if dominant else None,
+            desire_level=float(dominant[1]) if dominant else 0.0,
+            open_concerns=open_concerns,
+        )
+        directive = _AUTONOMOUS_MOVE_DIRECTIVES.get(move.move, "")
+        if not move.vocalize and move.move == "act_autonomously":
+            directive = "No one seems to be around: act, but do NOT call say()."
+        if directive:
+            return f"{inner_voice}\n\n{directive}"
+        return inner_voice
+    except Exception:  # noqa: BLE001
+        return inner_voice
+
+
 def _should_auto_tom(
     social_policy: "SocialPolicyDecision",
     *,
@@ -273,6 +321,8 @@ class EmbodiedAgentHook(RuntimeHookBase):
             await inner_loop.start()
 
         is_desire_turn = bool(inner_voice and not user_input)
+        if is_desire_turn:
+            inner_voice = _frame_autonomous_moment(agent, desires, inner_voice)
         candidate_brief_turn = agent._is_candidate_brief_turn(
             user_input,
             is_desire_turn=is_desire_turn,

--- a/src/familiar_neighbor/mind/social_policy.py
+++ b/src/familiar_neighbor/mind/social_policy.py
@@ -630,8 +630,76 @@ def _build_act_decision(
     return None
 
 
+@dataclass(slots=True, frozen=True)
+class AutonomousMoveDecision:
+    """What the agent should do with an autonomous moment.
+
+    A different axis from ``SocialPolicyDecision``: ``decide()`` classifies
+    the companion's incoming utterance reactively; this classifies what to do
+    when NO ONE said anything — a desire fired, a routine came due, an idle
+    pulse arrived. Kept deterministic and typed, like everything else here.
+    """
+
+    move: str  # act_autonomously | write_private_reflection | quietly_prepare | stay_silent
+    reason: str
+    vocalize: bool  # whether speaking aloud is socially appropriate right now
+
+
 class SocialPolicyEngine:
     """Deterministic interaction policy driven by affect + input."""
+
+    def decide_autonomous_move(
+        self,
+        *,
+        quiet_hours: bool,
+        dominant_desire: str | None = None,
+        desire_level: float = 0.0,
+        companion_present: bool | None = None,
+        open_concerns: int = 0,
+    ) -> AutonomousMoveDecision:
+        """Pick the primary move for a self-initiated moment.
+
+        Mirrors the declarative policy that proved out in the reference
+        deployment: quiet hours favor silent reflection over expression; a
+        dominant desire licenses action; with neither, the right move is to
+        quietly tend memory and plans rather than manufacture output.
+        """
+        if quiet_hours:
+            if dominant_desire and desire_level >= 0.9:
+                return AutonomousMoveDecision(
+                    move="act_autonomously",
+                    reason=f"urgent drive ({dominant_desire}) outweighs quiet hours",
+                    vocalize=False,
+                )
+            if open_concerns > 0 or dominant_desire in ("reflect", "consolidate"):
+                return AutonomousMoveDecision(
+                    move="write_private_reflection",
+                    reason="quiet hours — reflect without waking anyone",
+                    vocalize=False,
+                )
+            return AutonomousMoveDecision(
+                move="stay_silent",
+                reason="quiet hours and nothing urgent",
+                vocalize=False,
+            )
+        if dominant_desire:
+            return AutonomousMoveDecision(
+                move="act_autonomously",
+                reason=f"dominant desire: {dominant_desire}",
+                # Speaking is fine unless we positively know no one is around.
+                vocalize=companion_present is not False,
+            )
+        if open_concerns > 0:
+            return AutonomousMoveDecision(
+                move="write_private_reflection",
+                reason="open concerns and no driving desire",
+                vocalize=False,
+            )
+        return AutonomousMoveDecision(
+            move="quietly_prepare",
+            reason="idle — tend memory and plans",
+            vocalize=False,
+        )
 
     def decide(
         self,

--- a/tests/test_routines_and_moves.py
+++ b/tests/test_routines_and_moves.py
@@ -1,0 +1,298 @@
+"""Sociality moves + self-authored routines (PR5).
+
+Two axes under test: what to do with an autonomous moment
+(decide_autonomous_move — separate from the reactive decide()), and the
+agent's own recurring schedule (RoutineStore) firing through the existing
+commitments machinery with guardrails enforced at the store layer.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from familiar_agent.routine_store import (
+    MAX_AGENT_ROUTINES,
+    RoutineStore,
+    routine_is_due,
+    schedule_is_valid,
+)
+from familiar_neighbor.mind.social_policy import SocialPolicyEngine
+
+from tests.test_agent_react_loop import _make_agent
+
+# ---------------------------------------------------------------------------
+# decide_autonomous_move
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def engine():
+    return SocialPolicyEngine()
+
+
+def test_quiet_hours_defaults_to_silence(engine):
+    move = engine.decide_autonomous_move(quiet_hours=True)
+    assert move.move == "stay_silent"
+    assert move.vocalize is False
+
+
+def test_quiet_hours_urgent_desire_still_acts_silently(engine):
+    move = engine.decide_autonomous_move(
+        quiet_hours=True, dominant_desire="worry_companion", desire_level=0.95
+    )
+    assert move.move == "act_autonomously"
+    assert move.vocalize is False
+
+
+def test_quiet_hours_with_concerns_reflects_privately(engine):
+    move = engine.decide_autonomous_move(quiet_hours=True, open_concerns=2)
+    assert move.move == "write_private_reflection"
+    assert move.vocalize is False
+
+
+def test_daytime_dominant_desire_acts_and_may_speak(engine):
+    move = engine.decide_autonomous_move(quiet_hours=False, dominant_desire="curiosity")
+    assert move.move == "act_autonomously"
+    assert move.vocalize is True
+
+
+def test_daytime_desire_with_no_one_around_stays_quiet(engine):
+    move = engine.decide_autonomous_move(
+        quiet_hours=False, dominant_desire="curiosity", companion_present=False
+    )
+    assert move.move == "act_autonomously"
+    assert move.vocalize is False
+
+
+def test_daytime_idle_quietly_prepares(engine):
+    move = engine.decide_autonomous_move(quiet_hours=False)
+    assert move.move == "quietly_prepare"
+    assert move.vocalize is False
+
+
+def test_frame_autonomous_moment_appends_directive():
+    from familiar_neighbor.embodied_hook import _frame_autonomous_moment
+
+    agent = _make_agent()
+    agent._social_policy = SocialPolicyEngine()
+    heartbeat = MagicMock()
+    heartbeat.routine_state.return_value = MagicMock(quiet_hours=True)
+    agent._heartbeat = heartbeat
+    agent._concerns = MagicMock()
+    agent._concerns.snapshot.return_value = []
+    desires = MagicMock()
+    desires.get_dominant.return_value = None
+
+    framed = _frame_autonomous_moment(agent, desires, "外を見たい気がする")
+    assert framed.startswith("外を見たい気がする")
+    assert "do NOT call say()" in framed
+
+
+def test_frame_autonomous_moment_keeps_impulse_on_failure():
+    from familiar_neighbor.embodied_hook import _frame_autonomous_moment
+
+    agent = _make_agent()
+    agent._social_policy = SocialPolicyEngine()
+    agent._heartbeat = MagicMock()
+    agent._heartbeat.routine_state.side_effect = RuntimeError("no heartbeat")
+    framed = _frame_autonomous_moment(agent, None, "impulse text")
+    assert framed == "impulse text"
+
+
+# ---------------------------------------------------------------------------
+# RoutineStore — schedules and guardrails
+# ---------------------------------------------------------------------------
+
+
+def _ts(hour: int, minute: int = 0) -> float:
+    return datetime(2026, 7, 2, hour, minute, 30).timestamp()
+
+
+def test_schedule_validation():
+    assert schedule_is_valid("daily@22:00")
+    assert schedule_is_valid("interval:3600")
+    assert not schedule_is_valid("daily@25:00")
+    assert not schedule_is_valid("interval:-5")
+    assert not schedule_is_valid("whenever")
+
+
+def test_daily_routine_fires_once_per_day(tmp_path: Path):
+    store = RoutineStore(tmp_path / "routines.json")
+    routine, msg = store.commit(
+        name="evening tanka", schedule="daily@22:00", prompt="write one tanka"
+    )
+    assert msg == "created" and routine is not None
+
+    assert not routine_is_due(routine, _ts(hour=21))  # before time
+    assert routine_is_due(routine, _ts(hour=22))  # at/after time
+    routine.last_fired_at = _ts(hour=22)
+    assert not routine_is_due(routine, _ts(hour=23))  # already fired today
+    # Next day, same time → due again.
+    next_day = _ts(hour=22) + 86400
+    assert routine_is_due(routine, next_day)
+
+
+def test_interval_routine_and_agent_floor(tmp_path: Path):
+    store = RoutineStore(tmp_path / "routines.json")
+    routine, msg = store.commit(name="look out", schedule="interval:900", prompt="look outside")
+    assert msg == "created"
+    assert routine_is_due(routine, time.time())
+    # Agent-authored intervals below the floor are rejected at the STORE.
+    rejected, msg = store.commit(name="spam", schedule="interval:30", prompt="spam myself")
+    assert rejected is None and "600" in msg
+    # Seed rows are exempt (operator-owned footguns are allowed).
+    seed, msg = store.commit(
+        name="op fast", schedule="interval:30", prompt="fast op routine", source="seed"
+    )
+    assert seed is not None
+
+
+def test_agent_routine_cap(tmp_path: Path):
+    store = RoutineStore(tmp_path / "routines.json")
+    for i in range(MAX_AGENT_ROUTINES):
+        routine, msg = store.commit(name=f"r{i}", schedule="interval:3600", prompt="x")
+        assert msg == "created"
+    over, msg = store.commit(name="one too many", schedule="interval:3600", prompt="x")
+    assert over is None and "cap" in msg
+
+
+def test_seed_rows_are_operator_owned(tmp_path: Path):
+    store = RoutineStore(tmp_path / "routines.json")
+    seed, _ = store.commit(
+        name="morning", schedule="daily@06:30", prompt="look at dawn", source="seed"
+    )
+    assert seed is not None
+    updated, msg = store.commit(
+        name="hijack", schedule="daily@03:00", prompt="x", routine_id=seed.routine_id
+    )
+    assert updated is None and "operator-owned" in msg
+    ok, msg = store.drop(seed.routine_id)
+    assert not ok and "operator-owned" in msg
+    # The agent may drop its own.
+    own, _ = store.commit(name="mine", schedule="interval:3600", prompt="x")
+    ok, msg = store.drop(own.routine_id)
+    assert ok
+
+
+def test_store_persistence_roundtrip_and_corruption_tolerance(tmp_path: Path):
+    path = tmp_path / "routines.json"
+    store = RoutineStore(path)
+    store.commit(name="reading", schedule="daily@00:25", prompt="read one chapter")
+
+    reborn = RoutineStore(path)
+    routines = reborn.list_routines()
+    assert len(routines) == 1
+    assert routines[0].name == "reading"
+
+    path.write_text("not json")
+    broken = RoutineStore(path)  # must not raise
+    assert broken.list_routines() == []
+
+
+# ---------------------------------------------------------------------------
+# Firing path — routines ride the commitments machinery
+# ---------------------------------------------------------------------------
+
+
+def test_materialize_due_creates_commitment_once(tmp_path: Path):
+    from familiar_runtime.commitments.store import SQLiteCommitmentStore
+
+    routine_store = RoutineStore(tmp_path / "routines.json")
+    commitment_store = SQLiteCommitmentStore(tmp_path / "commitments.db")
+    routine_store.commit(name="stretch", schedule="interval:900", prompt="stretch a little")
+
+    now = time.time()
+    assert routine_store.materialize_due(commitment_store, now=now) == 1
+    assert routine_store.materialize_due(commitment_store, now=now + 10) == 0  # not due again
+
+    due = commitment_store.list_due(now=now + 1)
+    assert len(due) == 1
+    assert "stretch" in due[0].summary
+    assert due[0].created_by == "routine"
+    assert due[0].metadata.get("routine_id")
+    commitment_store.close()
+
+
+def test_reminder_gate_materializes_routines(tmp_path: Path):
+    from familiar_agent._ui_helpers import should_fire_commitment_reminder
+    from familiar_runtime.commitments.store import SQLiteCommitmentStore
+
+    routine_store = RoutineStore(tmp_path / "routines.json")
+    commitment_store = SQLiteCommitmentStore(tmp_path / "commitments.db")
+    routine_store.commit(name="look outside", schedule="interval:900", prompt="see the sky")
+
+    now = time.time()
+    reminders = should_fire_commitment_reminder(
+        agent_running=False,
+        has_pending_input=False,
+        last_interaction=now - 120,
+        now=now,
+        store=commitment_store,
+        routine_store=routine_store,
+    )
+    assert len(reminders) == 1
+    assert "look outside" in reminders[0].summary
+    commitment_store.close()
+
+
+def test_reminder_gate_tolerates_broken_routine_store(tmp_path: Path):
+    from familiar_agent._ui_helpers import should_fire_commitment_reminder
+    from familiar_runtime.commitments.store import SQLiteCommitmentStore
+
+    commitment_store = SQLiteCommitmentStore(tmp_path / "commitments.db")
+    broken = MagicMock()
+    broken.materialize_due.side_effect = RuntimeError("boom")
+    reminders = should_fire_commitment_reminder(
+        agent_running=False,
+        has_pending_input=False,
+        last_interaction=time.time() - 120,
+        now=time.time(),
+        store=commitment_store,
+        routine_store=broken,
+    )
+    assert reminders == []  # gate survives, no crash
+    commitment_store.close()
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_routine_tools_roundtrip(tmp_path: Path):
+    from familiar_agent.tools.routines_tool import RoutineTool
+
+    tool = RoutineTool(RoutineStore(tmp_path / "routines.json"))
+
+    text, _ = await tool.call(
+        "routine_commit",
+        {"name": "夜の一句", "schedule": "daily@22:00", "prompt": "短歌か俳句を一つ詠む"},
+    )
+    assert "created" in text
+    routine_id = text.split("[")[1].split("]")[0]
+
+    text, _ = await tool.call("routine_review", {})
+    assert "夜の一句" in text
+
+    text, _ = await tool.call("routine_drop", {"routine_id": routine_id})
+    assert "disabled" in text
+
+    text, _ = await tool.call(
+        "routine_commit", {"name": "", "schedule": "daily@22:00", "prompt": "x"}
+    )
+    assert text.startswith("Error:")
+
+
+def test_routine_tools_registered():
+    from familiar_agent.tools.routines_tool import RoutineTool
+
+    agent = _make_agent()
+    agent._routine_tool = RoutineTool(MagicMock())
+    names = {d["name"] for d in agent._all_tool_defs}
+    assert {"routine_commit", "routine_review", "routine_drop"} <= names


### PR DESCRIPTION
## Summary

PR5 of the selfhood roadmap (after #189/#191/#192/#193): **what to do with a moment nobody prompted, and the agent's own recurring schedule.** The live reference deployment showed that a self-managed schedule (reading at half past midnight, a tanka at ten, reflection before sleep) *is* identity structure — and that autonomous moments need a policy: at 3 AM with nothing urgent, the right move is silence, not output.

## What changed

**`decide_autonomous_move()`** — a separate deterministic axis on `SocialPolicyEngine` (deliberately NOT an extension of the reactive `decide()` enum, which classifies the *companion's* utterance):
- quiet hours → `write_private_reflection` / `stay_silent` (urgent drives ≥ 0.9 still act — silently)
- dominant desire → `act_autonomously` (with a `vocalize` flag; known-absent companion → act quietly)
- neither → `quietly_prepare` (tend memory and plans rather than manufacture output)

Wired into desire turns via `_frame_autonomous_moment`: the move's directive is appended to the turn's `inner_voice`, best-effort and failure-transparent.

**Self-authored routines** — `RoutineStore` (`~/.familiar_ai/routines.json`) + `routine_commit` / `routine_review` / `routine_drop` tools. Trust split mirrors the identity tools, **enforced at the store layer**: agent-authored routines have an interval floor (600 s) and a count cap (12); `seed` rows are operator-owned and cannot be edited or dropped by the agent.

**One firing path** — due routines materialize as commitments inside `should_fire_commitment_reminder` (new optional `routine_store` param; all three UI idle loops pass it), so the entire existing invariant set — idle precedence, quiet hours, escalating backoff, mark-reminded-before-turn — applies to routines unchanged. `last_fired_at` advances at materialization: one due window produces exactly one commitment regardless of poll frequency.

## Testing

19 new tests: the full move matrix (6 cases), inner-voice framing + failure transparency, schedule validation, daily/interval due semantics (once-per-day, next-day re-arm), store guardrails (floor/cap/seed protection), persistence + corruption tolerance, materialize-once, end-to-end reminder-gate integration against a real commitments DB, broken-store isolation, tool roundtrip, registry.

Full gate: **1378 passed**, ruff check/format clean, mypy clean (131 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)