### PR TITLE
fix(stt): PulseAudio (parec) capture fallback for WSL2/WSLg

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,9 @@ REALTIME_STT=false
 # Press Ctrl+M in the TUI to start/stop recording.
 # ──────────────────────────────────────────
 # STT_LANGUAGE=ja    # BCP-47 language code for batch + realtime transcription (default: ja)
+# FAMILIAR_STT_BACKEND=auto   # auto (default) | sounddevice | parec
+#   auto prefers sounddevice and falls back to PulseAudio's parec when no
+#   input device is visible — the common WSL2/WSLg case (needs pulseaudio-utils).
 
 # ──────────────────────────────────────────
 # Coding agent tools (optional)

--- a/README.md
+++ b/README.md
@@ -442,18 +442,27 @@ STT_LANGUAGE=ja            # recommended for Japanese; used by both batch and re
 
 familiar-ai streams microphone audio to ElevenLabs Scribe v2 and auto-commits transcripts when you pause speaking. No button press required. Coexists with the push-to-talk mode (Ctrl+T).
 
-On WSL2/WSLg, realtime STT also depends on `sounddevice` / PortAudio being able to
-see your microphone input, not just PulseAudio playback. Install
-`pulseaudio-utils` and `libasound2-plugins`, set
-`PULSE_SERVER=unix:/mnt/wslg/PulseServer`, then verify:
+On WSL2/WSLg, PortAudio often cannot see the WSLg microphone bridge even though
+PulseAudio-level capture works. familiar-ai handles this automatically: when
+`sounddevice` finds no input device, both STT paths (realtime and push-to-talk)
+fall back to PulseAudio's native `parec`. You only need:
 
 ```bash
-uv run python -m sounddevice
+sudo apt install pulseaudio-utils libasound2-plugins
+# in .env (or your shell):
+PULSE_SERVER=unix:/mnt/wslg/PulseServer
 ```
 
-If that command shows no input devices or reports `Error querying device -1`,
-familiar-ai will not be able to capture microphone audio until PortAudio can
-see the WSLg input bridge.
+Verify PulseAudio capture works (this is what the fallback uses):
+
+```bash
+pactl list short sources      # should show an RDPSource / input
+parec --rate=16000 --channels=1 | head -c 32000 > /dev/null && echo mic OK
+```
+
+To force a specific capture backend, set `FAMILIAR_STT_BACKEND=sounddevice`
+or `FAMILIAR_STT_BACKEND=parec` (default: auto — sounddevice first, parec
+fallback).
 
 ---
 

--- a/src/familiar_agent/realtime_stt_session.py
+++ b/src/familiar_agent/realtime_stt_session.py
@@ -28,7 +28,7 @@ from .voice_guard import VoiceLoopGuard, get_shared_voice_guard
 
 if TYPE_CHECKING:
     from .tools.realtime_stt import RealtimeSttClient
-    from .tools.mic import MicCapture
+    from .tools.mic import MicCapture, ParecCapture
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +101,7 @@ class RealtimeSttSession:
         self._language_code = language_code.strip()
         self._voice_guard = voice_guard or get_shared_voice_guard()
         self._stt_client: RealtimeSttClient | None = None
-        self._mic_capture: MicCapture | None = None
+        self._mic_capture: MicCapture | ParecCapture | None = None
         self._relay_task: asyncio.Task | None = None
         self._partial_task: asyncio.Task | None = None
         self._monitor_task: asyncio.Task | None = None
@@ -144,7 +144,7 @@ class RealtimeSttSession:
         committed_queue: asyncio.Queue[str | None],
     ) -> None:
         """Connect the STT WebSocket and start microphone capture."""
-        from .tools.mic import MicCapture  # noqa: PLC0415
+        from .tools.mic import create_mic_capture  # noqa: PLC0415
 
         if self.active:
             logger.debug("Realtime STT session already active; start() is a no-op")
@@ -164,7 +164,8 @@ class RealtimeSttSession:
         self._partial_task = asyncio.create_task(self._partial_relay())
         self._monitor_task = asyncio.create_task(self._monitor_connection())
 
-        self._mic_capture = MicCapture(on_audio=self._send_audio)
+        # Auto-selects sounddevice or the parec fallback (issue #153).
+        self._mic_capture = create_mic_capture(on_audio=self._send_audio)
         self._mic_capture.start(loop)
         logger.info("Realtime STT session started")
 

--- a/src/familiar_agent/tools/mic.py
+++ b/src/familiar_agent/tools/mic.py
@@ -1,4 +1,16 @@
-"""Microphone capture — streams PCM 16 kHz 16-bit mono to an async callback."""
+"""Microphone capture — streams PCM 16 kHz 16-bit mono to an async callback.
+
+Two backends, picked by :func:`create_mic_capture`:
+
+1. ``MicCapture`` — sounddevice/PortAudio (the default everywhere it works).
+2. ``ParecCapture`` — PulseAudio's native ``parec``. On WSL2/WSLg, PortAudio
+   often cannot enumerate the RDPSource microphone bridge even though
+   PulseAudio-level capture works fine (issue #153); parec talks to
+   PulseAudio directly and resamples to 16 kHz mono s16le for us.
+
+``FAMILIAR_STT_BACKEND=sounddevice|parec`` forces a backend; default is auto
+(sounddevice, falling back to parec when no input device is visible).
+"""
 
 from __future__ import annotations
 
@@ -6,6 +18,9 @@ import asyncio
 import logging
 import os
 import platform
+import shutil
+import subprocess
+import threading
 from typing import Any
 
 import numpy as np
@@ -52,6 +67,8 @@ def probe_sounddevice_input() -> tuple[bool, str]:
         import sounddevice as sd
     except ImportError:
         return False, "sounddevice is not installed."
+    except Exception as exc:  # noqa: BLE001 — e.g. OSError: PortAudio library not found
+        return False, f"sounddevice unavailable: {exc}"
 
     try:
         devices = sd.query_devices()
@@ -152,3 +169,124 @@ class MicCapture:
             self._stream.close()
             self._stream = None
             logger.info("Microphone capture stopped")
+
+
+def parec_command() -> list[str] | None:
+    """The parec argv for 16 kHz mono s16le capture, or None if unavailable."""
+    path = shutil.which("parec")
+    if not path:
+        return None
+    return [
+        path,
+        "--format=s16le",
+        f"--rate={TARGET_RATE}",
+        f"--channels={CHANNELS}",
+        f"--latency-msec={_BLOCK_MS}",
+    ]
+
+
+def probe_parec() -> tuple[bool, str]:
+    """Best-effort check that PulseAudio-native capture is available."""
+    if parec_command() is None:
+        return False, "parec not found — install pulseaudio-utils."
+    return True, "parec (PulseAudio native capture)"
+
+
+class ParecCapture:
+    """Capture via PulseAudio's ``parec`` subprocess (the WSL2/WSLg fallback).
+
+    Same interface as :class:`MicCapture`. parec outputs raw s16le PCM at the
+    requested rate, so no resampling is needed; a reader thread forwards
+    fixed-size blocks to *on_audio* on the event loop.
+    """
+
+    def __init__(self, on_audio, command: list[str] | None = None) -> None:  # noqa: ANN001
+        self._on_audio = on_audio
+        self._command = command
+        self._process: subprocess.Popen | None = None
+        self._thread: threading.Thread | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._running = False
+
+    def start(self, loop: asyncio.AbstractEventLoop) -> None:
+        command = self._command or parec_command()
+        if command is None:
+            raise RuntimeError("parec not found — install pulseaudio-utils.")
+        self._loop = loop
+        try:
+            self._process = subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+            )
+        except OSError as exc:
+            raise RuntimeError(f"parec failed to start: {exc}") from exc
+        logger.info("Microphone capture: parec (PulseAudio) @ %d Hz", TARGET_RATE)
+        self._running = True
+        self._thread = threading.Thread(target=self._reader, daemon=True, name="parec-reader")
+        self._thread.start()
+
+    def _reader(self) -> None:
+        block_bytes = int(TARGET_RATE * 2 * _BLOCK_MS / 1000)  # s16le mono
+        process = self._process
+        if process is None or process.stdout is None:
+            return
+        while self._running:
+            pcm = process.stdout.read(block_bytes)
+            if not pcm:
+                if self._running:
+                    logger.warning("parec ended unexpectedly (PulseAudio gone?)")
+                break
+            maybe_loop = self._loop
+            if maybe_loop is None or maybe_loop.is_closed():
+                break
+            loop: asyncio.AbstractEventLoop = maybe_loop
+
+            def _dispatch(b: bytes = pcm, target_loop: asyncio.AbstractEventLoop = loop) -> None:
+                target_loop.create_task(self._on_audio(b))
+
+            loop.call_soon_threadsafe(_dispatch)
+
+    def stop(self) -> None:
+        """Stop capturing and reap the subprocess."""
+        self._running = False
+        if self._process is not None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+            self._process = None
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None
+        logger.info("Microphone capture stopped (parec)")
+
+
+def create_mic_capture(on_audio) -> "MicCapture | ParecCapture":  # noqa: ANN001
+    """Pick a capture backend: sounddevice → parec → clear error.
+
+    ``FAMILIAR_STT_BACKEND=sounddevice|parec`` forces one; the default (auto)
+    prefers sounddevice and falls back to parec when PortAudio cannot see any
+    input device — the WSL2/WSLg situation from issue #153, where PulseAudio
+    capture works but PortAudio enumeration is empty.
+    """
+    forced = os.environ.get("FAMILIAR_STT_BACKEND", "").strip().lower()
+    if forced == "sounddevice":
+        return MicCapture(on_audio)
+    if forced == "parec":
+        ok, detail = probe_parec()
+        if not ok:
+            raise RuntimeError(detail)
+        return ParecCapture(on_audio)
+
+    ok, _ = probe_sounddevice_input()
+    if ok:
+        return MicCapture(on_audio)
+    parec_ok, parec_detail = probe_parec()
+    if parec_ok:
+        logger.info("Mic: sounddevice sees no input device; using parec (PulseAudio) instead")
+        return ParecCapture(on_audio)
+    raise RuntimeError(
+        describe_sounddevice_input_failure() + f" parec fallback also unavailable: {parec_detail}"
+    )

--- a/src/familiar_agent/tools/stt.py
+++ b/src/familiar_agent/tools/stt.py
@@ -92,6 +92,11 @@ class STTTool:
         # Try PC mic first
         audio_bytes = await asyncio.to_thread(self._record_mic, stop_event)
 
+        # PulseAudio-native fallback: on WSL2/WSLg PortAudio often sees no
+        # input device even though PulseAudio capture works (issue #153).
+        if audio_bytes is None:
+            audio_bytes = await asyncio.to_thread(self._record_parec, stop_event)
+
         # Fallback to RTSP camera mic
         if audio_bytes is None and self._rtsp_url:
             logger.info("STT: no local mic, falling back to RTSP camera mic")
@@ -113,8 +118,8 @@ class STTTool:
             import numpy as np
             import sounddevice as sd
             import soundfile as sf
-        except ImportError:
-            logger.warning("STT: sounddevice/soundfile not installed")
+        except Exception as e:  # noqa: BLE001 — incl. OSError: PortAudio library not found
+            logger.warning("STT: sounddevice/soundfile unavailable (%s)", e)
             return None
 
         chunks: list = []
@@ -136,7 +141,7 @@ class STTTool:
                         chunk, _ = stream.read(1024)
                         chunks.append(chunk)
                         time.sleep(0.01)  # yield slightly; this is already in a thread
-        except sd.PortAudioError as e:
+        except Exception as e:  # noqa: BLE001 — any capture failure falls through
             logger.warning("STT: %s", describe_sounddevice_input_failure(e))
             return None
 
@@ -146,6 +151,57 @@ class STTTool:
         audio = np.concatenate(chunks, axis=0)
         buf = io.BytesIO()
         sf.write(buf, audio, sample_rate, format="WAV", subtype="PCM_16")
+        return buf.getvalue()
+
+    def _record_parec(
+        self, stop_event: asyncio.Event, *, max_seconds: float = 60.0
+    ) -> bytes | None:
+        """Record via PulseAudio's native ``parec`` until stop_event is set.
+
+        Returns WAV bytes, or None when parec is unavailable or captured
+        nothing. parec resamples to 16 kHz mono s16le for us.
+        """
+        from .mic import TARGET_RATE, parec_command
+
+        command = parec_command()
+        if command is None:
+            return None
+        import subprocess
+        import wave
+
+        try:
+            process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+        except OSError as e:
+            logger.warning("STT: parec failed to start: %s", e)
+            return None
+
+        logger.info("STT: recording via parec (PulseAudio) at %dHz...", TARGET_RATE)
+        pcm = io.BytesIO()
+        block_bytes = TARGET_RATE * 2 // 10  # 100 ms of s16le mono
+        start = time.time()
+        try:
+            assert process.stdout is not None
+            while not stop_event.is_set() and time.time() - start < max_seconds:
+                chunk = process.stdout.read(block_bytes)
+                if not chunk:
+                    break
+                pcm.write(chunk)
+        finally:
+            process.terminate()
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                process.kill()
+
+        raw = pcm.getvalue()
+        if not raw:
+            return None
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as wav:
+            wav.setnchannels(_CHANNELS)
+            wav.setsampwidth(2)
+            wav.setframerate(TARGET_RATE)
+            wav.writeframes(raw)
         return buf.getvalue()
 
     async def _record_rtsp(self, stop_event: asyncio.Event) -> bytes:

--- a/tests/test_mic_fallback.py
+++ b/tests/test_mic_fallback.py
@@ -1,0 +1,207 @@
+"""PulseAudio (parec) STT fallback — issue #153.
+
+On WSL2/WSLg, PortAudio often cannot enumerate the RDPSource microphone even
+though PulseAudio-level capture works. Both STT paths (realtime capture and
+push-to-talk batch) must fall back to parec, and the selection must be
+forceable via FAMILIAR_STT_BACKEND.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import sys
+import wave
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from familiar_agent.tools import mic
+from familiar_agent.tools.mic import (
+    MicCapture,
+    ParecCapture,
+    create_mic_capture,
+    parec_command,
+    probe_parec,
+)
+
+# A fake "parec": emits 0.3 s of s16le@16k mono, then keeps the pipe open.
+_FAKE_PAREC = [
+    sys.executable,
+    "-c",
+    "import sys, time; sys.stdout.buffer.write(b'\\x01\\x02' * 4800); "
+    "sys.stdout.buffer.flush(); time.sleep(30)",
+]
+
+# ---------------------------------------------------------------------------
+# Probes and backend selection
+# ---------------------------------------------------------------------------
+
+
+def test_parec_command_and_probe(monkeypatch):
+    monkeypatch.setattr(mic.shutil, "which", lambda _: "/usr/bin/parec")
+    command = parec_command()
+    assert command is not None and command[0] == "/usr/bin/parec"
+    assert "--format=s16le" in command
+    assert "--rate=16000" in command
+    ok, detail = probe_parec()
+    assert ok
+
+    monkeypatch.setattr(mic.shutil, "which", lambda _: None)
+    assert parec_command() is None
+    ok, detail = probe_parec()
+    assert not ok and "pulseaudio-utils" in detail
+
+
+def test_auto_prefers_sounddevice(monkeypatch):
+    monkeypatch.delenv("FAMILIAR_STT_BACKEND", raising=False)
+    monkeypatch.setattr(mic, "probe_sounddevice_input", lambda: (True, "dev"))
+    capture = create_mic_capture(AsyncMock())
+    assert isinstance(capture, MicCapture)
+
+
+def test_auto_falls_back_to_parec_when_no_input_device(monkeypatch):
+    """The issue #153 situation: PortAudio empty, PulseAudio available."""
+    monkeypatch.delenv("FAMILIAR_STT_BACKEND", raising=False)
+    monkeypatch.setattr(mic, "probe_sounddevice_input", lambda: (False, "no input devices"))
+    monkeypatch.setattr(mic.shutil, "which", lambda _: "/usr/bin/parec")
+    capture = create_mic_capture(AsyncMock())
+    assert isinstance(capture, ParecCapture)
+
+
+def test_auto_raises_clear_error_when_both_unavailable(monkeypatch):
+    monkeypatch.delenv("FAMILIAR_STT_BACKEND", raising=False)
+    monkeypatch.setattr(mic, "probe_sounddevice_input", lambda: (False, "no input devices"))
+    monkeypatch.setattr(mic.shutil, "which", lambda _: None)
+    with pytest.raises(RuntimeError) as excinfo:
+        create_mic_capture(AsyncMock())
+    assert "parec" in str(excinfo.value)
+
+
+def test_env_forces_backend(monkeypatch):
+    monkeypatch.setenv("FAMILIAR_STT_BACKEND", "parec")
+    monkeypatch.setattr(mic.shutil, "which", lambda _: "/usr/bin/parec")
+    assert isinstance(create_mic_capture(AsyncMock()), ParecCapture)
+
+    monkeypatch.setenv("FAMILIAR_STT_BACKEND", "sounddevice")
+    # Forced sounddevice skips the probe entirely (start() will diagnose).
+    assert isinstance(create_mic_capture(AsyncMock()), MicCapture)
+
+    monkeypatch.setenv("FAMILIAR_STT_BACKEND", "parec")
+    monkeypatch.setattr(mic.shutil, "which", lambda _: None)
+    with pytest.raises(RuntimeError):
+        create_mic_capture(AsyncMock())
+
+
+# ---------------------------------------------------------------------------
+# ParecCapture streaming (real subprocess, fake parec)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_parec_capture_streams_pcm_blocks():
+    received: list[bytes] = []
+    done = asyncio.Event()
+
+    async def on_audio(pcm: bytes) -> None:
+        received.append(pcm)
+        if sum(len(b) for b in received) >= 9600:
+            done.set()
+
+    capture = ParecCapture(on_audio, command=_FAKE_PAREC)
+    capture.start(asyncio.get_running_loop())
+    try:
+        await asyncio.wait_for(done.wait(), timeout=10)
+    finally:
+        capture.stop()
+
+    total = b"".join(received)
+    assert len(total) >= 9600
+    assert total.startswith(b"\x01\x02")
+    assert capture._process is None  # subprocess reaped
+
+
+@pytest.mark.asyncio
+async def test_parec_capture_stop_without_data_is_clean():
+    capture = ParecCapture(
+        AsyncMock(), command=[sys.executable, "-c", "import time; time.sleep(30)"]
+    )
+    capture.start(asyncio.get_running_loop())
+    await asyncio.sleep(0.2)
+    capture.stop()  # must terminate promptly, no hang
+    assert capture._process is None
+
+
+def test_parec_capture_missing_binary_raises():
+    capture = ParecCapture(AsyncMock(), command=["/nonexistent/parec-xyz"])
+    with pytest.raises(RuntimeError):
+        capture.start(asyncio.new_event_loop())
+
+
+# ---------------------------------------------------------------------------
+# Push-to-talk batch path
+# ---------------------------------------------------------------------------
+
+
+def _wav_info(data: bytes) -> tuple[int, int, int]:
+    with wave.open(io.BytesIO(data), "rb") as wav:
+        return wav.getnchannels(), wav.getframerate(), wav.getnframes()
+
+
+def test_record_parec_returns_valid_wav(monkeypatch):
+    from familiar_agent.tools.stt import STTTool
+
+    # Fake parec that emits 0.2 s of audio then exits (EOF ends the read loop).
+    fake = [
+        sys.executable,
+        "-c",
+        "import sys; sys.stdout.buffer.write(b'\\x03\\x04' * 3200)",
+    ]
+    monkeypatch.setattr("familiar_agent.tools.mic.shutil.which", lambda _: "unused")
+    monkeypatch.setattr("familiar_agent.tools.mic.parec_command", lambda: fake)
+
+    tool = STTTool(api_key="k")
+    wav_bytes = tool._record_parec(asyncio.Event())
+    assert wav_bytes is not None
+    channels, rate, frames = _wav_info(wav_bytes)
+    assert (channels, rate) == (1, 16000)
+    assert frames == 3200
+
+
+def test_record_parec_unavailable_returns_none(monkeypatch):
+    from familiar_agent.tools.stt import STTTool
+
+    monkeypatch.setattr("familiar_agent.tools.mic.shutil.which", lambda _: None)
+    assert STTTool(api_key="k")._record_parec(asyncio.Event()) is None
+
+
+@pytest.mark.asyncio
+async def test_record_and_transcribe_falls_back_to_parec():
+    from familiar_agent.tools.stt import STTTool
+
+    tool = STTTool(api_key="k", rtsp_url="rtsp://cam/stream")
+    tool._record_mic = MagicMock(return_value=None)  # PortAudio saw nothing
+    tool._record_parec = MagicMock(return_value=b"fake-wav")
+    tool._record_rtsp = AsyncMock()
+    tool._transcribe_elevenlabs = AsyncMock(return_value="聞こえたで")
+
+    text = await tool.record_and_transcribe(asyncio.Event())
+    assert text == "聞こえたで"
+    tool._record_parec.assert_called_once()
+    tool._record_rtsp.assert_not_awaited()  # parec succeeded → no RTSP
+    tool._transcribe_elevenlabs.assert_awaited_once_with(b"fake-wav")
+
+
+@pytest.mark.asyncio
+async def test_record_and_transcribe_rtsp_still_last_resort():
+    from familiar_agent.tools.stt import STTTool
+
+    tool = STTTool(api_key="k", rtsp_url="rtsp://cam/stream")
+    tool._record_mic = MagicMock(return_value=None)
+    tool._record_parec = MagicMock(return_value=None)
+    tool._record_rtsp = AsyncMock(return_value=b"rtsp-wav")
+    tool._transcribe_elevenlabs = AsyncMock(return_value="text")
+
+    text = await tool.record_and_transcribe(asyncio.Event())
+    assert text == "text"
+    tool._record_rtsp.assert_awaited_once()


### PR DESCRIPTION
## Summary

Fixes #153 — STT doesn't work on WSL2 (sounddevice sees no input device) while TTS works fine.

## Root cause

Both STT paths — realtime capture (`MicCapture`) and push-to-talk batch (`STTTool._record_mic`) — were hard-wired to **sounddevice/PortAudio**. On WSL2/WSLg, PortAudio frequently cannot enumerate the RDPSource microphone bridge even though PulseAudio-level capture works on the same machine (exactly what the reporter's excellent triage showed: `parec` records fine, `sd.query_devices()` is empty). TTS never hit this because playback has a non-PortAudio fallback chain; capture had none.

## Fix

- **`ParecCapture`** — PulseAudio-native capture via a `parec` subprocess, same interface as `MicCapture`. parec resamples to 16 kHz mono s16le itself; a reader thread streams blocks to the session, with clean terminate/reap on stop.
- **`create_mic_capture()`** — backend selection: sounddevice when it sees an input device, parec fallback otherwise, one clear combined error when neither exists. `FAMILIAR_STT_BACKEND=sounddevice|parec` forces a backend. The realtime session now uses the factory.
- **Push-to-talk** — `_record_parec` slots between the sounddevice attempt and the RTSP last resort (mic → parec → RTSP), producing standard WAV via stdlib `wave`.
- **Bonus bug** (found verifying on a real WSL2 box): `import sounddevice` raises `OSError: PortAudio library not found` when the C library is missing — both import guards only caught `ImportError` and would **crash** instead of degrading. Broadened, and verified live that the worst case now yields one actionable `RuntimeError` with the WSL2 hint.

With this, the reporter's environment works with what they already have: `pulseaudio-utils` + `PULSE_SERVER=unix:/mnt/wslg/PulseServer` — no PortAudio wrestling required. README rewritten accordingly.

## Testing

12 new tests: real-subprocess streaming + WAV assembly against a fake parec, backend-selection matrix (auto/forced/none), fallback ordering, clean shutdown/reap, missing-binary error. Existing realtime-STT tests unchanged (28 pass together). Full gate: **1399 passed**, ruff check/format clean, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)