### PR TITLE
fix(models): capture streaming token usage on OpenAI-compatible backends

### DIFF
--- a/src/familiar_runtime/models/openai_compat.py
+++ b/src/familiar_runtime/models/openai_compat.py
@@ -13,6 +13,22 @@ from .base import ModelTurnResult, ToolCall
 logger = logging.getLogger(__name__)
 
 
+def _read_usage(chunk: Any, input_tokens: int, output_tokens: int) -> tuple[int, int]:
+    """Fold a streaming chunk's usage into running totals, if present.
+
+    With ``stream_options={"include_usage": True}`` OpenAI-compatible servers
+    (Ollama, vLLM, real OpenAI) emit a final usage-only chunk. Servers that
+    ignore the option simply never send one, so tokens stay 0 — no regression.
+    """
+    usage = getattr(chunk, "usage", None)
+    if usage is None:
+        return input_tokens, output_tokens
+    return (
+        getattr(usage, "prompt_tokens", None) or input_tokens,
+        getattr(usage, "completion_tokens", None) or output_tokens,
+    )
+
+
 class OpenAICompatibleBackend:
     """Backend for any OpenAI-compatible endpoint: Ollama, vllm, lm-studio, etc."""
 
@@ -157,10 +173,17 @@ class OpenAICompatibleBackend:
             **{tokens_key: max_tokens},
             messages=flat,
             stream=True,
+            stream_options={"include_usage": True},
         )
 
         text_chunks: list[str] = []
+        input_tokens = 0
+        output_tokens = 0
         async for chunk in stream:
+            input_tokens, output_tokens = _read_usage(chunk, input_tokens, output_tokens)
+            # The final usage-only chunk (and any keep-alive) carries no choices.
+            if not chunk.choices:
+                continue
             if chunk.choices[0].delta.content:
                 chunk_text = chunk.choices[0].delta.content
                 text_chunks.append(chunk_text)
@@ -175,7 +198,13 @@ class OpenAICompatibleBackend:
         stop = "tool_use" if tool_calls else "end_turn"
         raw_assistant = {"role": "assistant", "content": text or ""}
         return (
-            ModelTurnResult(stop_reason=stop, text=clean_text, tool_calls=tool_calls),
+            ModelTurnResult(
+                stop_reason=stop,
+                text=clean_text,
+                tool_calls=tool_calls,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            ),
             raw_assistant,
         )
 
@@ -200,17 +229,24 @@ class OpenAICompatibleBackend:
         }
         if oai_tools:
             kwargs["tools"] = oai_tools
+        kwargs["stream_options"] = {"include_usage": True}
 
         stream = await self.client.chat.completions.create(**kwargs)
 
         text_chunks: list[str] = []
         raw_tcs: dict[int, dict] = {}
         finish_reason: str | None = None
+        input_tokens = 0
+        output_tokens = 0
         # Filter Gemini thinking tokens: buffer until thinking block ends.
         _thinking_buf: str = ""
         _in_thinking: bool | None = None
 
         async for chunk in stream:
+            input_tokens, output_tokens = _read_usage(chunk, input_tokens, output_tokens)
+            # The final usage-only chunk (and any keep-alive) carries no choices.
+            if not chunk.choices:
+                continue
             choice = chunk.choices[0]
             delta = choice.delta
             finish_reason = choice.finish_reason or finish_reason
@@ -278,7 +314,13 @@ class OpenAICompatibleBackend:
                 for tc in tool_calls
             ]
         return (
-            ModelTurnResult(stop_reason=stop, text=text, tool_calls=tool_calls),
+            ModelTurnResult(
+                stop_reason=stop,
+                text=text,
+                tool_calls=tool_calls,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            ),
             raw_assistant,
         )
 

--- a/tests/test_runtime_models.py
+++ b/tests/test_runtime_models.py
@@ -123,6 +123,61 @@ def test_openai_compat_backend_native_and_prompt_tool_results() -> None:
     assert any(p.get("type") == "image_url" for p in parts)
 
 
+@pytest.mark.asyncio
+async def test_openai_compat_captures_streaming_usage_and_guards_empty_choices() -> None:
+    """Ollama/OpenAI-compat emit a final usage-only chunk (empty choices) under
+    stream_options.include_usage. The backend must fold that usage into the
+    result AND not IndexError on the choiceless chunk."""
+    pytest.importorskip("openai")
+    from types import SimpleNamespace
+
+    from familiar_runtime.models import OpenAICompatibleBackend
+
+    backend = OpenAICompatibleBackend(
+        api_key="", model="gemma4:latest", base_url="http://localhost:11434/v1", tools_mode="prompt"
+    )
+
+    def _delta_chunk(text):
+        choice = SimpleNamespace(delta=SimpleNamespace(content=text), finish_reason=None)
+        return SimpleNamespace(choices=[choice], usage=None)
+
+    def _usage_chunk(pt, ct):
+        return SimpleNamespace(
+            choices=[],  # the usage-only chunk carries no choices
+            usage=SimpleNamespace(prompt_tokens=pt, completion_tokens=ct),
+        )
+
+    class _FakeStream:
+        def __init__(self, chunks):
+            self._chunks = chunks
+
+        def __aiter__(self):
+            async def gen():
+                for c in self._chunks:
+                    yield c
+
+            return gen()
+
+    async def _fake_create(**kwargs):
+        assert kwargs.get("stream_options") == {"include_usage": True}
+        return _FakeStream([_delta_chunk("Hi "), _delta_chunk("there"), _usage_chunk(176, 78)])
+
+    backend.client.chat.completions.create = _fake_create  # type: ignore[assignment]
+
+    captured: list[str] = []
+    result, _ = await backend.stream_turn(
+        system="s",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        max_tokens=50,
+        on_text=captured.append,
+    )
+    assert result.text == "Hi there"
+    assert result.input_tokens == 176
+    assert result.output_tokens == 78
+    assert "".join(captured) == "Hi there"
+
+
 def test_kimi_backend_make_tool_results_includes_image_block() -> None:
     pytest.importorskip("openai")
     from familiar_runtime.models import KimiBackend, ToolCall


### PR DESCRIPTION
## Summary

Found while bringing familiar-ai up on **Ollama + gemma4** (local): both streaming paths of `OpenAICompatibleBackend` (prompt-mode and native tool calling) requested `stream=True` without `stream_options`, so streamed turns always reported `input_tokens=0 / output_tokens=0`.

That silently disabled context-size accounting downstream — most notably `_should_compact()` never fires on a local Ollama session, so long conversations eventually overflow the model context instead of compacting.

- Request `stream_options={"include_usage": true}` on both stream paths and fold the final usage-only chunk into `ModelTurnResult`.
- That final chunk carries **no choices** — both loops now guard `chunk.choices` before indexing (previously a latent `IndexError` for any server emitting usage/keep-alive frames).
- Servers that ignore the option simply never send the frame: tokens stay 0, no behavior change — verified the real-OpenAI, vLLM, and Ollama semantics all accept the option.

## Verification

- Live against Ollama `gemma4:latest`: tokens now captured in **both** tools modes (`prompt`: in=176/out=78; `native`: in=74/out=65 for the same greeting-with-tool turn).
- Full end-to-end: `EmbodiedAgent` runs a real conversational turn on Ollama+gemma4 with native tool calling; identity layer and inner loop exercised in the same session.
- Regression test drives a fake stream ending in a choiceless usage chunk, asserting token capture, the empty-choices guard, and that `stream_options` is actually sent.

## Test plan

- [x] New: `test_openai_compat_captures_streaming_usage_and_guards_empty_choices`
- [x] Full gate: ruff / format / mypy (132 files) / pytest **1399 passed** (the 1 failure, `test_stt.py::test_mic_none_with_rtsp_falls_back`, is a pre-existing environment-dependent failure on this WSL2+PulseAudio machine — reproduced on pristine develop, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)